### PR TITLE
Add User-Agent header to outbound requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/basetenlabs/baseten-cli
 go 1.26.1
 
 require (
-	github.com/basetenlabs/baseten-go v0.0.0-20260423145953-b7782e3acf2a
+	github.com/basetenlabs/baseten-go v0.0.0-20260505160058-d67fd4abcea1
 	github.com/charmbracelet/huh v1.0.0
 	github.com/itchyny/gojq v0.12.18
 	github.com/spf13/cobra v1.10.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/basetenlabs/baseten-cli
 go 1.26.1
 
 require (
-	github.com/basetenlabs/baseten-go v0.0.0-20260505160058-d67fd4abcea1
+	github.com/basetenlabs/baseten-go v0.0.0-20260506124153-57513d4d58d7
 	github.com/charmbracelet/huh v1.0.0
 	github.com/itchyny/gojq v0.12.18
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
-github.com/basetenlabs/baseten-go v0.0.0-20260505160058-d67fd4abcea1 h1:3c8VznJhMp2gdODQi/TwTu6R31lBti/Bafw8K77eKqk=
-github.com/basetenlabs/baseten-go v0.0.0-20260505160058-d67fd4abcea1/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.0.0-20260506124153-57513d4d58d7 h1:sZklVvfKlYOupXJtQCXhVG+sI96L4kORIEm17ZZB1pk=
+github.com/basetenlabs/baseten-go v0.0.0-20260506124153-57513d4d58d7/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/xnwFfbezlUnFMJy0nusZvytYysV4SCS2cYbvws=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
-github.com/basetenlabs/baseten-go v0.0.0-20260423145953-b7782e3acf2a h1:lVNAJgypQCUPnQv5LukXzSdhTXiD4z5RthLYN0bD9Go=
-github.com/basetenlabs/baseten-go v0.0.0-20260423145953-b7782e3acf2a/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.0.0-20260505160058-d67fd4abcea1 h1:3c8VznJhMp2gdODQi/TwTu6R31lBti/Bafw8K77eKqk=
+github.com/basetenlabs/baseten-go v0.0.0-20260505160058-d67fd4abcea1/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/xnwFfbezlUnFMJy0nusZvytYysV4SCS2cYbvws=

--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -1,11 +1,31 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
+	"github.com/basetenlabs/baseten-go/client"
 	"golang.org/x/oauth2"
 )
+
+// OAuthContext returns a context that carries an oauth2 HTTP client which
+// stamps the Baseten User-Agent on every request, layered over base.
+func OAuthContext(ctx context.Context, base http.RoundTripper) context.Context {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	c := &http.Client{Transport: userAgentRoundTripper{base: base}}
+	return context.WithValue(ctx, oauth2.HTTPClient, c)
+}
+
+type userAgentRoundTripper struct{ base http.RoundTripper }
+
+func (r userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	client.ApplyUserAgentHeader(req.Header)
+	return r.base.RoundTrip(req)
+}
 
 // Transport is an HTTP client that injects the appropriate Authorization
 // header based on the active credential. For OAuth credentials, it uses
@@ -69,7 +89,7 @@ func (t *Transport) Do(req *http.Request) (*http.Response, error) {
 			Expiry:       cred.Expiry,
 			TokenType:    "Bearer",
 		}
-		src := t.OAuthConfig.TokenSource(req.Context(), token)
+		src := t.OAuthConfig.TokenSource(OAuthContext(req.Context(), t.base()), token)
 		newToken, err := src.Token()
 		if err != nil {
 			return nil, fmt.Errorf("token expired and refresh failed: %w (run `baseten auth login` to re-authenticate)", err)

--- a/internal/cmd/command.api_test.go
+++ b/internal/cmd/command.api_test.go
@@ -85,6 +85,7 @@ func Test_API_Management_AuthHeader(t *testing.T) {
 	err := h.Execute("api", "management", "models")
 	h.Require.NoError(err)
 	h.Require.Equal("Api-Key test-key", req.Headers.Get("Authorization"))
+	h.Require.Regexp(`^baseten-cli/\S+ \(Go/\S+; [^)]+\)$`, req.Headers.Get("User-Agent"))
 }
 
 func Test_API_Management_ExplicitMethod(t *testing.T) {

--- a/internal/cmd/command.auth.go
+++ b/internal/cmd/command.auth.go
@@ -204,14 +204,15 @@ func commandAuthStatus(ctx *CommandContext, flags *cmd.AuthStatusFlags) error {
 
 func loginWeb(ctx *CommandContext, store *auth.Store, host string) error {
 	cfg := OAuthConfig(host)
-	devResp, err := cfg.DeviceAuth(ctx.Context)
+	oauthCtx := auth.OAuthContext(ctx.Context, ctx.httpClient().Transport)
+	devResp, err := cfg.DeviceAuth(oauthCtx)
 	if err != nil {
 		return fmt.Errorf("starting device authorization: %w", err)
 	}
 
 	ctx.Logf("Enter code %s at %s\n", devResp.UserCode, devResp.VerificationURI)
 
-	token, err := cfg.DeviceAccessToken(ctx.Context, devResp)
+	token, err := cfg.DeviceAccessToken(oauthCtx, devResp)
 	if err != nil {
 		return fmt.Errorf("waiting for authorization: %w", err)
 	}

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -9,9 +9,14 @@ import (
 	"strings"
 
 	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-go/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+func init() {
+	client.SetClientName("baseten-cli")
+}
 
 // ErrWithCode is an error that carries a specific process exit code.
 type ErrWithCode struct {


### PR DESCRIPTION
# What changed

Add `User-Agent` header on HTTP calls to Baseten and other minor adjustments