### PR TITLE
Add model list, fetch, predict, and delete commands

### DIFF
--- a/cmd/command.model.go
+++ b/cmd/command.model.go
@@ -30,14 +30,36 @@ var commandModel = Command{
 			Description: "Fetch a Baseten model.",
 			Flags:       ModelFetchFlags{},
 		},
+		{
+			Name:    "predict",
+			Summary: "Run a prediction against a model",
+			Description: "POST a JSON request to a model and write the response to stdout.\n\n" +
+				"Targets the production environment by default. Use --environment, " +
+				"--deployment-id, or --regional to target something else.\n\n" +
+				"Streaming responses (Transfer-Encoding: chunked) are passed through " +
+				"as they arrive. For machine-readable streaming JSON from OpenAI-compatible " +
+				"models, use --output jsonl.",
+			Flags: ModelPredictFlags{},
+		},
+		{
+			Name:    "delete",
+			Summary: "Delete a model",
+			Description: "Delete a Baseten model and all of its deployments.\n\n" +
+				"Prompts for the model name to confirm the deletion. Pass --yes to " +
+				"skip the prompt. When stdin is not a terminal, --yes is required.",
+			Flags: ModelDeleteFlags{},
+		},
 		commandModelDeployment,
 	},
 }
 
-// ModelIDFlags identifies a model by ID. Embedded by commands that act on a
-// specific model.
-type ModelIDFlags struct {
-	ModelID string `flag:"model-id" desc:"ID of the model." required:"true"`
+// ModelRefFlags identifies a model by ID or by name (with optional --team for
+// disambiguation across teams in the same org). Embedded by commands that act
+// on a specific model.
+type ModelRefFlags struct {
+	ModelID   string `flag:"model-id" desc:"ID of the model." oneof:"model-ref"`
+	ModelName string `flag:"model-name" desc:"Name of the model. Use --team to disambiguate when the same name exists in multiple teams." oneof:"model-ref"`
+	Team      string `flag:"team" desc:"Team name or ID. Only valid with --model-name."`
 }
 
 // ModelPushFlags configures `baseten model push`.
@@ -75,12 +97,35 @@ type ModelPushFlags struct {
 // ModelListFlags configures `baseten model list`.
 type ModelListFlags struct {
 	CommandFlags
+
+	Team string `flag:"team" desc:"Team name or ID to scope the listing to. Defaults to all teams the caller can see."`
 }
 
 // ModelFetchFlags configures `baseten model fetch`.
 type ModelFetchFlags struct {
 	CommandFlags
-	ModelIDFlags
+	ModelRefFlags
+}
 
-	TeamID string `flag:"team-id" desc:"Team the model belongs to."`
+// ModelDeleteFlags configures `baseten model delete`.
+type ModelDeleteFlags struct {
+	CommandFlags
+	ModelRefFlags
+
+	Yes bool `flag:"yes" desc:"Skip the interactive confirmation prompt. Required when stdin is not a terminal."`
+}
+
+// ModelPredictFlags configures `baseten model predict`.
+type ModelPredictFlags struct {
+	CommandFlags
+	ModelRefFlags
+
+	Environment  string `flag:"environment" desc:"Environment to target (e.g. production, development). Defaults to production. Mutually exclusive with --deployment-id and --regional."`
+	DeploymentID string `flag:"deployment-id" desc:"Specific deployment to target. Mutually exclusive with --environment and --regional."`
+	Regional     string `flag:"regional" desc:"Regional environment name; routes via the regional hostname. Mutually exclusive with --environment and --deployment-id."`
+
+	Data string `flag:"data" desc:"Inline JSON request body." oneof:"predict-input"`
+	File string `flag:"file" desc:"Path to a JSON file containing the request body. Use '-' for stdin." oneof:"predict-input"`
+
+	Websocket bool `flag:"websocket" desc:"Use the WebSocket predict endpoint. Sends the body as one frame, reads one frame back, then closes. Not for multi-message or back-and-forth sessions."`
 }

--- a/cmd/command.model_deployment.go
+++ b/cmd/command.model_deployment.go
@@ -24,7 +24,7 @@ var commandModelDeployment = Command{
 // ModelDeploymentIDFlags identifies a deployment of a model. Embedded by
 // commands that act on a specific deployment.
 type ModelDeploymentIDFlags struct {
-	ModelIDFlags
+	ModelRefFlags
 	DeploymentID string `flag:"deployment-id" desc:"ID of the deployment." required:"true"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/fang v1.0.0
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/coder/websocket v1.8.14
 	github.com/itchyny/gojq v0.12.18
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSE
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=

--- a/internal/cmd/command.model.go
+++ b/internal/cmd/command.model.go
@@ -1,18 +1,214 @@
 package cmd
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
 	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+	"github.com/charmbracelet/huh"
 )
 
 func init() {
 	Register("model list", commandModelList)
 	Register("model fetch", commandModelFetch)
+	Register("model delete", commandModelDelete)
 }
 
-func commandModelList(_ *CommandContext, _ *cmd.ModelListFlags) error {
-	panic("TODO: implement model list")
+// ModelRef is the result of resolving [cmd.ModelRefFlags] against the
+// management API. Team is the resolved team ID (empty when unscoped).
+type ModelRef struct {
+	ID   string
+	Team string
 }
 
-func commandModelFetch(_ *CommandContext, _ *cmd.ModelFetchFlags) error {
-	panic("TODO: implement model fetch")
+// ResolveModelRef resolves [cmd.ModelRefFlags] into a [ModelRef]. When
+// --model-id is set it returns immediately. When --model-name is set it
+// resolves the optional team and looks up the model by name; absent or
+// ambiguous matches return an error.
+func ResolveModelRef(
+	ctx context.Context, api *managementapi.Client, flags cmd.ModelRefFlags,
+) (ModelRef, error) {
+	if flags.ModelID != "" {
+		if flags.Team != "" {
+			return ModelRef{}, &ErrUsage{Err: errors.New("--team is only valid with --model-name")}
+		}
+		return ModelRef{ID: flags.ModelID}, nil
+	}
+	teamID, err := ResolveTeam(ctx, api, flags.Team)
+	if err != nil {
+		return ModelRef{}, err
+	}
+	id, err := findModelIDByName(ctx, api, flags.ModelName, teamID)
+	if err != nil {
+		return ModelRef{}, err
+	}
+	if id == "" {
+		if teamID != "" {
+			return ModelRef{}, fmt.Errorf("no model named %q in team %q", flags.ModelName, flags.Team)
+		}
+		return ModelRef{}, fmt.Errorf("no model named %q", flags.ModelName)
+	}
+	return ModelRef{ID: id, Team: teamID}, nil
+}
+
+// findModelIDByName returns the ID of the unique model with the given name,
+// scoped to teamID when non-empty. Returns "" with nil error when no model
+// matches. Returns an error when multiple models match (only possible when
+// teamID is empty, since (org, team, name) is unique server-side).
+func findModelIDByName(
+	ctx context.Context, api *managementapi.Client, name, teamID string,
+) (string, error) {
+	models, err := listModels(ctx, api, teamID)
+	if err != nil {
+		return "", err
+	}
+	var matches []managementapi.Model
+	for _, m := range models {
+		if m.Name == name {
+			matches = append(matches, m)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return "", nil
+	case 1:
+		return matches[0].Id, nil
+	default:
+		return "", fmt.Errorf("multiple models named %q across teams; pass --team to disambiguate", name)
+	}
+}
+
+// listModels returns models, optionally scoped to a single team. teamID is the
+// resolved team ID (not name); pass "" to list across all accessible teams.
+func listModels(
+	ctx context.Context, api *managementapi.Client, teamID string,
+) ([]managementapi.Model, error) {
+	if teamID == "" {
+		resp, err := api.GetModels(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list models: %w", err)
+		}
+		return resp.Models, nil
+	}
+	resp, err := api.GetTeamsModels(ctx, teamID)
+	if err != nil {
+		return nil, fmt.Errorf("list models for team %s: %w", teamID, err)
+	}
+	return resp.Models, nil
+}
+
+func commandModelList(ctx *CommandContext, flags *cmd.ModelListFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	teamID, err := ResolveTeam(ctx, cl.API(), flags.Team)
+	if err != nil {
+		return err
+	}
+	models, err := listModels(ctx, cl.API(), teamID)
+	if err != nil {
+		return err
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(managementapi.Models{Models: models})
+		return nil
+	}
+	if len(models) == 0 {
+		ctx.LogLine("No models found.")
+		return nil
+	}
+	rows := make([][]string, 0, len(models))
+	for _, m := range models {
+		rows = append(rows, []string{
+			m.Id,
+			m.Name,
+			m.TeamName,
+			fmt.Sprintf("%d", m.DeploymentsCount),
+			m.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+	ctx.OutputTable([]string{"ID", "NAME", "TEAM", "DEPLOYMENTS", "CREATED"}, rows)
+	return nil
+}
+
+func commandModelFetch(ctx *CommandContext, flags *cmd.ModelFetchFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := ResolveModelRef(ctx, cl.API(), flags.ModelRefFlags)
+	if err != nil {
+		return err
+	}
+	model, err := cl.API().GetModelsModelId(ctx, ref.ID)
+	if err != nil {
+		return fmt.Errorf("fetch model %s: %w", ref.ID, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(model)
+		return nil
+	}
+	ctx.Outputf("ID:           %s\n", model.Id)
+	ctx.Outputf("Name:         %s\n", model.Name)
+	ctx.Outputf("Team:         %s\n", model.TeamName)
+	ctx.Outputf("Deployments:  %d\n", model.DeploymentsCount)
+	ctx.Outputf("Instance:     %s\n", model.InstanceTypeName)
+	if model.ProductionDeploymentId != nil {
+		ctx.Outputf("Production:   %s\n", *model.ProductionDeploymentId)
+	}
+	if model.DevelopmentDeploymentId != nil {
+		ctx.Outputf("Development:  %s\n", *model.DevelopmentDeploymentId)
+	}
+	ctx.Outputf("Created:      %s\n", model.CreatedAt.UTC().Format(time.RFC3339))
+	return nil
+}
+
+func commandModelDelete(ctx *CommandContext, flags *cmd.ModelDeleteFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := ResolveModelRef(ctx, cl.API(), flags.ModelRefFlags)
+	if err != nil {
+		return err
+	}
+	model, err := cl.API().GetModelsModelId(ctx, ref.ID)
+	if err != nil {
+		return fmt.Errorf("fetch model %s: %w", ref.ID, err)
+	}
+
+	if !flags.Yes {
+		if !ctx.IsInteractive() {
+			return &ErrUsage{Err: fmt.Errorf("cannot confirm deletion: stdin is not a terminal; pass --yes to skip the prompt")}
+		}
+		var typed string
+		err := huh.NewInput().
+			Title(fmt.Sprintf("Type the model name %q to confirm deletion", model.Name)).
+			Value(&typed).
+			Run()
+		if err != nil {
+			return err
+		}
+		if typed != model.Name {
+			return fmt.Errorf("typed name %q does not match model name %q; deletion aborted", typed, model.Name)
+		}
+	}
+
+	tombstone, err := cl.API().DeleteModels(ctx, ref.ID)
+	if err != nil {
+		return fmt.Errorf("delete model %s: %w", ref.ID, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(tombstone)
+		return nil
+	}
+	ctx.Logf("Deleted model %s (%s)\n", model.Name, ref.ID)
+	return nil
 }

--- a/internal/cmd/command.model_deployment_logs.go
+++ b/internal/cmd/command.model_deployment_logs.go
@@ -40,11 +40,15 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 	if err != nil {
 		return err
 	}
+	ref, err := ResolveModelRef(ctx, api.API(), flags.ModelRefFlags)
+	if err != nil {
+		return err
+	}
 
 	if flags.Tail {
 		res := TailDeploymentLogs(ctx, TailDeploymentLogsOptions{
 			API:          api.API(),
-			ModelID:      flags.ModelID,
+			ModelID:      ref.ID,
 			DeploymentID: flags.DeploymentID,
 		})
 		if err := emitDeploymentLogs(ctx, res.Logs); err != nil {
@@ -89,7 +93,7 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 		startMs, endMs = &s, &e
 	}
 
-	resp, err := api.API().PostModelsDeploymentsLogs(ctx, flags.ModelID, flags.DeploymentID,
+	resp, err := api.API().PostModelsDeploymentsLogs(ctx, ref.ID, flags.DeploymentID,
 		managementapi.GetDeploymentLogsRequest{StartEpochMillis: startMs, EndEpochMillis: endMs})
 	if err != nil {
 		return err

--- a/internal/cmd/command.model_predict.go
+++ b/internal/cmd/command.model_predict.go
@@ -226,18 +226,22 @@ func openPredictBody(ctx *CommandContext, flags *cmd.ModelPredictFlags) (io.Read
 }
 
 func writePredictResponse(ctx *CommandContext, resp *predictResponse) error {
-	if resp.streaming {
-		if err := writePredictStreamingResponse(ctx, resp.body, resp.contentType == "text/event-stream"); err != nil {
-			return err
-		}
-	} else if resp.contentType == "application/json" {
-		if err := writePredictJSONResponse(ctx, resp.body); err != nil {
-			return err
-		}
-	} else {
-		if err := writePredictBinaryResponse(ctx, resp.body); err != nil {
-			return err
-		}
+	var writeErr error
+	switch {
+	case resp.contentType == "text/event-stream":
+		// Parse SSE from the body regardless of Transfer-Encoding. Beefeater
+		// may serve SSE chunked or buffered with Content-Length; framing lives
+		// in the body bytes either way.
+		writeErr = writePredictStreamingResponse(ctx, resp.body, true)
+	case resp.streaming:
+		writeErr = writePredictStreamingResponse(ctx, resp.body, false)
+	case resp.contentType == "application/json":
+		writeErr = writePredictJSONResponse(ctx, resp.body)
+	default:
+		writeErr = writePredictBinaryResponse(ctx, resp.body)
+	}
+	if writeErr != nil {
+		return writeErr
 	}
 	if sa, ok := resp.body.(*statusAwareBody); ok && sa.status >= 400 {
 		return fmt.Errorf("request failed with status %d", sa.status)

--- a/internal/cmd/command.model_predict.go
+++ b/internal/cmd/command.model_predict.go
@@ -1,0 +1,343 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/coder/websocket"
+)
+
+func init() {
+	Register("model predict", commandModelPredict)
+}
+
+// predictResponse is the transport-agnostic result of a predict round trip.
+// HTTP gives chunked + content-type from headers; WebSocket synthesizes a
+// content-type from the frame type (text -> application/json, bytes ->
+// application/octet-stream) and always reports streaming=false.
+type predictResponse struct {
+	body        io.ReadCloser
+	contentType string
+	streaming   bool
+}
+
+func commandModelPredict(ctx *CommandContext, flags *cmd.ModelPredictFlags) error {
+	targets := 0
+	if flags.Environment != "" {
+		targets++
+	}
+	if flags.DeploymentID != "" {
+		targets++
+	}
+	if flags.Regional != "" {
+		targets++
+	}
+	if targets > 1 {
+		return &ErrUsage{Err: errors.New("--environment, --deployment-id, and --regional are mutually exclusive")}
+	}
+
+	mgmtCl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := ResolveModelRef(ctx, mgmtCl.API(), flags.ModelRefFlags)
+	if err != nil {
+		return err
+	}
+
+	icFlags := cmd.InferenceClientFlags{ModelID: ref.ID}
+	if flags.Regional != "" {
+		icFlags.Environment = flags.Regional
+	}
+	ic, err := ctx.NewInferenceClient(icFlags)
+	if err != nil {
+		return err
+	}
+	api := ic.API()
+
+	body, err := openPredictBody(ctx, flags)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+
+	var resp *predictResponse
+	if flags.Websocket {
+		resp, err = doWebsocketPredict(ctx, api.HTTPClient, api.BaseURL, flags, body)
+	} else {
+		resp, err = doHTTPPredict(ctx, api.HTTPClient, api.BaseURL, flags, body)
+	}
+	if err != nil {
+		return err
+	}
+	defer resp.body.Close()
+	return writePredictResponse(ctx, resp)
+}
+
+func predictPath(flags *cmd.ModelPredictFlags, scheme string) string {
+	suffix := "/predict"
+	if scheme == "ws" {
+		suffix = "/websocket"
+	}
+	switch {
+	case flags.DeploymentID != "":
+		return "/deployment/" + flags.DeploymentID + suffix
+	case flags.Regional != "":
+		return suffix
+	default:
+		env := flags.Environment
+		if env == "" {
+			env = "production"
+		}
+		return "/environments/" + env + suffix
+	}
+}
+
+func doHTTPPredict(
+	ctx *CommandContext,
+	httpClient interface {
+		Do(*http.Request) (*http.Response, error)
+	},
+	baseURL string,
+	flags *cmd.ModelPredictFlags,
+	body io.Reader,
+) (*predictResponse, error) {
+	url := strings.TrimRight(baseURL, "/") + predictPath(flags, "http")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	contentType := strings.TrimSpace(strings.SplitN(resp.Header.Get("Content-Type"), ";", 2)[0])
+	streaming := false
+	for _, te := range resp.TransferEncoding {
+		if te == "chunked" {
+			streaming = true
+		}
+	}
+	// Wrap so we can surface a non-2xx status code after the body has been
+	// written by the formatter.
+	rc := &statusAwareBody{ReadCloser: resp.Body, status: resp.StatusCode}
+	return &predictResponse{body: rc, contentType: contentType, streaming: streaming}, nil
+}
+
+// statusAwareBody wraps an HTTP response body so writePredictResponse can
+// return a non-2xx error after writing the body bytes. Without this we'd
+// either lose the body output or lose the status code.
+type statusAwareBody struct {
+	io.ReadCloser
+	status int
+}
+
+// roundTripperFunc adapts a Do-style function to http.RoundTripper.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func doWebsocketPredict(
+	ctx *CommandContext,
+	httpClient interface {
+		Do(*http.Request) (*http.Response, error)
+	},
+	baseURL string,
+	flags *cmd.ModelPredictFlags,
+	body io.Reader,
+) (*predictResponse, error) {
+	wsURL := wsURLFromBase(baseURL) + predictPath(flags, "ws")
+
+	client := &http.Client{Transport: roundTripperFunc(httpClient.Do)}
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPClient: client})
+	if err != nil {
+		return nil, fmt.Errorf("websocket dial: %w", err)
+	}
+	// Default read limit is 32 KiB; raise to predict-sized payloads.
+	conn.SetReadLimit(100 * 1024 * 1024)
+
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		conn.Close(websocket.StatusInternalError, "")
+		return nil, fmt.Errorf("reading request body: %w", err)
+	}
+	if err := conn.Write(ctx, websocket.MessageText, payload); err != nil {
+		conn.Close(websocket.StatusInternalError, "")
+		return nil, fmt.Errorf("websocket send: %w", err)
+	}
+
+	msgType, msg, err := conn.Read(ctx)
+	if err != nil {
+		// Surface the close code if the server closed before sending a frame.
+		conn.Close(websocket.StatusInternalError, "")
+		return nil, fmt.Errorf("websocket receive: %w", err)
+	}
+	contentType := "application/octet-stream"
+	if msgType == websocket.MessageText {
+		contentType = "application/json"
+	}
+
+	// Close cleanly; ignore errors (we already have the frame we needed).
+	_ = conn.Close(websocket.StatusNormalClosure, "")
+
+	return &predictResponse{
+		body:        io.NopCloser(bytes.NewReader(msg)),
+		contentType: contentType,
+		streaming:   false,
+	}, nil
+}
+
+// wsURLFromBase converts an http/https base URL to ws/wss. Inputs without
+// an http(s) scheme are returned unchanged (lets tests pass a raw wss URL).
+func wsURLFromBase(base string) string {
+	trimmed := strings.TrimRight(base, "/")
+	switch {
+	case strings.HasPrefix(trimmed, "https://"):
+		return "wss://" + strings.TrimPrefix(trimmed, "https://")
+	case strings.HasPrefix(trimmed, "http://"):
+		return "ws://" + strings.TrimPrefix(trimmed, "http://")
+	}
+	return trimmed
+}
+
+func openPredictBody(ctx *CommandContext, flags *cmd.ModelPredictFlags) (io.ReadCloser, error) {
+	if flags.Data != "" {
+		return io.NopCloser(strings.NewReader(flags.Data)), nil
+	}
+	if flags.File == "-" {
+		return io.NopCloser(ctx.Stdin), nil
+	}
+	f, err := os.Open(flags.File)
+	if err != nil {
+		return nil, fmt.Errorf("opening input file: %w", err)
+	}
+	return f, nil
+}
+
+func writePredictResponse(ctx *CommandContext, resp *predictResponse) error {
+	if resp.streaming {
+		if err := writePredictStreamingResponse(ctx, resp.body, resp.contentType == "text/event-stream"); err != nil {
+			return err
+		}
+	} else if resp.contentType == "application/json" {
+		if err := writePredictJSONResponse(ctx, resp.body); err != nil {
+			return err
+		}
+	} else {
+		if err := writePredictBinaryResponse(ctx, resp.body); err != nil {
+			return err
+		}
+	}
+	if sa, ok := resp.body.(*statusAwareBody); ok && sa.status >= 400 {
+		return fmt.Errorf("request failed with status %d", sa.status)
+	}
+	return nil
+}
+
+func writePredictJSONResponse(ctx *CommandContext, body io.Reader) error {
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+	if len(bodyBytes) == 0 {
+		return nil
+	}
+	var parsed any
+	if err := json.Unmarshal(bodyBytes, &parsed); err != nil {
+		ctx.Output(string(bodyBytes))
+		return nil
+	}
+	ctx.OutputJSON(parsed)
+	return nil
+}
+
+func writePredictBinaryResponse(ctx *CommandContext, body io.Reader) error {
+	if !ctx.JSON {
+		if _, err := io.Copy(ctx.Stdout, body); err != nil {
+			return fmt.Errorf("writing response: %w", err)
+		}
+		return nil
+	}
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+	ctx.OutputJSON(map[string]any{
+		"body": base64.StdEncoding.EncodeToString(bodyBytes),
+	})
+	return nil
+}
+
+func writePredictStreamingResponse(ctx *CommandContext, body io.Reader, isSSE bool) error {
+	if !ctx.JSON {
+		if _, err := io.Copy(ctx.Stdout, body); err != nil {
+			return fmt.Errorf("streaming response: %w", err)
+		}
+		return nil
+	}
+	if !ctx.JSONLines {
+		ctx.LogLine("warning: streaming response cannot be emitted as a single JSON document; output will be JSONL")
+		// Force compact, line-delimited records for the rest of this command.
+		ctx.JSONCompact = true
+	}
+	if isSSE {
+		return streamPredictSSEAsJSONL(ctx, body)
+	}
+	return streamPredictBinaryAsJSONL(ctx, body)
+}
+
+func streamPredictSSEAsJSONL(ctx *CommandContext, body io.Reader) error {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(line[len("data:"):])
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var parsed any
+		if err := json.Unmarshal([]byte(payload), &parsed); err != nil {
+			ctx.OutputJSON(map[string]any{
+				"body": base64.StdEncoding.EncodeToString([]byte(payload)),
+			})
+			continue
+		}
+		ctx.OutputJSON(parsed)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading SSE stream: %w", err)
+	}
+	return nil
+}
+
+func streamPredictBinaryAsJSONL(ctx *CommandContext, body io.Reader) error {
+	buf := make([]byte, 4096)
+	for {
+		n, err := body.Read(buf)
+		if n > 0 {
+			ctx.OutputJSON(map[string]any{
+				"body": base64.StdEncoding.EncodeToString(buf[:n]),
+			})
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("streaming response: %w", err)
+		}
+	}
+}

--- a/internal/cmd/command.model_predict_test.go
+++ b/internal/cmd/command.model_predict_test.go
@@ -1,0 +1,327 @@
+package cmd_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/coder/websocket"
+)
+
+// newPredictHarness wires a CommandHarness to a MockManagementAPI and points
+// the inference base URL at it. Returns the harness so tests can register
+// per-route predict handlers.
+func newPredictHarness(t *testing.T) (*CommandHarness, *MockManagementAPI) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	t.Setenv("BASETEN_INFERENCE_BASE_URL_OVERRIDE", m.URL)
+	return h, m
+}
+
+func Test_Model_Predict_DefaultEnvironment(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRoute("POST", "/environments/production/predict", 200, map[string]any{"result": "ok"})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--data", `{"x":1}`)
+	h.Require.NoError(err)
+	call := m.FindCall("POST", "/environments/production/predict")
+	h.Require.NotNil(call)
+	h.Require.Equal(`{"x":1}`, call.Body)
+	h.Require.Contains(h.Stdout.String(), `"result"`)
+}
+
+func Test_Model_Predict_NamedEnvironment(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRoute("POST", "/environments/development/predict", 200, map[string]any{"r": 1})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--environment", "development", "--data", `{}`)
+	h.Require.NoError(err)
+	h.Require.NotNil(m.FindCall("POST", "/environments/development/predict"))
+}
+
+func Test_Model_Predict_DeploymentID(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRoute("POST", "/deployment/d-1/predict", 200, map[string]any{"r": 1})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--deployment-id", "d-1", "--data", `{}`)
+	h.Require.NoError(err)
+	h.Require.NotNil(m.FindCall("POST", "/deployment/d-1/predict"))
+}
+
+func Test_Model_Predict_Regional(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRoute("POST", "/predict", 200, map[string]any{"r": 1})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--regional", "prod-us", "--data", `{}`)
+	h.Require.NoError(err)
+	h.Require.NotNil(m.FindCall("POST", "/predict"))
+}
+
+func Test_Model_Predict_TargetsMutuallyExclusive(t *testing.T) {
+	h, _ := newPredictHarness(t)
+	err := h.Execute("model", "predict", "--model-id", "m-1",
+		"--environment", "production", "--deployment-id", "d-1", "--data", `{}`)
+	h.Require.ErrorContains(err, "mutually exclusive")
+}
+
+func Test_Model_Predict_InputOneofRequired(t *testing.T) {
+	h, _ := newPredictHarness(t)
+	err := h.Execute("model", "predict", "--model-id", "m-1")
+	h.Require.Error(err)
+}
+
+func Test_Model_Predict_InputOneofExclusive(t *testing.T) {
+	h, _ := newPredictHarness(t)
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--data", `{}`, "--file", "x.json")
+	h.Require.Error(err)
+}
+
+func Test_Model_Predict_FromFile(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRoute("POST", "/environments/production/predict", 200, map[string]any{"ok": true})
+
+	path := filepath.Join(t.TempDir(), "in.json")
+	h.Require.NoError(os.WriteFile(path, []byte(`{"from":"file"}`), 0o600))
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--file", path)
+	h.Require.NoError(err)
+	call := m.FindCall("POST", "/environments/production/predict")
+	h.Require.Equal(`{"from":"file"}`, call.Body)
+}
+
+func Test_Model_Predict_FromStdin(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRoute("POST", "/environments/production/predict", 200, map[string]any{"ok": true})
+	h.Stdin.WriteString(`{"from":"stdin"}`)
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--file", "-")
+	h.Require.NoError(err)
+	call := m.FindCall("POST", "/environments/production/predict")
+	h.Require.Equal(`{"from":"stdin"}`, call.Body)
+}
+
+func Test_Model_Predict_OutputJSONPretty(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRoute("POST", "/environments/production/predict", 200, map[string]any{"result": 42})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--data", `{}`, "--output", "json")
+	h.Require.NoError(err)
+	h.Require.Equal("{\n  \"result\": 42\n}\n", h.Stdout.String())
+}
+
+func Test_Model_Predict_OutputJSONLCompact(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRoute("POST", "/environments/production/predict", 200, map[string]any{"result": 42})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--data", `{}`, "--output", "jsonl")
+	h.Require.NoError(err)
+	h.Require.Equal("{\"result\":42}\n", h.Stdout.String())
+}
+
+func Test_Model_Predict_BinaryResponse_Text(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRouteFunc("POST", "/environments/production/predict", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", "5")
+		_, _ = w.Write([]byte("\x00\x01\x02\x03\x04"))
+	})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--data", `{}`)
+	h.Require.NoError(err)
+	h.Require.Equal("\x00\x01\x02\x03\x04", h.Stdout.String())
+}
+
+func Test_Model_Predict_BinaryResponse_JSONEnvelope(t *testing.T) {
+	h, m := newPredictHarness(t)
+	payload := []byte("\x00\x01\x02\x03\x04")
+	m.SetRouteFunc("POST", "/environments/production/predict", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+		_, _ = w.Write(payload)
+	})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--data", `{}`, "--output", "jsonl")
+	h.Require.NoError(err)
+	expected := fmt.Sprintf("{\"body\":%q}\n", base64.StdEncoding.EncodeToString(payload))
+	h.Require.Equal(expected, h.Stdout.String())
+}
+
+func Test_Model_Predict_SSE_Text_RawPassthrough(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRouteFunc("POST", "/environments/production/predict", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "data: {\"i\":1}\n\n")
+		flusher.Flush()
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--data", `{}`)
+	h.Require.NoError(err)
+	h.Require.Contains(h.Stdout.String(), `data: {"i":1}`)
+	h.Require.Contains(h.Stdout.String(), "data: [DONE]")
+}
+
+func Test_Model_Predict_SSE_JSONL(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRouteFunc("POST", "/environments/production/predict", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "data: {\"i\":1}\n\n")
+		flusher.Flush()
+		_, _ = fmt.Fprint(w, "data: {\"i\":2}\n\n")
+		flusher.Flush()
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--data", `{}`, "--output", "jsonl")
+	h.Require.NoError(err)
+	lines := strings.Split(strings.TrimRight(h.Stdout.String(), "\n"), "\n")
+	h.Require.Equal([]string{`{"i":1}`, `{"i":2}`}, lines)
+	h.Require.NotContains(h.Stderr.String(), "warning")
+}
+
+func Test_Model_Predict_SSE_JSON_WarnsAndJSONL(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRouteFunc("POST", "/environments/production/predict", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "data: {\"i\":1}\n\n")
+		flusher.Flush()
+	})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--data", `{}`, "--output", "json")
+	h.Require.NoError(err)
+	h.Require.Equal("{\"i\":1}\n", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "output will be JSONL")
+}
+
+func Test_Model_Predict_SSE_JSONL_NonJSONDataWrapped(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRouteFunc("POST", "/environments/production/predict", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		_, _ = fmt.Fprint(w, "data: hello\n\n")
+		flusher.Flush()
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--data", `{}`, "--output", "jsonl")
+	h.Require.NoError(err)
+	expected := fmt.Sprintf("{\"body\":%q}\n", base64.StdEncoding.EncodeToString([]byte("hello")))
+	h.Require.Equal(expected, h.Stdout.String())
+}
+
+func Test_Model_Predict_NonSSEStream_JSONLWrapsChunks(t *testing.T) {
+	h, m := newPredictHarness(t)
+	chunks := [][]byte{[]byte("alpha"), []byte("beta")}
+	m.SetRouteFunc("POST", "/environments/production/predict", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		flusher := w.(http.Flusher)
+		for _, c := range chunks {
+			_, _ = w.Write(c)
+			flusher.Flush()
+		}
+	})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--data", `{}`, "--output", "jsonl")
+	h.Require.NoError(err)
+
+	// Output is one envelope per Read; we don't assert exact chunking, only
+	// that every line is a valid `{"body": "<b64>"}` and the decoded
+	// concatenation matches the full payload.
+	var got []byte
+	for _, line := range strings.Split(strings.TrimRight(h.Stdout.String(), "\n"), "\n") {
+		var env struct {
+			Body string `json:"body"`
+		}
+		h.Require.NoError(json.Unmarshal([]byte(line), &env))
+		decoded, err := base64.StdEncoding.DecodeString(env.Body)
+		h.Require.NoError(err)
+		got = append(got, decoded...)
+	}
+	h.Require.Equal([]byte("alphabeta"), got)
+}
+
+func Test_Model_Predict_ErrorStatus(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRoute("POST", "/environments/production/predict", 500, map[string]any{"error": "boom"})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--data", `{}`)
+	h.Require.ErrorContains(err, "500")
+}
+
+func Test_Model_Predict_Websocket_Echo(t *testing.T) {
+	h, m := newPredictHarness(t)
+	var serverGot string
+	m.SetRouteFunc("GET", "/environments/production/websocket", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		defer conn.Close(websocket.StatusInternalError, "")
+		_, msg, err := conn.Read(r.Context())
+		if err != nil {
+			t.Errorf("read: %v", err)
+			return
+		}
+		serverGot = string(msg)
+		reply := []byte(`{"echo":` + string(msg) + `}`)
+		if err := conn.Write(r.Context(), websocket.MessageText, reply); err != nil {
+			t.Errorf("write: %v", err)
+			return
+		}
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--websocket", "--data", `{"x":1}`)
+	h.Require.NoError(err)
+	h.Require.Equal(`{"x":1}`, serverGot)
+	h.Require.Contains(h.Stdout.String(), `"echo"`)
+}
+
+func Test_Model_Predict_Websocket_BinaryReply(t *testing.T) {
+	h, m := newPredictHarness(t)
+	payload := []byte{0x00, 0x01, 0x02, 0x03}
+	m.SetRouteFunc("GET", "/environments/production/websocket", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		defer conn.Close(websocket.StatusInternalError, "")
+		_, _, err = conn.Read(r.Context())
+		if err != nil {
+			t.Errorf("read: %v", err)
+			return
+		}
+		if err := conn.Write(r.Context(), websocket.MessageBinary, payload); err != nil {
+			t.Errorf("write: %v", err)
+			return
+		}
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--websocket", "--data", `{}`, "--output", "jsonl")
+	h.Require.NoError(err)
+	expected := fmt.Sprintf("{\"body\":%q}\n", base64.StdEncoding.EncodeToString(payload))
+	h.Require.Equal(expected, h.Stdout.String())
+}
+
+func Test_Model_Predict_Websocket_DialFailure(t *testing.T) {
+	h, m := newPredictHarness(t)
+	// No route registered → mock returns 404, which fails the WS upgrade.
+	_ = m
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--websocket", "--data", `{}`)
+	h.Require.ErrorContains(err, "websocket dial")
+}

--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -297,7 +297,11 @@ func prepareModelPushUpload(
 ) (*managementapi.PrepareModelUploadResponse, string, error) {
 	modelName := *prepareReq.Name
 
-	existingModelID, err := findModelIDByName(ctx, api, modelName, "")
+	teamScope := ""
+	if prepareReq.TeamId != nil {
+		teamScope = *prepareReq.TeamId
+	}
+	existingModelID, err := findModelIDByName(ctx, api, modelName, teamScope)
 	if err != nil {
 		return nil, "", err
 	}
@@ -305,11 +309,8 @@ func prepareModelPushUpload(
 		if flags.DisableArchiveDownload {
 			return nil, "", &ErrUsage{Err: errors.New("--disable-archive-download is only valid when creating a new model")}
 		}
-		if flags.Team != "" {
-			ctx.Logf("Ignoring --team: model %q already exists.\n", modelName)
-			prepareReq.TeamId = nil
-		}
 		prepareReq.Name = nil
+		prepareReq.TeamId = nil
 		prepareReq.ModelId = &existingModelID
 	}
 

--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -297,7 +297,7 @@ func prepareModelPushUpload(
 ) (*managementapi.PrepareModelUploadResponse, string, error) {
 	modelName := *prepareReq.Name
 
-	existingModelID, err := findExistingModelByName(ctx, api, modelName)
+	existingModelID, err := findModelIDByName(ctx, api, modelName, "")
 	if err != nil {
 		return nil, "", err
 	}
@@ -318,27 +318,6 @@ func prepareModelPushUpload(
 		return nil, "", fmt.Errorf("prepare upload: %w", err)
 	}
 	return resp, existingModelID, nil
-}
-
-func findExistingModelByName(ctx context.Context, api *managementapi.Client, name string) (string, error) {
-	resp, err := api.GetModels(ctx)
-	if err != nil {
-		return "", fmt.Errorf("list models: %w", err)
-	}
-	var matches []managementapi.Model
-	for _, m := range resp.Models {
-		if m.Name == name {
-			matches = append(matches, m)
-		}
-	}
-	switch len(matches) {
-	case 0:
-		return "", nil
-	case 1:
-		return matches[0].Id, nil
-	default:
-		return "", fmt.Errorf("multiple models named %q across teams; disambiguate by team in the API or rename", name)
-	}
 }
 
 func uploadModelPushArchive(

--- a/internal/cmd/command.model_push_test.go
+++ b/internal/cmd/command.model_push_test.go
@@ -229,6 +229,7 @@ func Test_Model_Push_TeamByID(t *testing.T) {
 			map[string]any{"id": "team-xyz", "name": "infra"},
 		},
 	})
+	h.API.SetRoute("GET", "/v1/teams/team-abc/models", 200, map[string]any{"models": []any{}})
 	h.API.SetRoute("POST", "/v1/teams/team-abc/models", 200, map[string]any{
 		"model": map[string]any{
 			"id": "model-123", "name": "test-model",
@@ -262,6 +263,7 @@ func Test_Model_Push_TeamByName(t *testing.T) {
 			map[string]any{"id": "team-xyz", "name": "infra"},
 		},
 	})
+	h.API.SetRoute("GET", "/v1/teams/team-abc/models", 200, map[string]any{"models": []any{}})
 	h.API.SetRoute("POST", "/v1/teams/team-abc/models", 200, map[string]any{
 		"model": map[string]any{
 			"id": "model-123", "name": "test-model",

--- a/internal/cmd/command.model_test.go
+++ b/internal/cmd/command.model_test.go
@@ -1,0 +1,275 @@
+package cmd_test
+
+import (
+	"testing"
+)
+
+func Test_Model_List_Empty(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/models", 200, map[string]any{"models": []any{}})
+
+	h.Require.NoError(h.Execute("model", "list"))
+	h.Require.Equal("", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "No models found.")
+}
+
+func Test_Model_List_Rows(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/models", 200, map[string]any{
+		"models": []any{
+			map[string]any{
+				"id":                 "m-1",
+				"name":               "alpha",
+				"team_name":          "default",
+				"deployments_count":  2,
+				"created_at":         "2026-01-02T03:04:05Z",
+				"instance_type_name": "A10G",
+			},
+			map[string]any{
+				"id":                 "m-2",
+				"name":               "beta",
+				"team_name":          "ml",
+				"deployments_count":  0,
+				"created_at":         "2026-02-03T04:05:06Z",
+				"instance_type_name": "A100",
+			},
+		},
+	})
+
+	h.Require.NoError(h.Execute("model", "list"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "ID")
+	h.Require.Contains(out, "NAME")
+	h.Require.Contains(out, "TEAM")
+	h.Require.Contains(out, "DEPLOYMENTS")
+	h.Require.Contains(out, "CREATED")
+	h.Require.Contains(out, "m-1")
+	h.Require.Contains(out, "alpha")
+	h.Require.Contains(out, "beta")
+	h.Require.Contains(out, "2026-01-02T03:04:05Z")
+}
+
+func Test_Model_List_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/models", 200, map[string]any{
+		"models": []any{
+			map[string]any{
+				"id": "m-1", "name": "alpha", "team_name": "default",
+				"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+				"instance_type_name": "A10G",
+			},
+		},
+	})
+
+	h.Require.NoError(h.Execute("model", "list", "--output", "json"))
+	h.Require.Contains(h.Stdout.String(), `"name": "alpha"`)
+}
+
+func Test_Model_List_ScopedByTeam(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/teams", 200, map[string]any{
+		"teams": []any{
+			map[string]any{"id": "team-abc", "name": "ml"},
+		},
+	})
+	m.SetRoute("GET", "/v1/teams/team-abc/models", 200, map[string]any{
+		"models": []any{
+			map[string]any{
+				"id": "m-1", "name": "alpha", "team_name": "ml",
+				"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+				"instance_type_name": "A10G",
+			},
+		},
+	})
+
+	h.Require.NoError(h.Execute("model", "list", "--team", "ml"))
+	h.Require.NotNil(m.FindCall("GET", "/v1/teams/team-abc/models"))
+	h.Require.Contains(h.Stdout.String(), "alpha")
+}
+
+func Test_Model_Fetch_ByID(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/models/m-1", 200, map[string]any{
+		"id": "m-1", "name": "alpha", "team_name": "default",
+		"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+		"instance_type_name": "A10G",
+	})
+
+	h.Require.NoError(h.Execute("model", "fetch", "--model-id", "m-1"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "ID:")
+	h.Require.Contains(out, "m-1")
+	h.Require.Contains(out, "alpha")
+}
+
+func Test_Model_Fetch_ByName(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/models", 200, map[string]any{
+		"models": []any{
+			map[string]any{
+				"id": "m-1", "name": "alpha", "team_name": "default",
+				"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+				"instance_type_name": "A10G",
+			},
+		},
+	})
+	m.SetRoute("GET", "/v1/models/m-1", 200, map[string]any{
+		"id": "m-1", "name": "alpha", "team_name": "default",
+		"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+		"instance_type_name": "A10G",
+	})
+
+	h.Require.NoError(h.Execute("model", "fetch", "--model-name", "alpha"))
+	h.Require.NotNil(m.FindCall("GET", "/v1/models/m-1"))
+}
+
+func Test_Model_Fetch_ByNameAmbiguous(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/models", 200, map[string]any{
+		"models": []any{
+			map[string]any{
+				"id": "m-1", "name": "alpha", "team_name": "default",
+				"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+				"instance_type_name": "A10G",
+			},
+			map[string]any{
+				"id": "m-2", "name": "alpha", "team_name": "ml",
+				"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+				"instance_type_name": "A10G",
+			},
+		},
+	})
+
+	err := h.Execute("model", "fetch", "--model-name", "alpha")
+	h.Require.ErrorContains(err, "multiple models named")
+	h.Require.ErrorContains(err, "--team")
+}
+
+func Test_Model_Fetch_ByNameWithTeam(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/teams", 200, map[string]any{
+		"teams": []any{
+			map[string]any{"id": "team-abc", "name": "ml"},
+		},
+	})
+	m.SetRoute("GET", "/v1/teams/team-abc/models", 200, map[string]any{
+		"models": []any{
+			map[string]any{
+				"id": "m-2", "name": "alpha", "team_name": "ml",
+				"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+				"instance_type_name": "A10G",
+			},
+		},
+	})
+	m.SetRoute("GET", "/v1/models/m-2", 200, map[string]any{
+		"id": "m-2", "name": "alpha", "team_name": "ml",
+		"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+		"instance_type_name": "A10G",
+	})
+
+	h.Require.NoError(h.Execute("model", "fetch", "--model-name", "alpha", "--team", "ml"))
+	h.Require.NotNil(m.FindCall("GET", "/v1/models/m-2"))
+}
+
+func Test_Model_Fetch_ByNameNotFound(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/models", 200, map[string]any{"models": []any{}})
+
+	err := h.Execute("model", "fetch", "--model-name", "ghost")
+	h.Require.ErrorContains(err, `no model named "ghost"`)
+}
+
+func Test_Model_Fetch_TeamWithID_Rejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "fetch", "--model-id", "m-1", "--team", "ml")
+	h.Require.ErrorContains(err, "--team is only valid with --model-name")
+}
+
+func Test_Model_Fetch_MissingRef(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "fetch")
+	h.Require.Error(err)
+}
+
+func Test_Model_Delete_Yes_ByID(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/models/m-1", 200, map[string]any{
+		"id": "m-1", "name": "alpha", "team_name": "default",
+		"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+		"instance_type_name": "A10G",
+	})
+	m.SetRoute("DELETE", "/v1/models/m-1", 200, map[string]any{
+		"id": "m-1", "deleted": true,
+	})
+
+	h.Require.NoError(h.Execute("model", "delete", "--model-id", "m-1", "--yes"))
+	h.Require.NotNil(m.FindCall("DELETE", "/v1/models/m-1"))
+	h.Require.Contains(h.Stderr.String(), "Deleted model alpha (m-1)")
+}
+
+func Test_Model_Delete_Yes_ByName(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/models", 200, map[string]any{
+		"models": []any{
+			map[string]any{
+				"id": "m-1", "name": "alpha", "team_name": "default",
+				"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+				"instance_type_name": "A10G",
+			},
+		},
+	})
+	m.SetRoute("GET", "/v1/models/m-1", 200, map[string]any{
+		"id": "m-1", "name": "alpha", "team_name": "default",
+		"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+		"instance_type_name": "A10G",
+	})
+	m.SetRoute("DELETE", "/v1/models/m-1", 200, map[string]any{
+		"id": "m-1", "deleted": true,
+	})
+
+	h.Require.NoError(h.Execute("model", "delete", "--model-name", "alpha", "--yes"))
+	h.Require.NotNil(m.FindCall("DELETE", "/v1/models/m-1"))
+}
+
+func Test_Model_Delete_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/models/m-1", 200, map[string]any{
+		"id": "m-1", "name": "alpha", "team_name": "default",
+		"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+		"instance_type_name": "A10G",
+	})
+	m.SetRoute("DELETE", "/v1/models/m-1", 200, map[string]any{
+		"id": "m-1", "deleted": true,
+	})
+
+	h.Require.NoError(h.Execute("model", "delete", "--model-id", "m-1", "--yes", "--output", "json"))
+	h.Require.Contains(h.Stdout.String(), `"deleted": true`)
+}
+
+func Test_Model_Delete_NoTTY_RequiresYes(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/models/m-1", 200, map[string]any{
+		"id": "m-1", "name": "alpha", "team_name": "default",
+		"deployments_count": 1, "created_at": "2026-01-02T03:04:05Z",
+		"instance_type_name": "A10G",
+	})
+
+	err := h.Execute("model", "delete", "--model-id", "m-1")
+	h.Require.ErrorContains(err, "stdin is not a terminal")
+	h.Require.Nil(m.FindCall("DELETE", "/v1/models/m-1"))
+}
+
+func Test_Model_Delete_NotFound(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/models", 200, map[string]any{"models": []any{}})
+
+	err := h.Execute("model", "delete", "--model-name", "ghost", "--yes")
+	h.Require.ErrorContains(err, `no model named "ghost"`)
+}

--- a/internal/e2e-tests/helpers_test.go
+++ b/internal/e2e-tests/helpers_test.go
@@ -25,8 +25,22 @@ resources:
   use_gpu: false
 `
 
-const trussModelPy = `class Model:
+const trussModelPy = `from fastapi.responses import StreamingResponse
+
+class Model:
     def predict(self, request):
+        if request.get("style") == "streaming":
+            chunks = request.get("chunks", ["alpha", "beta", "gamma"])
+            def gen():
+                for c in chunks:
+                    yield c
+            return gen()
+        if request.get("style") == "sse":
+            chunks = request.get("chunks", ["alpha", "beta", "gamma"])
+            def gen():
+                for c in chunks:
+                    yield f"data: {c}\n\n"
+            return StreamingResponse(gen(), media_type="text/event-stream")
         return {"got request": request}
 `
 

--- a/internal/e2e-tests/model_test.go
+++ b/internal/e2e-tests/model_test.go
@@ -5,10 +5,12 @@ package e2etests
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,9 +22,12 @@ import (
 // required env vars are absent.
 func TestE2EModelLifecycle(t *testing.T) {
 	l := newLifecycle(t)
-	t.Run("ManagementAPI", l.ManagementAPI)
-	t.Run("InferenceAPI", l.InferenceAPI)
+	t.Run("APIManagement", l.APIManagement)
+	t.Run("APIInference", l.APIInference)
+	t.Run("Model", l.Model)
+	t.Run("ModelPredict", l.ModelPredict)
 	t.Run("Redeploy", l.Redeploy)
+	t.Run("Delete", l.Delete)
 }
 
 // lifecycle holds the state shared across the lifecycle sub-tests. Created
@@ -61,13 +66,12 @@ func newLifecycle(t *testing.T) *lifecycle {
 			l.modelID = lookupModelIDByName(t, l.modelName)
 		}
 		if l.modelID == "" {
-			t.Logf("no model to clean up for %s", l.modelName)
 			return
 		}
 		t.Logf("deleting model %s (%s)", l.modelName, l.modelID)
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		if _, errOut, err := cliCtx(t, ctx, "api", "management", "-X", "DELETE", "models/"+l.modelID); err != nil {
+		if _, errOut, err := cliCtx(t, ctx, "model", "delete", "--model-id", l.modelID, "--yes"); err != nil {
 			t.Logf("cleanup delete failed: %v\nstderr: %s", err, errOut)
 		}
 	})
@@ -81,7 +85,7 @@ func newLifecycle(t *testing.T) *lifecycle {
 	return l
 }
 
-func (l *lifecycle) ManagementAPI(t *testing.T) {
+func (l *lifecycle) APIManagement(t *testing.T) {
 	t.Run("ListIncludesModel", func(t *testing.T) {
 		out := mustCLI(t, "api", "management", "models")
 		var resp struct {
@@ -129,11 +133,87 @@ func (l *lifecycle) ManagementAPI(t *testing.T) {
 	})
 }
 
-func (l *lifecycle) InferenceAPI(t *testing.T) {
+func (l *lifecycle) APIInference(t *testing.T) {
 	out := mustCLI(t, "api", "inference", "--model-id", l.modelID, "-F", "x=1", "production/predict")
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal([]byte(out), &resp))
 	require.Equal(t, map[string]any{"got request": map[string]any{"x": float64(1)}}, resp)
+}
+
+func (l *lifecycle) Model(t *testing.T) {
+	t.Run("List", func(t *testing.T) {
+		out := mustCLI(t, "model", "list", "--output", "json")
+		var resp struct {
+			Models []struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"models"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		for _, m := range resp.Models {
+			if m.ID == l.modelID {
+				require.Equal(t, l.modelName, m.Name)
+				return
+			}
+		}
+		t.Fatalf("model %s missing from model list", l.modelID)
+	})
+
+	t.Run("FetchByID", func(t *testing.T) {
+		out := mustCLI(t, "model", "fetch", "--model-id", l.modelID, "--output", "json")
+		var resp struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.Equal(t, l.modelID, resp.ID)
+		require.Equal(t, l.modelName, resp.Name)
+	})
+
+	t.Run("FetchByName", func(t *testing.T) {
+		out := mustCLI(t, "model", "fetch", "--model-name", l.modelName, "--output", "json")
+		var resp struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.Equal(t, l.modelID, resp.ID)
+		require.Equal(t, l.modelName, resp.Name)
+	})
+}
+
+func (l *lifecycle) ModelPredict(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		out := mustCLI(t, "model", "predict", "--model-id", l.modelID, "--data", `{"x":1}`, "--output", "json")
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.Equal(t, map[string]any{"got request": map[string]any{"x": float64(1)}}, resp)
+	})
+
+	t.Run("Streaming_Text", func(t *testing.T) {
+		out := mustCLI(t, "model", "predict", "--model-id", l.modelID,
+			"--data", `{"style":"streaming","chunks":["alpha","beta","gamma"]}`)
+		require.Equal(t, "alphabetagamma", out)
+	})
+
+	t.Run("SSE_JSONL", func(t *testing.T) {
+		out := mustCLI(t, "model", "predict", "--model-id", l.modelID,
+			"--data", `{"style":"sse","chunks":["alpha","beta","gamma"]}`,
+			"--output", "jsonl")
+		lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+		require.Equal(t, 3, len(lines), "SSE should yield one envelope per data: event")
+		var concat []byte
+		for _, line := range lines {
+			var env struct {
+				Body string `json:"body"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(line), &env))
+			b, err := base64.StdEncoding.DecodeString(env.Body)
+			require.NoError(t, err)
+			concat = append(concat, b...)
+		}
+		require.Equal(t, []byte("alphabetagamma"), concat)
+	})
 }
 
 func (l *lifecycle) Redeploy(t *testing.T) {
@@ -142,6 +222,15 @@ func (l *lifecycle) Redeploy(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(out), &redeploy))
 	require.Equal(t, l.modelID, redeploy.Model.ID, "redeploy should reuse existing model")
 	require.NotEqual(t, l.initialDeploymentID, redeploy.Deployment.ID, "redeploy should create a new deployment")
+}
+
+func (l *lifecycle) Delete(t *testing.T) {
+	deletedID := l.modelID
+	mustCLI(t, "model", "delete", "--model-id", deletedID, "--yes")
+	l.modelID = ""
+
+	_, errOut, err := cli(t, "model", "fetch", "--model-id", deletedID)
+	require.Error(t, err, "fetch should fail after delete; stderr: %s", errOut)
 }
 
 func randomSuffix(t *testing.T) string {

--- a/internal/e2e-tests/org_secret_test.go
+++ b/internal/e2e-tests/org_secret_test.go
@@ -82,4 +82,3 @@ func TestE2EOrgSecret(t *testing.T) {
 		}
 	})
 }
-


### PR DESCRIPTION

## :rocket: What

* Add `model list` - simple model listing
* Add `model fetch` - simple model fetching
* Add `model predict` - send predict calls, supports streaming and even [single message] websocket
* Add `model delete` - delete model, but must type out model to confirm or pass `--yes`
* Add concept of `--model-name` (+ optional `--team`) to refer to a model everywhere as an alternative to `--model-id`

## :computer: How

* New CLI implementations of the aforementioned commands
* Adjust existing commands to leverage common model-ref helper to leverage model name lookup

## :microscope: Testing

* Unit tests
* E2E tests
