### PR TITLE
Add --remote-url flag

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -25,8 +25,9 @@ var Root = Command{
 // CommandFlags are shared flags that every command must embed, either directly
 // or via another struct that embeds it.
 type CommandFlags struct {
-	Verbose bool   `flag:"verbose" short:"v" desc:"Enable verbose logging"`
-	Output  string `flag:"output" short:"o" desc:"Output format" default:"text" enum:"text,json,jsonl,none"`
+	Verbose   bool   `flag:"verbose" short:"v" desc:"Enable verbose logging"`
+	Output    string `flag:"output" short:"o" desc:"Output format" default:"text" enum:"text,json,jsonl,none"`
+	RemoteURL string `flag:"remote-url" desc:"Baseten remote URL, overrides BASETEN_REMOTE_URL (default https://app.baseten.co)"`
 }
 
 // Command defines a CLI command declaratively. The tree structure is built

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -190,7 +190,11 @@ func buildCommand(def cmd.Command, parentPath string, options *ExecuteOptions) *
 
 		r := runners[path]
 		c.RunE = func(_ *cobra.Command, args []string) error {
-			remote, err := NewRemote()
+			var cmdFlags cmd.CommandFlags
+			if f := flagsVal.FieldByName("CommandFlags"); f.IsValid() {
+				cmdFlags = f.Interface().(cmd.CommandFlags)
+			}
+			remote, err := NewRemote(cmdFlags.RemoteURL)
 			if err != nil {
 				return err
 			}
@@ -204,15 +208,12 @@ func buildCommand(def cmd.Command, parentPath string, options *ExecuteOptions) *
 				ExitWithCode: options.ExitWithCode,
 				Remote:       remote,
 			}
-			if f := flagsVal.FieldByName("CommandFlags"); f.IsValid() {
-				cmdFlags := f.Interface().(cmd.CommandFlags)
-				ctx.JSON = cmdFlags.Output == "json" || cmdFlags.Output == "jsonl"
-				ctx.JSONCompact = cmdFlags.Output == "jsonl"
-				ctx.JSONLines = cmdFlags.Output == "jsonl"
-				ctx.verbose = cmdFlags.Verbose
-				if cmdFlags.Output == "none" {
-					ctx.Stdout = io.Discard
-				}
+			ctx.JSON = cmdFlags.Output == "json" || cmdFlags.Output == "jsonl"
+			ctx.JSONCompact = cmdFlags.Output == "jsonl"
+			ctx.JSONLines = cmdFlags.Output == "jsonl"
+			ctx.verbose = cmdFlags.Verbose
+			if cmdFlags.Output == "none" {
+				ctx.Stdout = io.Discard
 			}
 			results := reflect.ValueOf(r.fn).Call([]reflect.Value{
 				reflect.ValueOf(ctx),

--- a/internal/cmd/remote.go
+++ b/internal/cmd/remote.go
@@ -21,17 +21,20 @@ type Remote struct {
 	inferenceHostSuffix string
 }
 
-// NewRemote parses BASETEN_REMOTE_URL (default https://app.baseten.co), looks
-// up any known per-remote URL overrides, and applies the optional override
-// env vars on top.
-func NewRemote() (*Remote, error) {
-	r := &Remote{remoteURL: os.Getenv("BASETEN_REMOTE_URL")}
+// NewRemote resolves the remote URL (flag arg, then BASETEN_REMOTE_URL, then
+// https://app.baseten.co), looks up any known per-remote URL overrides, and
+// applies the optional override env vars on top.
+func NewRemote(remoteURL string) (*Remote, error) {
+	r := &Remote{remoteURL: remoteURL}
+	if r.remoteURL == "" {
+		r.remoteURL = os.Getenv("BASETEN_REMOTE_URL")
+	}
 	if r.remoteURL == "" {
 		r.remoteURL = "https://app.baseten.co"
 	}
 	u, err := url.Parse(r.remoteURL)
 	if err != nil || u.Scheme == "" || u.Host == "" {
-		return nil, fmt.Errorf("invalid BASETEN_REMOTE_URL: %q", r.remoteURL)
+		return nil, fmt.Errorf("invalid remote URL: %q", r.remoteURL)
 	}
 	r.scheme = u.Scheme
 	r.baseHost = strings.TrimPrefix(u.Host, "app.")

--- a/internal/cmd/remote.go
+++ b/internal/cmd/remote.go
@@ -36,6 +36,10 @@ func NewRemote(remoteURL string) (*Remote, error) {
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		return nil, fmt.Errorf("invalid remote URL: %q", r.remoteURL)
 	}
+	if (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" {
+		return nil, fmt.Errorf("remote URL must not include a path, query, or fragment: %q", r.remoteURL)
+	}
+	r.remoteURL = u.Scheme + "://" + u.Host
 	r.scheme = u.Scheme
 	r.baseHost = strings.TrimPrefix(u.Host, "app.")
 


### PR DESCRIPTION
## :rocket: What

* Add a `--remote-url` flag that overrides `BASETEN_REMOTE_URL`. Precedence: flag then env var then `https://app.baseten.co`.

## :computer: How

* Added `RemoteURL` to the shared `CommandFlags` struct so it appears on every command. `NewRemote` now takes the resolved URL as an argument, with the env-var/default fallback inside.

## :microscope: Testing

* Existing tests cover the env-var path. Manually verified `--remote-url`, env var, and default each resolve correctly.