### PR TITLE
Add per-platform install one-liners to README and CI version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,17 @@ jobs:
       - name: Test
         run: go test ./...
 
+      - name: Verify README references the latest release
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)
+          if ! grep -qF "Or install $TAG with a one-liner:" README.md; then
+            echo "README.md install instructions do not reference latest release $TAG; please update them."
+            exit 1
+          fi
+
       - name: E2E test
         if: matrix.os == 'ubuntu-latest'
         env:

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Or install v0.1.0 with a one-liner:
 ### Linux (x64)
 
     curl -sL https://github.com/basetenlabs/baseten-cli/releases/download/v0.1.0/baseten_0.1.0_linux_amd64.tar.gz \
-      | tar xz && sudo mv baseten /usr/local/bin/
+      | sudo tar xz -C /usr/local/bin baseten
 
 ### macOS (arm64)
 
     curl -sL https://github.com/basetenlabs/baseten-cli/releases/download/v0.1.0/baseten_0.1.0_darwin_arm64.tar.gz \
-      | tar xz && sudo mv baseten /usr/local/bin/
+      | sudo tar xz -C /usr/local/bin baseten
 
 ### Windows (x64)
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,29 @@ CLI for the [Baseten Inference Platform](https://baseten.co).
 
 ## Installation
 
-Download the [latest release](https://github.com/basetenlabs/baseten-cli/releases/latest) for your platform.
+Download the [latest release](https://github.com/basetenlabs/baseten-cli/releases/latest) for your platform, extract the archive, and place the `baseten` executable on your `PATH`.
 
-Extract the archive and use the `baseten` executable within. Place it on your `PATH` to invoke it from anywhere.
+Or install v0.1.0 with a one-liner:
+
+### Linux (x64)
+
+    curl -sL https://github.com/basetenlabs/baseten-cli/releases/download/v0.1.0/baseten_0.1.0_linux_amd64.tar.gz \
+      | tar xz && sudo mv baseten /usr/local/bin/
+
+### macOS (arm64)
+
+    curl -sL https://github.com/basetenlabs/baseten-cli/releases/download/v0.1.0/baseten_0.1.0_darwin_arm64.tar.gz \
+      | tar xz && sudo mv baseten /usr/local/bin/
+
+### Windows (x64)
+
+PowerShell:
+
+    Invoke-WebRequest `
+      https://github.com/basetenlabs/baseten-cli/releases/download/v0.1.0/baseten_0.1.0_windows_amd64.zip `
+      -OutFile baseten.zip; Expand-Archive -Force baseten.zip .
+
+Then move `baseten.exe` to a directory on your `PATH`.
 
 ## Usage
 


### PR DESCRIPTION
## :rocket: What

Until we submit to OS package managers, add one-liners to README for install. To keep the command succinct we have to put the latest version in the command, which means we are also adding a CI check to ensure it stays up to date. The CI check knowingly will only break _after_ release, but that is an acceptable tradeoff since there is no reasonable way to do it pre-tag.

## :computer: How

Add one-liners to README and check to CI that is up to date

## :microscope: Testing

Manual CLI commands and Running CI in this PR