### PR TITLE
Add filter flags to model deployment logs

### DIFF
--- a/cmd/command.model_deployment.go
+++ b/cmd/command.model_deployment.go
@@ -310,9 +310,16 @@ type ModelDeploymentLogsFlags struct {
 	CommandFlags
 	ModelDeploymentIDFlags
 
-	Tail bool `flag:"tail" desc:"Stream new logs as they arrive until the deployment leaves a runnable state or you interrupt with Ctrl-C. Cannot be combined with --start, --end, or --since. For machine-readable streaming, prefer --output jsonl over --output json."`
+	Tail bool `flag:"tail" desc:"Stream new logs as they arrive until the deployment leaves a runnable state or you interrupt with Ctrl-C. Cannot be combined with the filter flags. For machine-readable streaming, prefer --output jsonl over --output json."`
 
-	Start time.Time     `flag:"start" desc:"Start of the log time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. If omitted but --end is given, defaults to 7 days before --end. Window must be at most 7 days."`
-	End   time.Time     `flag:"end" desc:"End of the log time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. If omitted but --start is given, defaults to now. Window must be at most 7 days."`
+	Start time.Time     `flag:"start" desc:"Start of the log time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the start to 30 minutes before the end. Window must be at most 7 days."`
+	End   time.Time     `flag:"end" desc:"End of the log time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the end to now. Window must be at most 7 days."`
 	Since time.Duration `flag:"since" desc:"Shortcut for fetching logs from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
+
+	MinLevel      string   `flag:"min-level" desc:"Only return logs at or above this severity level." enum:"debug,info,warning,error"`
+	Includes      []string `flag:"includes" desc:"Case-sensitive substring that must appear in the log message. May be repeated; all must match."`
+	Excludes      []string `flag:"excludes" desc:"Case-sensitive substring; lines containing it are dropped. May be repeated."`
+	SearchPattern string   `flag:"search-pattern" desc:"RE2 regular expression matched against the log message. Prefer --includes and --excludes for plain substring matches."`
+	Replica       string   `flag:"replica" desc:"Only return logs emitted by this replica (5-char short ID)."`
+	RequestID     string   `flag:"request-id" desc:"Only return logs tagged with this inference request ID."`
 }

--- a/cmd/command.model_deployment.go
+++ b/cmd/command.model_deployment.go
@@ -310,7 +310,7 @@ type ModelDeploymentLogsFlags struct {
 	CommandFlags
 	ModelDeploymentIDFlags
 
-	Tail bool `flag:"tail" desc:"Stream new logs as they arrive until the deployment leaves a runnable state or you interrupt with Ctrl-C. Cannot be combined with the filter flags. For machine-readable streaming, prefer --output jsonl over --output json."`
+	Tail bool `flag:"tail" desc:"Stream new logs as they arrive until the deployment leaves a runnable state or you interrupt with Ctrl-C. Cannot be combined with the time-range or filter flags. For machine-readable streaming, prefer --output jsonl over --output json."`
 
 	Start time.Time     `flag:"start" desc:"Start of the log time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the start to 30 minutes before the end. Window must be at most 7 days."`
 	End   time.Time     `flag:"end" desc:"End of the log time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the end to now. Window must be at most 7 days."`

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.0.0-20260519163234-472e42b898f0
+	github.com/basetenlabs/baseten-go v0.1.0
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.0.0-20260519163234-472e42b898f0 h1:7dxPu/y18dkcvGqZFDHZNd42VF9JpeoNKveSfEvwvWU=
-github.com/basetenlabs/baseten-go v0.0.0-20260519163234-472e42b898f0/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.1.0 h1:jOnntq9cZP+8YBUN9G0hQx6Ms7A9F5ujLUNcPD9LsLE=
+github.com/basetenlabs/baseten-go v0.1.0/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/internal/cmd/command.model_deployment.go
+++ b/internal/cmd/command.model_deployment.go
@@ -117,7 +117,8 @@ func commandModelDeploymentConfig(ctx *CommandContext, flags *cmd.ModelDeploymen
 	if err != nil {
 		return err
 	}
-	resp, err := cl.API().GetModelsDeploymentsConfig(ctx, ref.ID, flags.DeploymentID)
+	resp, err := cl.API().GetModelsDeploymentsConfig(ctx, ref.ID, flags.DeploymentID,
+		managementapi.GetV1ModelsModelIdDeploymentsDeploymentIdConfigParams{})
 	if err != nil {
 		return fmt.Errorf("fetch deployment config for %s: %w", flags.DeploymentID, err)
 	}

--- a/internal/cmd/command.model_deployment_logs.go
+++ b/internal/cmd/command.model_deployment_logs.go
@@ -29,8 +29,10 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 	// Use Changed rather than the zero value so explicit --since 0 fails
 	// the positive-duration check below instead of being silently dropped.
 	hasSince := ctx.Command.Flags().Changed("since")
-	if flags.Tail && (hasStart || hasEnd || hasSince) {
-		return cmd.NewErrUsagef("--tail cannot be combined with --start, --end, or --since")
+	hasFilters := flags.MinLevel != "" || len(flags.Includes) > 0 || len(flags.Excludes) > 0 ||
+		flags.SearchPattern != "" || flags.Replica != "" || flags.RequestID != ""
+	if flags.Tail && (hasStart || hasEnd || hasSince || hasFilters) {
+		return cmd.NewErrUsagef("--tail cannot be combined with the filter flags")
 	}
 	if hasSince && (hasStart || hasEnd) {
 		return cmd.NewErrUsagef("--since cannot be combined with --start or --end")
@@ -62,7 +64,7 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 
 	// Resolve --start/--end/--since into epoch-millis bounds. Nil bounds mean
 	// "server default"; unset start/end/since pass nils.
-	var startMs, endMs *int
+	var req managementapi.GetDeploymentLogsRequest
 	if hasSince {
 		if flags.Since <= 0 {
 			return cmd.NewErrUsagef("--since must be a positive duration")
@@ -73,28 +75,50 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 		now := ctx.Now()
 		s := int(now.Add(-flags.Since).UnixMilli())
 		e := int(now.UnixMilli())
-		startMs, endMs = &s, &e
+		req.StartEpochMillis, req.EndEpochMillis = &s, &e
 	} else if hasStart || hasEnd {
-		startT, endT := flags.Start, flags.End
-		if !hasEnd {
-			endT = ctx.Now().Truncate(time.Second)
+		// Send only the bounds given and leave the other nil so the server
+		// backfills it (missing end -> now, missing start -> 30m before end).
+		// Validate the window client-side only when both bounds are given.
+		if hasStart {
+			s := int(flags.Start.UnixMilli())
+			req.StartEpochMillis = &s
 		}
-		if !hasStart {
-			startT = endT.Add(-maxLogTimeRange)
+		if hasEnd {
+			e := int(flags.End.UnixMilli())
+			req.EndEpochMillis = &e
 		}
-		if !startT.Before(endT) {
-			return cmd.NewErrUsagef("--start must be earlier than --end")
+		if hasStart && hasEnd {
+			if !flags.Start.Before(flags.End) {
+				return cmd.NewErrUsagef("--start must be earlier than --end")
+			}
+			if flags.End.Sub(flags.Start) > maxLogTimeRange {
+				return cmd.NewErrUsagef("log time range must be at most 7 days; narrow --start/--end or use --since")
+			}
 		}
-		if endT.Sub(startT) > maxLogTimeRange {
-			return cmd.NewErrUsagef("log time range must be at most 7 days; narrow --start/--end or use --since")
-		}
-		s := int(startT.UnixMilli())
-		e := int(endT.UnixMilli())
-		startMs, endMs = &s, &e
 	}
 
-	resp, err := api.API().PostModelsDeploymentsLogs(ctx, ref.ID, flags.DeploymentID,
-		managementapi.GetDeploymentLogsRequest{StartEpochMillis: startMs, EndEpochMillis: endMs})
+	if flags.MinLevel != "" {
+		level := managementapi.LogLevel(strings.ToUpper(flags.MinLevel))
+		req.MinLevel = &level
+	}
+	if len(flags.Includes) > 0 {
+		req.Includes = &flags.Includes
+	}
+	if len(flags.Excludes) > 0 {
+		req.Excludes = &flags.Excludes
+	}
+	if flags.SearchPattern != "" {
+		req.SearchPattern = &flags.SearchPattern
+	}
+	if flags.Replica != "" {
+		req.Replica = &flags.Replica
+	}
+	if flags.RequestID != "" {
+		req.RequestId = &flags.RequestID
+	}
+
+	resp, err := api.API().PostModelsDeploymentsLogs(ctx, ref.ID, flags.DeploymentID, req)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/command.model_deployment_logs.go
+++ b/internal/cmd/command.model_deployment_logs.go
@@ -32,7 +32,7 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 	hasFilters := flags.MinLevel != "" || len(flags.Includes) > 0 || len(flags.Excludes) > 0 ||
 		flags.SearchPattern != "" || flags.Replica != "" || flags.RequestID != ""
 	if flags.Tail && (hasStart || hasEnd || hasSince || hasFilters) {
-		return cmd.NewErrUsagef("--tail cannot be combined with the filter flags")
+		return cmd.NewErrUsagef("--tail cannot be combined with the time-range or filter flags")
 	}
 	if hasSince && (hasStart || hasEnd) {
 		return cmd.NewErrUsagef("--since cannot be combined with --start or --end")

--- a/internal/cmd/command.model_deployment_logs_test.go
+++ b/internal/cmd/command.model_deployment_logs_test.go
@@ -80,6 +80,57 @@ func Test_Model_Deployment_Logs_SinceOver7DaysRejected(t *testing.T) {
 	h.Require.Contains(err.Error(), "at most 7d")
 }
 
+func Test_Model_Deployment_Logs_FiltersSent(t *testing.T) {
+	h := NewCommandHarness(t)
+	api := h.MockManagementAPI()
+	api.SetRoute("POST", logsLogsPath, 200, logsResponse())
+	err := h.Execute("model", "deployment", "logs",
+		"--model-id", "m", "--deployment-id", "d",
+		"--min-level", "info",
+		"--includes", "warn", "--includes", "fail",
+		"--excludes", "healthz",
+		"--search-pattern", ".*timeout",
+		"--replica", "g00r0",
+		"--request-id", "req-123")
+	h.Require.NoError(err)
+	req := api.FindCall("POST", logsLogsPath).BodyJSON(h.T)
+	// --min-level is uppercased before sending.
+	h.Require.Equal("INFO", req["min_level"])
+	h.Require.Equal([]any{"warn", "fail"}, req["includes"])
+	h.Require.Equal([]any{"healthz"}, req["excludes"])
+	h.Require.Equal(".*timeout", req["search_pattern"])
+	h.Require.Equal("g00r0", req["replica"])
+	h.Require.Equal("req-123", req["request_id"])
+}
+
+func Test_Model_Deployment_Logs_FiltersOmittedWhenUnset(t *testing.T) {
+	h := NewCommandHarness(t)
+	api := h.MockManagementAPI()
+	api.SetRoute("POST", logsLogsPath, 200, logsResponse())
+	err := h.Execute("model", "deployment", "logs", "--model-id", "m", "--deployment-id", "d")
+	h.Require.NoError(err)
+	req := api.FindCall("POST", logsLogsPath).BodyJSON(h.T)
+	for _, field := range []string{"min_level", "includes", "excludes", "search_pattern", "replica", "request_id"} {
+		h.Require.Nil(req[field], "expected %s to be omitted", field)
+	}
+}
+
+func Test_Model_Deployment_Logs_MinLevelInvalidRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "deployment", "logs",
+		"--model-id", "m", "--deployment-id", "d", "--min-level", "trace")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "must be one of")
+}
+
+func Test_Model_Deployment_Logs_TailWithFilterRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "deployment", "logs",
+		"--model-id", "m", "--deployment-id", "d", "--tail", "--min-level", "info")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "--tail cannot be combined")
+}
+
 func Test_Model_Deployment_Logs_OneShotText(t *testing.T) {
 	h := NewCommandHarness(t)
 	// 2026-05-14T12:00:00Z in nanoseconds since epoch. Display is in the
@@ -161,17 +212,32 @@ func Test_Model_Deployment_Logs_SinceWithDaySuffix(t *testing.T) {
 	h.Require.Equal(float64(startMs), req["start_epoch_millis"])
 }
 
-func Test_Model_Deployment_Logs_StartOnlyEndDefaultsToNow(t *testing.T) {
+func Test_Model_Deployment_Logs_StartOnlyDefersEndToServer(t *testing.T) {
 	h := NewCommandHarness(t)
 	api := h.MockManagementAPI()
 	api.SetRoute("POST", logsLogsPath, 200, logsResponse())
-	fixed := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
-	h.Context = cmd.WithNow(h.Context, func() time.Time { return fixed })
+	start := time.Date(2026, 5, 13, 11, 0, 0, 0, time.Local)
 	err := h.Execute("model", "deployment", "logs",
 		"--model-id", "m", "--deployment-id", "d", "--start", "2026-05-13T11:00:00")
 	h.Require.NoError(err)
 	req := api.FindCall("POST", logsLogsPath).BodyJSON(h.T)
-	h.Require.Equal(float64(fixed.UnixMilli()), req["end_epoch_millis"])
+	// Only --start is sent; end is left for the server to backfill.
+	h.Require.Equal(float64(start.UnixMilli()), req["start_epoch_millis"])
+	h.Require.Nil(req["end_epoch_millis"])
+}
+
+func Test_Model_Deployment_Logs_EndOnlyDefersStartToServer(t *testing.T) {
+	h := NewCommandHarness(t)
+	api := h.MockManagementAPI()
+	api.SetRoute("POST", logsLogsPath, 200, logsResponse())
+	end := time.Date(2026, 5, 14, 12, 0, 0, 0, time.Local)
+	err := h.Execute("model", "deployment", "logs",
+		"--model-id", "m", "--deployment-id", "d", "--end", "2026-05-14T12:00:00")
+	h.Require.NoError(err)
+	req := api.FindCall("POST", logsLogsPath).BodyJSON(h.T)
+	// Only --end is sent; start is left for the server to backfill.
+	h.Require.Equal(float64(end.UnixMilli()), req["end_epoch_millis"])
+	h.Require.Nil(req["start_epoch_millis"])
 }
 
 func Test_Model_Deployment_Logs_TailTerminatesOnStopStatus(t *testing.T) {

--- a/internal/e2e-tests/helpers_test.go
+++ b/internal/e2e-tests/helpers_test.go
@@ -25,9 +25,29 @@ resources:
   use_gpu: false
 `
 
-const trussModelPy = `from fastapi.responses import StreamingResponse
+// Marker tokens emitted by the test model's load() and asserted by the Logs
+// phase. The shared marker scopes queries to our lines; the per-level words
+// drive the min-level / includes / excludes assertions. A fixed marker is
+// safe because we only ever query this deployment's logs.
+const (
+	e2eLogMarker      = "baseten-e2e-log"
+	e2eLogInfoWord    = "apple"
+	e2eLogWarningWord = "banana"
+	e2eLogErrorWord   = "cherry"
+)
+
+const trussModelPy = `import logging
+
+from fastapi.responses import StreamingResponse
+
+_logger = logging.getLogger(__name__)
 
 class Model:
+    def load(self):
+        _logger.info("baseten-e2e-log info apple")
+        _logger.warning("baseten-e2e-log warning banana")
+        _logger.error("baseten-e2e-log error cherry")
+
     def predict(self, request):
         if request.get("style") == "streaming":
             chunks = request.get("chunks", ["alpha", "beta", "gamma"])

--- a/internal/e2e-tests/model_test.go
+++ b/internal/e2e-tests/model_test.go
@@ -27,6 +27,7 @@ func TestE2EModelLifecycle(t *testing.T) {
 	t.Run("APIInference", l.APIInference)
 	t.Run("Model", l.Model)
 	t.Run("Deployment", l.Deployment)
+	t.Run("Logs", l.Logs)
 	t.Run("Environment", l.Environment)
 	t.Run("ModelPredict", l.ModelPredict)
 	t.Run("Redeploy", l.Redeploy)
@@ -254,6 +255,99 @@ func (l *lifecycle) Deployment(t *testing.T) {
 		st, err := os.Stat(outFile)
 		require.NoError(t, err)
 		require.Greater(t, st.Size(), int64(0), "downloaded tar should be non-empty")
+	})
+}
+
+// logLine is the subset of a log record the Logs phase asserts on.
+type logLine struct {
+	Message string `json:"message"`
+	Level   string `json:"level"`
+}
+
+// collectLogs runs `model deployment logs --output jsonl` over the last hour
+// with the given extra filter args and parses each line. CLI errors are
+// returned (not fatal) so callers can retry while logs propagate.
+func (l *lifecycle) collectLogs(t *testing.T, extraArgs ...string) ([]logLine, error) {
+	t.Helper()
+	args := append([]string{"model", "deployment", "logs",
+		"--model-id", l.modelID, "--deployment-id", l.initialDeploymentID,
+		"--since", "1h", "--output", "jsonl"}, extraArgs...)
+	out, _, err := cli(t, args...)
+	if err != nil {
+		return nil, err
+	}
+	var lines []logLine
+	for _, raw := range strings.Split(strings.TrimSpace(out), "\n") {
+		if raw == "" {
+			continue
+		}
+		var ll logLine
+		require.NoError(t, json.Unmarshal([]byte(raw), &ll))
+		lines = append(lines, ll)
+	}
+	return lines, nil
+}
+
+func (l *lifecycle) Logs(t *testing.T) {
+	contains := func(lines []logLine, word string) bool {
+		for _, ll := range lines {
+			if strings.Contains(ll.Message, word) {
+				return true
+			}
+		}
+		return false
+	}
+	mustCollect := func(t *testing.T, extraArgs ...string) []logLine {
+		lines, err := l.collectLogs(t, extraArgs...)
+		require.NoError(t, err)
+		return lines
+	}
+
+	// Loki can lag a few seconds after the deployment goes ACTIVE; poll until
+	// the info marker lands.
+	var lines []logLine
+	require.Eventually(t, func() bool {
+		got, err := l.collectLogs(t)
+		if err != nil {
+			return false
+		}
+		lines = got
+		return contains(lines, e2eLogInfoWord)
+	}, 10*time.Second, time.Second, "info log line never appeared")
+
+	t.Run("AllLevels", func(t *testing.T) {
+		require.True(t, contains(lines, e2eLogInfoWord), "info line missing")
+		require.True(t, contains(lines, e2eLogWarningWord), "warning line missing")
+		require.True(t, contains(lines, e2eLogErrorWord), "error line missing")
+	})
+
+	t.Run("MinLevelWarning", func(t *testing.T) {
+		lines := mustCollect(t, "--min-level", "warning")
+		require.False(t, contains(lines, e2eLogInfoWord), "info should be filtered out")
+		require.True(t, contains(lines, e2eLogWarningWord))
+		require.True(t, contains(lines, e2eLogErrorWord))
+	})
+
+	t.Run("MinLevelError", func(t *testing.T) {
+		lines := mustCollect(t, "--min-level", "error")
+		require.False(t, contains(lines, e2eLogInfoWord))
+		require.False(t, contains(lines, e2eLogWarningWord))
+		require.True(t, contains(lines, e2eLogErrorWord))
+	})
+
+	t.Run("Includes", func(t *testing.T) {
+		lines := mustCollect(t, "--includes", e2eLogWarningWord)
+		require.NotEmpty(t, lines)
+		for _, ll := range lines {
+			require.Contains(t, ll.Message, e2eLogWarningWord)
+		}
+	})
+
+	t.Run("Excludes", func(t *testing.T) {
+		lines := mustCollect(t, "--includes", e2eLogMarker, "--excludes", e2eLogWarningWord)
+		require.True(t, contains(lines, e2eLogInfoWord))
+		require.True(t, contains(lines, e2eLogErrorWord))
+		require.False(t, contains(lines, e2eLogWarningWord))
 	})
 }
 


### PR DESCRIPTION
## :rocket: What

Adds log filter flags to `baseten model deployment logs`, matching the filters `truss model-logs` exposes in https://github.com/basetenlabs/truss/pull/2497:

- `--min-level` (`debug`/`info`/`warning`/`error`)
- `--includes` / `--excludes` (repeatable, case-sensitive substrings)
- `--search-pattern` (RE2 regex)
- `--replica`, `--request-id`

Also:
- Changes `--start`/`--end` defaulting to defer to the server: only the given bound is sent and the server backfills the other (a missing end becomes now, a missing start becomes 30m before the end), so the effective default is `--since 30m`. Previously a lone `--end` was paired with a client-side 7-day look-back.
- `--tail` now rejects all filter flags (it can't pass them through).
- Bumps `baseten-go` to `v0.1.0` for the filter fields on `GetDeploymentLogsRequest`.

## :computer: How

- Filter flags are wired onto `managementapi.GetDeploymentLogsRequest`; `--min-level` is uppercased before sending. Unset filters are omitted from the request.
- The window is still validated client-side (start before end, 7 days or less) only when both bounds are given; otherwise the server enforces it.
- The `baseten-go` bump changed `GetModelsDeploymentsConfig` to take a params arg; passing an empty struct preserves the prior behavior (`output_format` defaults to `both` server-side).

## :microscope: Testing

- Unit tests for filter pass-through, `--min-level` uppercasing, invalid-level rejection, `--tail` plus filter rejection, and the new one-sided time-range defaulting.
- Extended the e2e lifecycle with a `Logs` phase: the test model emits info/warning/error lines from `load()`, and the test asserts retrieval plus `--min-level`, `--includes`, and `--excludes` filtering against a real deployment.