### PR TITLE
Replace host/label auth model with named profiles

### DIFF
--- a/cmd/command.auth.go
+++ b/cmd/command.auth.go
@@ -10,74 +10,81 @@ var commandAuth = Command{
 		{
 			Name:    "login",
 			Summary: "Authenticate with Baseten",
-			Description: "Log in to Baseten via browser (OAuth device flow) or API key.\n\n" +
+			Description: "Log in to Baseten via browser (OAuth device flow) or API key, storing a " +
+				"named profile.\n\n" +
 				"By default, opens a browser for interactive login. Use --web to skip prompts " +
 				"(suitable for non-TTY environments). Use --with-api-key to provide an API key " +
-				"(reads from stdin, or prompts interactively if TTY).",
+				"(reads from stdin, or prompts interactively if TTY).\n\n" +
+				"Browser logins name the profile after your email; API key logins require an " +
+				"explicit --profile name. The new profile becomes current unless --no-switch is given.",
 			Flags: AuthLoginFlags{},
 			Output: &CommandOutput[AuthLoginResult]{
-				TextDescription: "Prints \"Logged in as <email> (<workspace>)\" to stdout on success.",
+				TextDescription: "Prints \"Logged in as <email> (<workspace>) as profile <profile>\" to stdout on success.",
 				Examples: []CommandExample{
 					{
 						Description: "Browser-based login (OAuth device flow).",
 						Command:     "baseten auth login --web",
 					},
 					{
-						Description: "Provide an API key on stdin.",
-						Command:     "echo $API_KEY | baseten auth login --with-api-key --label <label>",
+						Description: "Provide an API key on stdin under a named profile.",
+						Command:     "echo $API_KEY | baseten auth login --with-api-key --profile <profile>",
 					},
 				},
 				JQExample: CommandExample{
-					Description: "Print just the logged-in user's email.",
-					Command:     "baseten auth login --web --jq '.email'",
+					Description: "Print just the new profile name.",
+					Command:     "baseten auth login --web --jq '.profile'",
 				},
 			},
 		},
 		{
 			Name:        "logout",
-			Summary:     "Remove stored credentials",
-			Description: "Remove stored credentials for the active user. For OAuth credentials, also revokes the session.",
+			Summary:     "Remove a stored profile",
+			Description: "Remove a stored profile and its credentials. Defaults to the current profile; pass --profile to choose another. For OAuth credentials, also revokes the session.",
 			Flags:       AuthLogoutFlags{},
 			Output: &CommandOutput[AuthLogoutResult]{
-				TextDescription: "Prints \"Logged out <user>\" to stdout on success.",
+				TextDescription: "Prints \"Logged out <profile>\" to stdout on success.",
 				Examples: []CommandExample{
 					{
-						Description: "Log out the active user.",
+						Description: "Log out the current profile.",
 						Command:     "baseten auth logout",
+					},
+					{
+						Description: "Log out a specific profile.",
+						Command:     "baseten auth logout --profile <profile>",
 					},
 				},
 				JQExample: CommandExample{
-					Description: "Print just the logged-out user label.",
-					Command:     "baseten auth logout --jq '.user'",
+					Description: "Print just the logged-out profile name.",
+					Command:     "baseten auth logout --jq '.profile'",
 				},
 			},
 		},
 		{
 			Name:        "switch",
-			Summary:     "Switch active account",
-			Description: "Switch the active account for the current host.",
+			Summary:     "Switch the current profile",
+			Description: "Set the current profile used when no profile is selected via --profile or BASETEN_PROFILE.",
 			Flags:       AuthSwitchFlags{},
 			Output: &CommandOutput[AuthSwitchResult]{
-				TextDescription: "Prints \"Switched to <user>\" to stdout on success.",
+				TextDescription: "Prints \"Switched to <profile>\" to stdout on success.",
 				Examples: []CommandExample{
 					{
-						Description: "Switch to a specific account non-interactively.",
-						Command:     "baseten auth switch --user <user>",
+						Description: "Switch to a specific profile non-interactively.",
+						Command:     "baseten auth switch --profile <profile>",
 					},
 				},
 				JQExample: CommandExample{
-					Description: "Print just the newly active user.",
-					Command:     "baseten auth switch --user <user> --jq '.user'",
+					Description: "Print just the new current profile.",
+					Command:     "baseten auth switch --profile <profile> --jq '.profile'",
 				},
 			},
 		},
 		{
 			Name:        "status",
 			Summary:     "Show authentication status",
-			Description: "Show the current authentication state, including the active user and auth type.",
+			Description: "Show the resolved authentication state, including the profile, remote, and auth type.",
 			Flags:       AuthStatusFlags{},
 			Output: &CommandOutput[AuthStatusResult]{
-				TextDescription: "Three-line summary: host URL, \"Logged in as <user>\", \"Auth type: <type>\".",
+				TextDescription: "Summary of the resolved profile: profile name, remote URL, and auth type.",
 				Examples: []CommandExample{
 					{
 						Description: "Show the current auth status.",
@@ -95,6 +102,7 @@ var commandAuth = Command{
 
 // AuthLoginResult is the JSON output of `baseten auth login`.
 type AuthLoginResult struct {
+	Profile       string `json:"profile"`
 	UserID        string `json:"user_id"`
 	Email         string `json:"email"`
 	Name          string `json:"name"`
@@ -103,19 +111,19 @@ type AuthLoginResult struct {
 
 // AuthLogoutResult is the JSON output of `baseten auth logout`.
 type AuthLogoutResult struct {
-	User string `json:"user"`
+	Profile string `json:"profile"`
 }
 
 // AuthSwitchResult is the JSON output of `baseten auth switch`.
 type AuthSwitchResult struct {
-	User string `json:"user"`
+	Profile string `json:"profile"`
 }
 
 // AuthStatusResult is the JSON output of `baseten auth status`.
 type AuthStatusResult struct {
-	Host     string `json:"host"`
-	User     string `json:"user"`
-	AuthType string `json:"auth_type"`
+	Profile   string `json:"profile"`
+	RemoteURL string `json:"remote_url"`
+	AuthType  string `json:"auth_type"`
 }
 
 // AuthLoginFlags are the flags for baseten auth login.
@@ -123,7 +131,8 @@ type AuthLoginFlags struct {
 	CommandFlags
 	Web             bool   `flag:"web" desc:"Use browser login without interactive prompts"`
 	WithAPIKey      bool   `flag:"with-api-key" desc:"Read API key from stdin"`
-	Label           string `flag:"label" desc:"Label for the API key credential"`
+	RemoteURL       string `flag:"remote-url" desc:"Baseten remote URL for this profile (default https://app.baseten.co)"`
+	NoSwitch        bool   `flag:"no-switch" desc:"Store the profile without making it the current profile"`
 	InsecureStorage bool   `flag:"insecure-storage" desc:"Store credentials in plain text instead of system keyring"`
 }
 
@@ -135,7 +144,6 @@ type AuthLogoutFlags struct {
 // AuthSwitchFlags are the flags for baseten auth switch.
 type AuthSwitchFlags struct {
 	CommandFlags
-	User string `flag:"user" desc:"User to switch to"`
 }
 
 // AuthStatusFlags are the flags for baseten auth status.

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -43,10 +43,10 @@ var Root = Command{
 // CommandFlags are shared flags that every command must embed, either directly
 // or via another struct that embeds it.
 type CommandFlags struct {
-	Verbose   bool   `flag:"verbose" short:"v" desc:"Enable verbose logging" group:"common" group-pri:"500"`
-	Output    string `flag:"output" short:"o" desc:"Output format" default:"text" enum:"text,json,jsonl,none" group:"common"`
-	JQ        string `flag:"jq" short:"q" desc:"Filter JSON output with a jq expression; implies --output json (or jsonl for streamed commands)" group:"common"`
-	RemoteURL string `flag:"remote-url" desc:"Baseten remote URL, overrides BASETEN_REMOTE_URL (default https://app.baseten.co)" group:"common"`
+	Verbose bool   `flag:"verbose" short:"v" desc:"Enable verbose logging" group:"common" group-pri:"500"`
+	Output  string `flag:"output" short:"o" desc:"Output format" default:"text" enum:"text,json,jsonl,none" group:"common"`
+	JQ      string `flag:"jq" short:"q" desc:"Filter JSON output with a jq expression; implies --output json (or jsonl for streamed commands)" group:"common"`
+	Profile string `flag:"profile" desc:"Use a specific stored profile for this command, overriding BASETEN_PROFILE and the current profile" group:"common"`
 }
 
 // Command defines a CLI command declaratively. The tree structure is built

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -12,6 +13,10 @@ import (
 )
 
 const authFileName = "auth.json"
+
+// keyringServiceName namespaces CLI profile secrets in the system keyring,
+// keyed by profile name.
+const keyringServiceName = "baseten-profile"
 
 // AuthType identifies how a credential was obtained.
 type AuthType string
@@ -31,26 +36,27 @@ type OAuthCredential struct {
 	Expiry       time.Time `json:"expiry,omitempty"`
 }
 
-// UserEntry is a single stored credential in auth.json.
-type UserEntry struct {
-	AuthType AuthType `json:"auth_type"`
+// Profile is a single named, self-contained credential: a remote URL plus the
+// auth used against it. The profile name is the keyring account and the
+// auth.json map key.
+type Profile struct {
+	RemoteURL string   `json:"remote_url"`
+	AuthType  AuthType `json:"auth_type"`
 
-	// InsecureOAuthCredential and InsecureAPIKey are only populated when
-	// the keyring is unavailable or --insecure-storage was used.
+	// InsecureOAuthCredential and InsecureAPIKey are only populated when the
+	// keyring is unavailable or --insecure-storage was used.
 	InsecureOAuthCredential *OAuthCredential `json:"oauth_credential,omitempty"`
 	InsecureAPIKey          string           `json:"api_key,omitempty"`
 }
 
-// HostEntry holds all users for a single host.
-type HostEntry struct {
-	ActiveUser string               `json:"active_user"`
-	Users      map[string]UserEntry `json:"users"`
-}
-
-// AuthFile is the on-disk auth.json structure.
+// AuthFile is the on-disk auth.json structure. Unrecognized keys are ignored
+// on read and dropped on the next write.
 type AuthFile struct {
-	Version int                  `json:"version"`
-	Hosts   map[string]HostEntry `json:"hosts"`
+	Version int `json:"version"`
+	// Current is the name of the profile used when no profile is selected via
+	// flag or environment.
+	Current  string             `json:"current,omitempty"`
+	Profiles map[string]Profile `json:"profiles"`
 }
 
 // Store manages reading and writing auth.json and keyring secrets.
@@ -92,10 +98,6 @@ func (s *Store) path() string {
 	return filepath.Join(s.dir, authFileName)
 }
 
-func keyringService(host string) string {
-	return "baseten:" + host
-}
-
 // Load reads auth.json from disk. Returns an empty AuthFile if it does not
 // exist.
 func (s *Store) Load() (*AuthFile, error) {
@@ -107,7 +109,7 @@ func (s *Store) Load() (*AuthFile, error) {
 func (s *Store) loadLocked() (*AuthFile, error) {
 	data, err := os.ReadFile(s.path())
 	if os.IsNotExist(err) {
-		return &AuthFile{Version: 1, Hosts: map[string]HostEntry{}}, nil
+		return &AuthFile{Version: 1, Profiles: map[string]Profile{}}, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", s.path(), err)
@@ -116,23 +118,17 @@ func (s *Store) loadLocked() (*AuthFile, error) {
 	if err := json.Unmarshal(data, &af); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", s.path(), err)
 	}
-	if af.Hosts == nil {
-		af.Hosts = map[string]HostEntry{}
+	if af.Profiles == nil {
+		af.Profiles = map[string]Profile{}
 	}
 	return &af, nil
-}
-
-// Save writes auth.json to disk, creating the directory if needed.
-func (s *Store) Save(af *AuthFile) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.saveLocked(af)
 }
 
 func (s *Store) saveLocked(af *AuthFile) error {
 	if err := os.MkdirAll(s.dir, 0o700); err != nil {
 		return fmt.Errorf("creating config directory: %w", err)
 	}
+	af.Version = 1
 	data, err := json.MarshalIndent(af, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling auth file: %w", err)
@@ -144,10 +140,11 @@ func (s *Store) saveLocked(af *AuthFile) error {
 	return nil
 }
 
-// SetOAuthUser stores an OAuth credential for a user and sets them as active.
-// Tries the keyring first; falls back to plaintext in auth.json with a
-// warning written to warnWriter (if non-nil).
-func (s *Store) SetOAuthUser(host, label string, cred OAuthCredential, warnWriter func(string)) error {
+// SetOAuthProfile stores an OAuth credential under name. When switchCurrent is
+// true, the profile also becomes the current profile. Tries the keyring first;
+// falls back to plaintext in auth.json with a warning written to warnWriter
+// (if non-nil).
+func (s *Store) SetOAuthProfile(profileName, remoteURL string, cred OAuthCredential, switchCurrent bool, warnWriter func(string)) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -156,33 +153,32 @@ func (s *Store) SetOAuthUser(host, label string, cred OAuthCredential, warnWrite
 		return err
 	}
 
-	he := s.getOrCreateHost(af, host)
-	entry := UserEntry{AuthType: AuthTypeOAuth}
-
+	profile := Profile{RemoteURL: remoteURL, AuthType: AuthTypeOAuth}
 	if !s.insecureStorage {
 		secretJSON, err := json.Marshal(cred)
 		if err != nil {
 			return fmt.Errorf("marshaling credential: %w", err)
 		}
-		if err := keyring.Set(keyringService(host), label, string(secretJSON)); err != nil {
+		if err := keyring.Set(keyringServiceName, profileName, string(secretJSON)); err != nil {
 			if warnWriter != nil {
 				warnWriter("warning: could not store credentials in system keyring, storing in plain text\n")
 			}
-			entry.InsecureOAuthCredential = &cred
+			profile.InsecureOAuthCredential = &cred
 		}
 	} else {
-		entry.InsecureOAuthCredential = &cred
+		profile.InsecureOAuthCredential = &cred
 	}
 
-	he.Users[label] = entry
-	he.ActiveUser = label
-	af.Hosts[host] = he
+	af.Profiles[profileName] = profile
+	if switchCurrent {
+		af.Current = profileName
+	}
 	return s.saveLocked(af)
 }
 
-// SetAPIKeyUser stores an API key credential for a user and sets them as
-// active.
-func (s *Store) SetAPIKeyUser(host, label, apiKey string, warnWriter func(string)) error {
+// SetAPIKeyProfile stores an API key credential under name. When switchCurrent
+// is true, the profile also becomes the current profile.
+func (s *Store) SetAPIKeyProfile(profileName, remoteURL, apiKey string, switchCurrent bool, warnWriter func(string)) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -191,30 +187,29 @@ func (s *Store) SetAPIKeyUser(host, label, apiKey string, warnWriter func(string
 		return err
 	}
 
-	he := s.getOrCreateHost(af, host)
-	entry := UserEntry{AuthType: AuthTypeAPIKey}
-
+	profile := Profile{RemoteURL: remoteURL, AuthType: AuthTypeAPIKey}
 	if !s.insecureStorage {
-		if err := keyring.Set(keyringService(host), label, apiKey); err != nil {
+		if err := keyring.Set(keyringServiceName, profileName, apiKey); err != nil {
 			if warnWriter != nil {
 				warnWriter("warning: could not store credentials in system keyring, storing in plain text\n")
 			}
-			entry.InsecureAPIKey = apiKey
+			profile.InsecureAPIKey = apiKey
 		}
 	} else {
-		entry.InsecureAPIKey = apiKey
+		profile.InsecureAPIKey = apiKey
 	}
 
-	he.Users[label] = entry
-	he.ActiveUser = label
-	af.Hosts[host] = he
+	af.Profiles[profileName] = profile
+	if switchCurrent {
+		af.Current = profileName
+	}
 	return s.saveLocked(af)
 }
 
-// GetOAuthCredential retrieves the OAuth credential for a user, trying the
+// GetOAuthCredential retrieves the OAuth credential for a profile, trying the
 // keyring first, then falling back to the auth.json plaintext field.
-func (s *Store) GetOAuthCredential(host, label string) (*OAuthCredential, error) {
-	secret, err := keyring.Get(keyringService(host), label)
+func (s *Store) GetOAuthCredential(profileName string) (*OAuthCredential, error) {
+	secret, err := keyring.Get(keyringServiceName, profileName)
 	if err == nil {
 		var cred OAuthCredential
 		if err := json.Unmarshal([]byte(secret), &cred); err != nil {
@@ -227,24 +222,20 @@ func (s *Store) GetOAuthCredential(host, label string) (*OAuthCredential, error)
 	if err != nil {
 		return nil, err
 	}
-	he, ok := af.Hosts[host]
+	profile, ok := af.Profiles[profileName]
 	if !ok {
-		return nil, fmt.Errorf("no credentials for host %s", host)
+		return nil, fmt.Errorf("no profile named %q", profileName)
 	}
-	ue, ok := he.Users[label]
-	if !ok {
-		return nil, fmt.Errorf("no credential for user %q on host %s", label, host)
+	if profile.InsecureOAuthCredential == nil {
+		return nil, fmt.Errorf("no OAuth credential found for profile %q", profileName)
 	}
-	if ue.InsecureOAuthCredential == nil {
-		return nil, fmt.Errorf("no OAuth credential found for user %q on host %s", label, host)
-	}
-	return ue.InsecureOAuthCredential, nil
+	return profile.InsecureOAuthCredential, nil
 }
 
-// GetAPIKey retrieves the API key for a user, trying the keyring first, then
+// GetAPIKey retrieves the API key for a profile, trying the keyring first, then
 // falling back to the auth.json plaintext field.
-func (s *Store) GetAPIKey(host, label string) (string, error) {
-	secret, err := keyring.Get(keyringService(host), label)
+func (s *Store) GetAPIKey(profileName string) (string, error) {
+	secret, err := keyring.Get(keyringServiceName, profileName)
 	if err == nil {
 		return secret, nil
 	}
@@ -253,48 +244,38 @@ func (s *Store) GetAPIKey(host, label string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	he, ok := af.Hosts[host]
+	profile, ok := af.Profiles[profileName]
 	if !ok {
-		return "", fmt.Errorf("no credentials for host %s", host)
+		return "", fmt.Errorf("no profile named %q", profileName)
 	}
-	ue, ok := he.Users[label]
-	if !ok {
-		return "", fmt.Errorf("no credential for user %q on host %s", label, host)
+	if profile.InsecureAPIKey == "" {
+		return "", fmt.Errorf("no API key found for profile %q", profileName)
 	}
-	if ue.InsecureAPIKey == "" {
-		return "", fmt.Errorf("no API key found for user %q on host %s", label, host)
-	}
-	return ue.InsecureAPIKey, nil
+	return profile.InsecureAPIKey, nil
 }
 
-// RemoveUser removes a user from a host and deletes their keyring entry. If
-// the removed user was active, active_user is cleared.
-func (s *Store) RemoveUser(host, label string) error {
+// RemoveProfile removes a profile and deletes its keyring entry. If the removed
+// profile was current, the current pointer is cleared.
+func (s *Store) RemoveProfile(profileName string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	_ = keyring.Delete(keyringService(host), label)
+	_ = keyring.Delete(keyringServiceName, profileName)
 
 	af, err := s.loadLocked()
 	if err != nil {
 		return err
 	}
-
-	he, ok := af.Hosts[host]
-	if !ok {
-		return nil
+	delete(af.Profiles, profileName)
+	if af.Current == profileName {
+		af.Current = ""
 	}
-	delete(he.Users, label)
-	if he.ActiveUser == label {
-		he.ActiveUser = ""
-	}
-	af.Hosts[host] = he
 	return s.saveLocked(af)
 }
 
-// SwitchUser sets the active user for a host. Returns an error if the user
-// does not exist.
-func (s *Store) SwitchUser(host, label string) error {
+// SwitchProfile sets the current profile. Returns an error if it does not
+// exist.
+func (s *Store) SwitchProfile(profileName string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -302,43 +283,46 @@ func (s *Store) SwitchUser(host, label string) error {
 	if err != nil {
 		return err
 	}
-
-	he, ok := af.Hosts[host]
-	if !ok {
-		return fmt.Errorf("no credentials stored for host %s", host)
+	if _, ok := af.Profiles[profileName]; !ok {
+		return fmt.Errorf("profile %q not found", profileName)
 	}
-	if _, ok := he.Users[label]; !ok {
-		return fmt.Errorf("user %q not found for host %s", label, host)
-	}
-	he.ActiveUser = label
-	af.Hosts[host] = he
+	af.Current = profileName
 	return s.saveLocked(af)
 }
 
-// ActiveUser returns the active user label and entry for a host.
-func (s *Store) ActiveUser(host string) (label string, entry UserEntry, ok bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	af, err := s.loadLocked()
+// GetProfile returns the profile with the given name.
+func (s *Store) GetProfile(profileName string) (Profile, bool) {
+	af, err := s.Load()
 	if err != nil {
-		return "", UserEntry{}, false
+		return Profile{}, false
 	}
-	he, exists := af.Hosts[host]
-	if !exists || he.ActiveUser == "" {
-		return "", UserEntry{}, false
-	}
-	ue, exists := he.Users[he.ActiveUser]
-	if !exists {
-		return "", UserEntry{}, false
-	}
-	return he.ActiveUser, ue, true
+	profile, ok := af.Profiles[profileName]
+	return profile, ok
 }
 
-func (s *Store) getOrCreateHost(af *AuthFile, host string) HostEntry {
-	he, ok := af.Hosts[host]
-	if !ok {
-		he = HostEntry{Users: map[string]UserEntry{}}
+// CurrentProfile returns the current profile name and entry.
+func (s *Store) CurrentProfile() (name string, profile Profile, ok bool) {
+	af, err := s.Load()
+	if err != nil || af.Current == "" {
+		return "", Profile{}, false
 	}
-	return he
+	profile, ok = af.Profiles[af.Current]
+	if !ok {
+		return "", Profile{}, false
+	}
+	return af.Current, profile, true
+}
+
+// ProfileNames returns the stored profile names in sorted order.
+func (s *Store) ProfileNames() ([]string, error) {
+	af, err := s.Load()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(af.Profiles))
+	for name := range af.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
 }

--- a/internal/auth/store_test.go
+++ b/internal/auth/store_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 const (
-	testHost     = "https://api.example.com"
-	otherHost    = "https://api.other.example.com"
-	userLabelA   = "alice@example.com"
-	userLabelB   = "bob@example.com"
+	remoteURL    = "https://app.example.com"
+	otherRemote  = "https://app.other.example.com"
+	profileA     = "alice@example.com"
+	profileB     = "bob@example.com"
 	apiKeyA      = "api-key-alice"
 	accessToken  = "access-token-xyz"
 	refreshToken = "refresh-token-xyz"
@@ -35,159 +35,193 @@ func newInsecureStore(t *testing.T) *auth.Store {
 	return auth.NewStore(auth.StoreOptions{Dir: t.TempDir(), InsecureStorage: true})
 }
 
-func TestStore_EmptyNoActiveUser(t *testing.T) {
+func TestStore_EmptyNoCurrentProfile(t *testing.T) {
 	s := newKeyringStore(t)
-	label, _, ok := s.ActiveUser(testHost)
+	name, _, ok := s.CurrentProfile()
 	require.False(t, ok)
-	require.Empty(t, label)
+	require.Empty(t, name)
 }
 
-func TestStore_SetAPIKeyUser_Keyring(t *testing.T) {
+func TestStore_SetAPIKeyProfile_Keyring(t *testing.T) {
 	s := newKeyringStore(t)
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelA, apiKeyA, nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
 
-	label, entry, ok := s.ActiveUser(testHost)
+	name, profile, ok := s.CurrentProfile()
 	require.True(t, ok)
-	require.Equal(t, userLabelA, label)
-	require.Equal(t, auth.AuthTypeAPIKey, entry.AuthType)
-	require.Empty(t, entry.InsecureAPIKey, "keyring-stored key must not leak to auth.json")
+	require.Equal(t, profileA, name)
+	require.Equal(t, remoteURL, profile.RemoteURL)
+	require.Equal(t, auth.AuthTypeAPIKey, profile.AuthType)
+	require.Empty(t, profile.InsecureAPIKey, "keyring-stored key must not leak to auth.json")
 
-	got, err := s.GetAPIKey(testHost, userLabelA)
+	got, err := s.GetAPIKey(profileA)
 	require.NoError(t, err)
 	require.Equal(t, apiKeyA, got)
 }
 
-func TestStore_SetAPIKeyUser_Insecure(t *testing.T) {
+func TestStore_SetAPIKeyProfile_Insecure(t *testing.T) {
 	s := newInsecureStore(t)
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelA, apiKeyA, nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
 
-	_, entry, ok := s.ActiveUser(testHost)
+	_, profile, ok := s.CurrentProfile()
 	require.True(t, ok)
-	require.Equal(t, apiKeyA, entry.InsecureAPIKey)
+	require.Equal(t, apiKeyA, profile.InsecureAPIKey)
 
-	got, err := s.GetAPIKey(testHost, userLabelA)
+	got, err := s.GetAPIKey(profileA)
 	require.NoError(t, err)
 	require.Equal(t, apiKeyA, got)
 }
 
-func TestStore_SetOAuthUser_Keyring(t *testing.T) {
+func TestStore_SetOAuthProfile_Keyring(t *testing.T) {
 	s := newKeyringStore(t)
 	cred := auth.OAuthCredential{AccessToken: accessToken, RefreshToken: refreshToken}
-	require.NoError(t, s.SetOAuthUser(testHost, userLabelA, cred, nil))
+	require.NoError(t, s.SetOAuthProfile(profileA, remoteURL, cred, true, nil))
 
-	_, entry, ok := s.ActiveUser(testHost)
+	_, profile, ok := s.CurrentProfile()
 	require.True(t, ok)
-	require.Equal(t, auth.AuthTypeOAuth, entry.AuthType)
-	require.Nil(t, entry.InsecureOAuthCredential)
+	require.Equal(t, auth.AuthTypeOAuth, profile.AuthType)
+	require.Nil(t, profile.InsecureOAuthCredential)
 
-	got, err := s.GetOAuthCredential(testHost, userLabelA)
+	got, err := s.GetOAuthCredential(profileA)
 	require.NoError(t, err)
 	require.Equal(t, cred, *got)
 }
 
-func TestStore_SetOAuthUser_Insecure(t *testing.T) {
+func TestStore_SetOAuthProfile_Insecure(t *testing.T) {
 	s := newInsecureStore(t)
 	cred := auth.OAuthCredential{AccessToken: accessToken, RefreshToken: refreshToken}
-	require.NoError(t, s.SetOAuthUser(testHost, userLabelA, cred, nil))
+	require.NoError(t, s.SetOAuthProfile(profileA, remoteURL, cred, true, nil))
 
-	_, entry, ok := s.ActiveUser(testHost)
+	_, profile, ok := s.CurrentProfile()
 	require.True(t, ok)
-	require.NotNil(t, entry.InsecureOAuthCredential)
-	require.Equal(t, cred, *entry.InsecureOAuthCredential)
+	require.NotNil(t, profile.InsecureOAuthCredential)
+	require.Equal(t, cred, *profile.InsecureOAuthCredential)
 }
 
-func TestStore_SwitchUser(t *testing.T) {
+func TestStore_SetProfile_NoSwitchKeepsCurrent(t *testing.T) {
 	s := newKeyringStore(t)
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelA, apiKeyA, nil))
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelB, "key-bob", nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileB, remoteURL, "key-bob", false, nil))
 
-	label, _, _ := s.ActiveUser(testHost)
-	require.Equal(t, userLabelB, label)
-
-	require.NoError(t, s.SwitchUser(testHost, userLabelA))
-	label, _, _ = s.ActiveUser(testHost)
-	require.Equal(t, userLabelA, label)
+	name, _, ok := s.CurrentProfile()
+	require.True(t, ok)
+	require.Equal(t, profileA, name, "switchCurrent=false must not move the current pointer")
 }
 
-func TestStore_SwitchUser_UnknownFails(t *testing.T) {
+func TestStore_SwitchProfile(t *testing.T) {
 	s := newKeyringStore(t)
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelA, apiKeyA, nil))
-	err := s.SwitchUser(testHost, "ghost@example.com")
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileB, remoteURL, "key-bob", true, nil))
+
+	name, _, _ := s.CurrentProfile()
+	require.Equal(t, profileB, name)
+
+	require.NoError(t, s.SwitchProfile(profileA))
+	name, _, _ = s.CurrentProfile()
+	require.Equal(t, profileA, name)
+}
+
+func TestStore_SwitchProfile_UnknownFails(t *testing.T) {
+	s := newKeyringStore(t)
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
+	err := s.SwitchProfile("ghost@example.com")
 	require.ErrorContains(t, err, "not found")
 }
 
-func TestStore_SwitchUser_UnknownHostFails(t *testing.T) {
+func TestStore_RemoveProfile_ClearsCurrent(t *testing.T) {
 	s := newKeyringStore(t)
-	err := s.SwitchUser(testHost, userLabelA)
-	require.ErrorContains(t, err, "no credentials stored")
-}
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
+	require.NoError(t, s.RemoveProfile(profileA))
 
-func TestStore_RemoveUser_ClearsActive(t *testing.T) {
-	s := newKeyringStore(t)
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelA, apiKeyA, nil))
-	require.NoError(t, s.RemoveUser(testHost, userLabelA))
-
-	_, _, ok := s.ActiveUser(testHost)
+	_, _, ok := s.CurrentProfile()
 	require.False(t, ok)
 
-	_, err := s.GetAPIKey(testHost, userLabelA)
+	_, err := s.GetAPIKey(profileA)
 	require.Error(t, err, "keyring and file entry must both be gone")
 }
 
-func TestStore_RemoveUser_OnlyActiveIsCleared(t *testing.T) {
+func TestStore_RemoveProfile_OnlyCurrentIsCleared(t *testing.T) {
 	s := newKeyringStore(t)
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelA, apiKeyA, nil))
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelB, "key-bob", nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileB, remoteURL, "key-bob", true, nil))
 
-	require.NoError(t, s.RemoveUser(testHost, userLabelA))
+	require.NoError(t, s.RemoveProfile(profileA))
 
-	label, _, ok := s.ActiveUser(testHost)
+	name, _, ok := s.CurrentProfile()
 	require.True(t, ok)
-	require.Equal(t, userLabelB, label)
+	require.Equal(t, profileB, name)
 }
 
-func TestStore_RemoveUser_MissingHostNoError(t *testing.T) {
+func TestStore_RemoveProfile_MissingNoError(t *testing.T) {
 	s := newKeyringStore(t)
-	require.NoError(t, s.RemoveUser(testHost, userLabelA))
+	require.NoError(t, s.RemoveProfile(profileA))
 }
 
-func TestStore_HostIsolation(t *testing.T) {
+func TestStore_ProfileIsolation(t *testing.T) {
 	s := newKeyringStore(t)
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelA, apiKeyA, nil))
-	require.NoError(t, s.SetAPIKeyUser(otherHost, userLabelA, "key-other", nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileB, otherRemote, "key-other", true, nil))
 
-	got, err := s.GetAPIKey(testHost, userLabelA)
+	got, err := s.GetAPIKey(profileA)
 	require.NoError(t, err)
 	require.Equal(t, apiKeyA, got)
 
-	got, err = s.GetAPIKey(otherHost, userLabelA)
+	got, err = s.GetAPIKey(profileB)
 	require.NoError(t, err)
 	require.Equal(t, "key-other", got)
+}
+
+func TestStore_ProfileNames(t *testing.T) {
+	s := newKeyringStore(t)
+	require.NoError(t, s.SetAPIKeyProfile(profileB, remoteURL, "key-bob", true, nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
+
+	names, err := s.ProfileNames()
+	require.NoError(t, err)
+	require.Equal(t, []string{profileA, profileB}, names)
 }
 
 func TestStore_SaveLoadRoundtrip(t *testing.T) {
 	dir := t.TempDir()
 	keyring.MockInit()
 	s := auth.NewStore(auth.StoreOptions{Dir: dir, InsecureStorage: true})
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelA, apiKeyA, nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
 
 	s2 := auth.NewStore(auth.StoreOptions{Dir: dir, InsecureStorage: true})
-	label, _, ok := s2.ActiveUser(testHost)
+	name, _, ok := s2.CurrentProfile()
 	require.True(t, ok)
-	require.Equal(t, userLabelA, label)
+	require.Equal(t, profileA, name)
 }
 
 func TestStore_AuthFileFormat(t *testing.T) {
 	dir := t.TempDir()
 	keyring.MockInit()
 	s := auth.NewStore(auth.StoreOptions{Dir: dir, InsecureStorage: true})
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelA, apiKeyA, nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
 
 	data, err := os.ReadFile(filepath.Join(dir, "auth.json"))
 	require.NoError(t, err)
 	var af auth.AuthFile
 	require.NoError(t, json.Unmarshal(data, &af))
 	require.Equal(t, 1, af.Version)
-	require.Contains(t, af.Hosts, testHost)
-	require.Equal(t, userLabelA, af.Hosts[testHost].ActiveUser)
+	require.Equal(t, profileA, af.Current)
+	require.Contains(t, af.Profiles, profileA)
+	require.Equal(t, remoteURL, af.Profiles[profileA].RemoteURL)
+}
+
+// TestStore_IgnoresUnknownKeys confirms an auth.json carrying keys from an
+// earlier layout loads without error and those keys are dropped on save.
+func TestStore_IgnoresUnknownKeys(t *testing.T) {
+	dir := t.TempDir()
+	keyring.MockInit()
+	legacy := `{"version":1,"hosts":{"https://app.example.com":{"active_user":"x","users":{}}}}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "auth.json"), []byte(legacy), 0o600))
+
+	s := auth.NewStore(auth.StoreOptions{Dir: dir, InsecureStorage: true})
+	_, _, ok := s.CurrentProfile()
+	require.False(t, ok)
+
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
+	data, err := os.ReadFile(filepath.Join(dir, "auth.json"))
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "hosts")
 }

--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -4,10 +4,81 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/basetenlabs/baseten-go/client"
 	"golang.org/x/oauth2"
 )
+
+// Session is the auth context resolved once per invocation. Exactly one of the
+// credential paths applies: a stored profile (ProfileName set) or ephemeral env
+// credentials (ephemeralAPIKey set).
+type Session struct {
+	store           *Store
+	profileName     string
+	ephemeralAPIKey string
+	remoteURL       string
+}
+
+// ResolveSession determines the effective auth for this invocation, most
+// specific source first:
+//
+//  1. profileFlag (the --profile flag)
+//  2. BASETEN_API_KEY (+ optional BASETEN_REMOTE_URL), ephemeral
+//  3. BASETEN_PROFILE
+//  4. the current profile in auth.json
+//
+// A named profile that does not exist is not an error here; the failure
+// surfaces when a credential is actually needed (or in the auth commands that
+// manage profiles directly).
+func ResolveSession(profileFlag string) (*Session, error) {
+	dir, err := DefaultConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	store := NewStore(StoreOptions{Dir: dir})
+	s := &Session{store: store}
+
+	if profileFlag != "" {
+		s.profileName = profileFlag
+		if p, ok := store.GetProfile(profileFlag); ok {
+			s.remoteURL = p.RemoteURL
+		}
+		return s, nil
+	}
+
+	if key := os.Getenv("BASETEN_API_KEY"); key != "" {
+		s.ephemeralAPIKey = key
+		s.remoteURL = os.Getenv("BASETEN_REMOTE_URL")
+		return s, nil
+	}
+
+	if envProfile := os.Getenv("BASETEN_PROFILE"); envProfile != "" {
+		s.profileName = envProfile
+		if p, ok := store.GetProfile(envProfile); ok {
+			s.remoteURL = p.RemoteURL
+		}
+		return s, nil
+	}
+
+	if name, p, ok := store.CurrentProfile(); ok {
+		s.profileName = name
+		s.remoteURL = p.RemoteURL
+	}
+	return s, nil
+}
+
+// RemoteURL is the remote the resolved session targets. It may be empty, in
+// which case the caller applies its own default.
+func (s *Session) RemoteURL() string { return s.remoteURL }
+
+// ProfileName is the stored profile this session uses, or "" when the session
+// is ephemeral or unauthenticated.
+func (s *Session) ProfileName() string { return s.profileName }
+
+// IsEphemeral reports whether the session uses credentials from BASETEN_API_KEY
+// rather than a stored profile.
+func (s *Session) IsEphemeral() bool { return s.ephemeralAPIKey != "" }
 
 // OAuthContext returns a context that carries an oauth2 HTTP client which
 // stamps the Baseten User-Agent on every request, layered over base.
@@ -28,20 +99,16 @@ func (r userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 }
 
 // Transport is an HTTP client that injects the appropriate Authorization
-// header based on the active credential. For OAuth credentials, it uses
+// header for the resolved session. For OAuth credentials, it uses
 // oauth2.TokenSource for transparent token refresh.
 //
 // It implements the Do(*http.Request) (*http.Response, error) interface
 // expected by the baseten-go SDK clients.
 type Transport struct {
-	Store *Store
-	Host  string
+	Session *Session
 
 	// OAuthConfig is the OAuth2 configuration used for token refresh.
 	OAuthConfig *oauth2.Config
-
-	// EnvAPIKey, if set, takes priority over all stored credentials.
-	EnvAPIKey string
 
 	Base http.RoundTripper
 }
@@ -54,20 +121,25 @@ func (t *Transport) base() http.RoundTripper {
 }
 
 func (t *Transport) Do(req *http.Request) (*http.Response, error) {
-	if t.EnvAPIKey != "" {
+	if t.Session.ephemeralAPIKey != "" {
 		req = req.Clone(req.Context())
-		req.Header.Set("Authorization", "Api-Key "+t.EnvAPIKey)
+		req.Header.Set("Authorization", "Api-Key "+t.Session.ephemeralAPIKey)
 		return t.base().RoundTrip(req)
 	}
 
-	label, entry, ok := t.Store.ActiveUser(t.Host)
-	if !ok {
+	if t.Session.profileName == "" {
 		return nil, fmt.Errorf("not logged in; run `baseten auth login` or set BASETEN_API_KEY")
 	}
 
-	switch entry.AuthType {
+	profileName := t.Session.profileName
+	profile, ok := t.Session.store.GetProfile(profileName)
+	if !ok {
+		return nil, fmt.Errorf("profile %q not found; run `baseten auth login`", profileName)
+	}
+
+	switch profile.AuthType {
 	case AuthTypeAPIKey:
-		apiKey, err := t.Store.GetAPIKey(t.Host, label)
+		apiKey, err := t.Session.store.GetAPIKey(profileName)
 		if err != nil {
 			return nil, err
 		}
@@ -79,7 +151,7 @@ func (t *Transport) Do(req *http.Request) (*http.Response, error) {
 		if t.OAuthConfig == nil {
 			return nil, fmt.Errorf("OAuth credential requires OAuthConfig to be set on Transport")
 		}
-		cred, err := t.Store.GetOAuthCredential(t.Host, label)
+		cred, err := t.Session.store.GetOAuthCredential(profileName)
 		if err != nil {
 			return nil, err
 		}
@@ -100,7 +172,7 @@ func (t *Transport) Do(req *http.Request) (*http.Response, error) {
 				RefreshToken: newToken.RefreshToken,
 				Expiry:       newToken.Expiry,
 			}
-			if err := t.Store.SetOAuthUser(t.Host, label, updated, nil); err != nil {
+			if err := t.Session.store.SetOAuthProfile(profileName, profile.RemoteURL, updated, false, nil); err != nil {
 				return nil, fmt.Errorf("storing refreshed credential: %w", err)
 			}
 		}
@@ -109,6 +181,6 @@ func (t *Transport) Do(req *http.Request) (*http.Response, error) {
 		return t.base().RoundTrip(req)
 
 	default:
-		return nil, fmt.Errorf("unknown auth type %q", entry.AuthType)
+		return nil, fmt.Errorf("unknown auth type %q", profile.AuthType)
 	}
 }

--- a/internal/auth/transport_test.go
+++ b/internal/auth/transport_test.go
@@ -20,6 +20,24 @@ func newOAuthConfig(tokenURL string) *oauth2.Config {
 	}
 }
 
+// storeWithConfigDir points BASETEN_CONFIG_DIR at a temp dir and clears the
+// env credential vars so ResolveSession reads the returned store.
+func storeWithConfigDir(t *testing.T) *auth.Store {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("BASETEN_CONFIG_DIR", dir)
+	t.Setenv("BASETEN_API_KEY", "")
+	t.Setenv("BASETEN_PROFILE", "")
+	return auth.NewStore(auth.StoreOptions{Dir: dir})
+}
+
+func mustResolve(t *testing.T, profileFlag string) *auth.Session {
+	t.Helper()
+	session, err := auth.ResolveSession(profileFlag)
+	require.NoError(t, err)
+	return session
+}
+
 // echoServer captures the last request and replies with an empty 200.
 type echoServer struct {
 	*httptest.Server
@@ -44,12 +62,13 @@ func mustRequest(t *testing.T, url string) *http.Request {
 	return req
 }
 
-func TestTransport_EnvAPIKeyOverridesStoredCreds(t *testing.T) {
-	s := newKeyringStore(t)
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelA, "stored-key", nil))
+func TestTransport_EphemeralAPIKeyWinsOverCurrentProfile(t *testing.T) {
+	s := storeWithConfigDir(t)
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, "stored-key", true, nil))
+	t.Setenv("BASETEN_API_KEY", "env-key")
 
 	es := newEchoServer(t)
-	tr := &auth.Transport{Store: s, Host: testHost, EnvAPIKey: "env-key"}
+	tr := &auth.Transport{Session: mustResolve(t, "")}
 
 	resp, err := tr.Do(mustRequest(t, es.URL))
 	require.NoError(t, err)
@@ -58,11 +77,11 @@ func TestTransport_EnvAPIKeyOverridesStoredCreds(t *testing.T) {
 }
 
 func TestTransport_APIKeyInjected(t *testing.T) {
-	s := newKeyringStore(t)
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelA, apiKeyA, nil))
+	s := storeWithConfigDir(t)
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
 
 	es := newEchoServer(t)
-	tr := &auth.Transport{Store: s, Host: testHost}
+	tr := &auth.Transport{Session: mustResolve(t, profileA)}
 
 	resp, err := tr.Do(mustRequest(t, es.URL))
 	require.NoError(t, err)
@@ -71,14 +90,13 @@ func TestTransport_APIKeyInjected(t *testing.T) {
 }
 
 func TestTransport_OAuthBearerInjected(t *testing.T) {
-	s := newKeyringStore(t)
+	s := storeWithConfigDir(t)
 	cred := auth.OAuthCredential{AccessToken: accessToken, RefreshToken: refreshToken}
-	require.NoError(t, s.SetOAuthUser(testHost, userLabelA, cred, nil))
+	require.NoError(t, s.SetOAuthProfile(profileA, remoteURL, cred, true, nil))
 
 	es := newEchoServer(t)
 	tr := &auth.Transport{
-		Store:       s,
-		Host:        testHost,
+		Session:     mustResolve(t, profileA),
 		OAuthConfig: newOAuthConfig("http://unused/token"),
 	}
 
@@ -89,18 +107,18 @@ func TestTransport_OAuthBearerInjected(t *testing.T) {
 }
 
 func TestTransport_NotLoggedInErrors(t *testing.T) {
-	s := newKeyringStore(t)
-	tr := &auth.Transport{Store: s, Host: testHost}
+	storeWithConfigDir(t)
+	tr := &auth.Transport{Session: mustResolve(t, "")}
 	_, err := tr.Do(mustRequest(t, "http://127.0.0.1:1"))
 	require.ErrorContains(t, err, "not logged in")
 }
 
 func TestTransport_OAuthRefreshRotatesStoredToken(t *testing.T) {
-	s := newKeyringStore(t)
+	s := storeWithConfigDir(t)
 	// Blank access token with a refresh token forces oauth2 to refresh
 	// immediately: the library treats a missing access token as invalid.
-	require.NoError(t, s.SetOAuthUser(testHost, userLabelA,
-		auth.OAuthCredential{AccessToken: "", RefreshToken: "old-refresh"}, nil))
+	require.NoError(t, s.SetOAuthProfile(profileA, remoteURL,
+		auth.OAuthCredential{AccessToken: "", RefreshToken: "old-refresh"}, true, nil))
 
 	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.NoError(t, r.ParseForm())
@@ -117,24 +135,23 @@ func TestTransport_OAuthRefreshRotatesStoredToken(t *testing.T) {
 	defer tokenSrv.Close()
 
 	es := newEchoServer(t)
-	cfg := newOAuthConfig(tokenSrv.URL)
-	tr := &auth.Transport{Store: s, Host: testHost, OAuthConfig: cfg}
+	tr := &auth.Transport{Session: mustResolve(t, profileA), OAuthConfig: newOAuthConfig(tokenSrv.URL)}
 
 	resp, err := tr.Do(mustRequest(t, es.URL))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, "Bearer new-access", es.LastAuthHeader)
 
-	stored, err := s.GetOAuthCredential(testHost, userLabelA)
+	stored, err := s.GetOAuthCredential(profileA)
 	require.NoError(t, err)
 	require.Equal(t, "new-access", stored.AccessToken)
 	require.Equal(t, "new-refresh", stored.RefreshToken)
 }
 
 func TestTransport_OAuthRefreshFailureSurfacesError(t *testing.T) {
-	s := newKeyringStore(t)
-	require.NoError(t, s.SetOAuthUser(testHost, userLabelA,
-		auth.OAuthCredential{AccessToken: "", RefreshToken: "bad-refresh"}, nil))
+	s := storeWithConfigDir(t)
+	require.NoError(t, s.SetOAuthProfile(profileA, remoteURL,
+		auth.OAuthCredential{AccessToken: "", RefreshToken: "bad-refresh"}, true, nil))
 
 	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -144,8 +161,7 @@ func TestTransport_OAuthRefreshFailureSurfacesError(t *testing.T) {
 	defer tokenSrv.Close()
 
 	tr := &auth.Transport{
-		Store:       s,
-		Host:        testHost,
+		Session:     mustResolve(t, profileA),
 		OAuthConfig: newOAuthConfig(tokenSrv.URL),
 	}
 	_, err := tr.Do(mustRequest(t, "http://127.0.0.1:1"))
@@ -153,8 +169,8 @@ func TestTransport_OAuthRefreshFailureSurfacesError(t *testing.T) {
 }
 
 func TestTransport_CustomBaseUsed(t *testing.T) {
-	s := newKeyringStore(t)
-	require.NoError(t, s.SetAPIKeyUser(testHost, userLabelA, apiKeyA, nil))
+	s := storeWithConfigDir(t)
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
 
 	called := false
 	base := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
@@ -166,7 +182,7 @@ func TestTransport_CustomBaseUsed(t *testing.T) {
 			Request:    r,
 		}, nil
 	})
-	tr := &auth.Transport{Store: s, Host: testHost, Base: base}
+	tr := &auth.Transport{Session: mustResolve(t, profileA), Base: base}
 	req := mustRequest(t, "http://example.invalid/")
 	resp, err := tr.Do(req)
 	require.NoError(t, err)

--- a/internal/cmd/command.auth.go
+++ b/internal/cmd/command.auth.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/basetenlabs/baseten-cli/cmd"
 	"github.com/basetenlabs/baseten-cli/internal/auth"
+	"github.com/basetenlabs/baseten-go/client/managementapi"
 	"github.com/charmbracelet/huh"
 	"github.com/cli/browser"
 )
@@ -24,14 +24,17 @@ func init() {
 }
 
 func commandAuthLogin(ctx *CommandContext, flags *cmd.AuthLoginFlags) error {
-	baseURL := ctx.Remote.RemoteURL()
-	store, err := NewAuthStore(flags.InsecureStorage)
+	if flags.Web && flags.WithAPIKey {
+		return cmd.NewErrUsagef("--web and --with-api-key are mutually exclusive")
+	}
+
+	remote, err := NewRemote(flags.RemoteURL)
 	if err != nil {
 		return err
 	}
-
-	if flags.Web && flags.WithAPIKey {
-		return cmd.NewErrUsagef("--web and --with-api-key are mutually exclusive")
+	store, err := NewAuthStore(flags.InsecureStorage)
+	if err != nil {
+		return err
 	}
 
 	method := ""
@@ -59,51 +62,65 @@ func commandAuthLogin(ctx *CommandContext, flags *cmd.AuthLoginFlags) error {
 
 	switch method {
 	case "web":
-		return loginWeb(ctx, store, baseURL)
+		return loginWeb(ctx, store, remote, flags)
 	case "api_key":
-		return loginAPIKey(ctx, store, baseURL, flags.Label)
+		return loginAPIKey(ctx, store, remote, flags)
 	default:
 		return fmt.Errorf("unexpected auth method %q", method)
 	}
 }
 
 func commandAuthLogout(ctx *CommandContext, flags *cmd.AuthLogoutFlags) error {
-	baseURL := ctx.Remote.RemoteURL()
 	store, err := NewAuthStore(false)
 	if err != nil {
 		return err
 	}
 
-	label, entry, ok := store.ActiveUser(baseURL)
-	if !ok {
-		return fmt.Errorf("no active user for %s", baseURL)
+	profileName := flags.Profile
+	if profileName == "" {
+		current, _, ok := store.CurrentProfile()
+		if !ok {
+			return fmt.Errorf("no current profile; pass --profile to choose one to remove")
+		}
+		profileName = current
 	}
 
-	if entry.AuthType == auth.AuthTypeOAuth {
-		if err := revokeOAuthSession(ctx, store, baseURL, label); err != nil {
+	profile, ok := store.GetProfile(profileName)
+	if !ok {
+		return fmt.Errorf("profile %q not found", profileName)
+	}
+
+	if profile.AuthType == auth.AuthTypeOAuth {
+		if err := revokeOAuthSession(ctx, profileName); err != nil {
 			ctx.Logf("warning: server-side session revocation failed: %v\n", err)
 		}
 	}
 
-	if err := store.RemoveUser(baseURL, label); err != nil {
+	if err := store.RemoveProfile(profileName); err != nil {
 		return err
 	}
 
 	if ctx.JSON {
-		ctx.OutputJSON(cmd.AuthLogoutResult{User: label})
+		ctx.OutputJSON(cmd.AuthLogoutResult{Profile: profileName})
 	} else {
-		ctx.Outputf("Logged out %s\n", label)
+		ctx.Outputf("Logged out %s\n", profileName)
 	}
 	return nil
 }
 
-func revokeOAuthSession(ctx *CommandContext, store *auth.Store, baseURL, label string) error {
-	mgmtURL := ctx.Remote.ManagementURL()
+func revokeOAuthSession(ctx *CommandContext, profileName string) error {
+	session, err := auth.ResolveSession(profileName)
+	if err != nil {
+		return err
+	}
+	remote, err := NewRemote(session.RemoteURL())
+	if err != nil {
+		return err
+	}
+	mgmtURL := remote.ManagementURL()
 	transport := &auth.Transport{
-		Store:       store,
-		Host:        baseURL,
+		Session:     session,
 		OAuthConfig: OAuthConfig(mgmtURL),
-		EnvAPIKey:   os.Getenv("BASETEN_API_KEY"),
 		Base:        ctx.httpClient().Transport,
 	}
 	req, err := http.NewRequestWithContext(
@@ -125,80 +142,99 @@ func revokeOAuthSession(ctx *CommandContext, store *auth.Store, baseURL, label s
 }
 
 func commandAuthSwitch(ctx *CommandContext, flags *cmd.AuthSwitchFlags) error {
-	baseURL := ctx.Remote.RemoteURL()
 	store, err := NewAuthStore(false)
 	if err != nil {
 		return err
 	}
 
-	label := flags.User
-	if label == "" {
+	profileName := flags.Profile
+	if profileName == "" {
 		if !ctx.IsInteractive() {
-			return cmd.NewErrUsagef("must specify --user when not interactive")
+			return cmd.NewErrUsagef("must specify --profile when not interactive")
 		}
 
-		af, err := store.Load()
+		names, err := store.ProfileNames()
 		if err != nil {
 			return err
 		}
-		he, ok := af.Hosts[baseURL]
-		if !ok || len(he.Users) == 0 {
-			return fmt.Errorf("no credentials stored for %s", baseURL)
+		if len(names) == 0 {
+			return fmt.Errorf("no profiles stored; run `baseten auth login`")
 		}
 
-		var options []huh.Option[string]
-		for name := range he.Users {
+		options := make([]huh.Option[string], 0, len(names))
+		for _, name := range names {
 			options = append(options, huh.NewOption(name, name))
 		}
-
 		err = huh.NewSelect[string]().
-			Title("Switch to which account?").
+			Title("Switch to which profile?").
 			Options(options...).
-			Value(&label).
+			Value(&profileName).
 			Run()
 		if err != nil {
 			return err
 		}
 	}
 
-	if err := store.SwitchUser(baseURL, label); err != nil {
+	if err := store.SwitchProfile(profileName); err != nil {
 		return err
 	}
 
 	if ctx.JSON {
-		ctx.OutputJSON(cmd.AuthSwitchResult{User: label})
+		ctx.OutputJSON(cmd.AuthSwitchResult{Profile: profileName})
 	} else {
-		ctx.Outputf("Switched to %s\n", label)
+		ctx.Outputf("Switched to %s\n", profileName)
 	}
 	return nil
 }
 
 func commandAuthStatus(ctx *CommandContext, flags *cmd.AuthStatusFlags) error {
-	baseURL := ctx.Remote.RemoteURL()
 	store, err := NewAuthStore(false)
 	if err != nil {
 		return err
 	}
 
-	label, entry, ok := store.ActiveUser(baseURL)
+	session, err := auth.ResolveSession(flags.Profile)
+	if err != nil {
+		return err
+	}
+
+	if session.IsEphemeral() {
+		remoteURL := session.RemoteURL()
+		if remoteURL == "" {
+			remoteURL = "https://app.baseten.co"
+		}
+		if ctx.JSON {
+			ctx.OutputJSON(cmd.AuthStatusResult{RemoteURL: remoteURL, AuthType: string(auth.AuthTypeAPIKey)})
+		} else {
+			ctx.Outputf("Using API key from BASETEN_API_KEY\n  Remote: %s\n", remoteURL)
+		}
+		return nil
+	}
+
+	profileName := session.ProfileName()
+	if profileName == "" {
+		return fmt.Errorf("not logged in; run `baseten auth login` or set BASETEN_API_KEY")
+	}
+	profile, ok := store.GetProfile(profileName)
 	if !ok {
-		return fmt.Errorf("not logged in to %s; run `baseten auth login` or set BASETEN_API_KEY", baseURL)
+		return fmt.Errorf("profile %q not found", profileName)
 	}
 
 	if ctx.JSON {
 		ctx.OutputJSON(cmd.AuthStatusResult{
-			Host:     baseURL,
-			User:     label,
-			AuthType: string(entry.AuthType),
+			Profile:   profileName,
+			RemoteURL: profile.RemoteURL,
+			AuthType:  string(profile.AuthType),
 		})
 	} else {
-		ctx.Outputf("%s\n  Logged in as %s\n  Auth type: %s\n", baseURL, label, entry.AuthType)
+		ctx.Outputf("%s\n  Remote: %s\n  Auth type: %s\n", profileName, profile.RemoteURL, profile.AuthType)
 	}
 	return nil
 }
 
-func loginWeb(ctx *CommandContext, store *auth.Store, baseURL string) error {
-	cfg := OAuthConfig(ctx.Remote.ManagementURL())
+func loginWeb(ctx *CommandContext, store *auth.Store, remote *Remote, flags *cmd.AuthLoginFlags) error {
+	mgmtURL := remote.ManagementURL()
+	cfg := OAuthConfig(mgmtURL)
 	oauthCtx := auth.OAuthContext(ctx.Context, ctx.httpClient().Transport)
 	devResp, err := cfg.DeviceAuth(oauthCtx)
 	if err != nil {
@@ -225,7 +261,7 @@ func loginWeb(ctx *CommandContext, store *auth.Store, baseURL string) error {
 		ctx.VerboseLogf("access token claims: %s\n", claims)
 	}
 
-	cl, err := ctx.NewManagementClientWithAuth("Bearer " + token.AccessToken)
+	cl, err := ctx.NewManagementClientWithAuth(mgmtURL, "Bearer "+token.AccessToken)
 	if err != nil {
 		return err
 	}
@@ -234,34 +270,30 @@ func loginWeb(ctx *CommandContext, store *auth.Store, baseURL string) error {
 		return fmt.Errorf("validating credentials: %w", err)
 	}
 
+	email := deref(user.Email)
+	profileName := flags.Profile
+	if profileName == "" {
+		if email == "" {
+			return fmt.Errorf("could not determine a profile name from the account; pass --profile")
+		}
+		profileName = defaultProfileName(email, remote)
+	}
+
 	warnWriter := func(msg string) { ctx.Log(msg) }
 	cred := auth.OAuthCredential{
 		AccessToken:  token.AccessToken,
 		RefreshToken: token.RefreshToken,
 		Expiry:       token.Expiry,
 	}
-	email := deref(user.Email)
-	if err := store.SetOAuthUser(baseURL, email, cred, warnWriter); err != nil {
+	if err := store.SetOAuthProfile(profileName, remote.RemoteURL(), cred, !flags.NoSwitch, warnWriter); err != nil {
 		return err
 	}
 
-	result := cmd.AuthLoginResult{
-		UserID:        user.UserId,
-		Email:         email,
-		Name:          deref(user.Name),
-		WorkspaceName: deref(user.WorkspaceName),
-	}
-	if ctx.JSON {
-		ctx.OutputJSON(result)
-	} else {
-		ctx.Outputf("Logged in as %s (%s)\n", result.Email, result.WorkspaceName)
-	}
-	return nil
+	return writeLoginResult(ctx, profileName, user)
 }
 
-func loginAPIKey(ctx *CommandContext, store *auth.Store, baseURL, label string) error {
+func loginAPIKey(ctx *CommandContext, store *auth.Store, remote *Remote, flags *cmd.AuthLoginFlags) error {
 	var apiKey string
-
 	if ctx.IsInteractive() {
 		err := huh.NewInput().
 			Title("Paste your API key").
@@ -281,10 +313,10 @@ func loginAPIKey(ctx *CommandContext, store *auth.Store, baseURL, label string) 
 	}
 
 	if apiKey == "" {
-		return cmd.NewErrUsagef("API key cannot be empty")
+		return fmt.Errorf("API key cannot be empty")
 	}
 
-	cl, err := ctx.NewManagementClientWithAuth("Api-Key " + apiKey)
+	cl, err := ctx.NewManagementClientWithAuth(remote.ManagementURL(), "Api-Key "+apiKey)
 	if err != nil {
 		return err
 	}
@@ -293,31 +325,35 @@ func loginAPIKey(ctx *CommandContext, store *auth.Store, baseURL, label string) 
 		return fmt.Errorf("validating API key: %w", err)
 	}
 
-	if label == "" {
-		if ctx.IsInteractive() {
-			err := huh.NewInput().
-				Title("Label for this credential").
-				Description("e.g. personal, deploy-bot").
-				Value(&label).
-				Run()
-			if err != nil {
-				return err
-			}
-		} else {
-			return cmd.NewErrUsagef("--label is required when not interactive")
+	profileName := flags.Profile
+	if profileName == "" {
+		if !ctx.IsInteractive() {
+			return cmd.NewErrUsagef("--profile is required when logging in with an API key non-interactively")
+		}
+		err := huh.NewInput().
+			Title("Profile name for this credential").
+			Description("e.g. personal, deploy-bot").
+			Value(&profileName).
+			Run()
+		if err != nil {
+			return err
 		}
 	}
-
-	if label == "" {
-		return cmd.NewErrUsagef("label cannot be empty")
+	if profileName == "" {
+		return cmd.NewErrUsagef("profile name cannot be empty")
 	}
 
 	warnWriter := func(msg string) { ctx.Log(msg) }
-	if err := store.SetAPIKeyUser(baseURL, label, apiKey, warnWriter); err != nil {
+	if err := store.SetAPIKeyProfile(profileName, remote.RemoteURL(), apiKey, !flags.NoSwitch, warnWriter); err != nil {
 		return err
 	}
 
+	return writeLoginResult(ctx, profileName, user)
+}
+
+func writeLoginResult(ctx *CommandContext, profileName string, user *managementapi.UserInfo) error {
 	result := cmd.AuthLoginResult{
+		Profile:       profileName,
 		UserID:        user.UserId,
 		Email:         deref(user.Email),
 		Name:          deref(user.Name),
@@ -326,9 +362,18 @@ func loginAPIKey(ctx *CommandContext, store *auth.Store, baseURL, label string) 
 	if ctx.JSON {
 		ctx.OutputJSON(result)
 	} else {
-		ctx.Outputf("Logged in as %s (%s)\n", result.Email, result.WorkspaceName)
+		ctx.Outputf("Logged in as %s (%s) as profile %s\n", result.Email, result.WorkspaceName, profileName)
 	}
 	return nil
+}
+
+// defaultProfileName derives the profile name for an OAuth login: the email,
+// with the remote host appended for non-default remotes to disambiguate.
+func defaultProfileName(email string, remote *Remote) string {
+	if remote.IsDefault() {
+		return email
+	}
+	return email + ":" + remote.HostLabel()
 }
 
 func deref(s *string) string {

--- a/internal/cmd/command.auth_test.go
+++ b/internal/cmd/command.auth_test.go
@@ -9,18 +9,18 @@ import (
 	"github.com/basetenlabs/baseten-cli/internal/auth"
 )
 
-// newAuthHarness returns a CommandHarness with BASETEN_API_KEY cleared so
-// auth commands exercise the credential store rather than the env override.
+// newAuthHarness returns a CommandHarness with the env credential vars cleared
+// so auth commands exercise the profile store rather than ephemeral env auth.
 func newAuthHarness(t *testing.T) *CommandHarness {
 	h := NewCommandHarness(t)
 	t.Setenv("BASETEN_API_KEY", "")
+	t.Setenv("BASETEN_PROFILE", "")
 	return h
 }
 
-// setTestRemote points the Remote at urlStr: BASETEN_REMOTE_URL becomes the
-// auth store key, and BASETEN_MANAGEMENT_API_URL_OVERRIDE routes management
-// calls to the same URL (useful for httptest servers).
-func setTestRemote(t *testing.T, urlStr string) {
+// pointManagementAt routes management API calls (and OAuth endpoints) to urlStr
+// and uses it as the login remote.
+func pointManagementAt(t *testing.T, urlStr string) {
 	t.Helper()
 	t.Setenv("BASETEN_REMOTE_URL", urlStr)
 	t.Setenv("BASETEN_MANAGEMENT_API_URL_OVERRIDE", urlStr)
@@ -75,52 +75,86 @@ func Test_Auth_Status_NotLoggedIn(t *testing.T) {
 
 func Test_Auth_Status_APIKey(t *testing.T) {
 	h := newAuthHarness(t)
-	setTestRemote(t, "https://api.example.com")
 
 	store := configDirStore(t)
-	h.Require.NoError(store.SetAPIKeyUser("https://api.example.com", "alice", "key-xyz", nil))
+	h.Require.NoError(store.SetAPIKeyProfile("alice", "https://app.example.com", "key-xyz", true, nil))
 
 	h.Require.NoError(h.Execute("auth", "status"))
 	out := h.Stdout.String()
-	h.Require.Contains(out, "https://api.example.com")
 	h.Require.Contains(out, "alice")
+	h.Require.Contains(out, "https://app.example.com")
 	h.Require.Contains(out, "api_key")
 }
 
 func Test_Auth_Status_JSON(t *testing.T) {
 	h := newAuthHarness(t)
-	setTestRemote(t, "https://api.example.com")
 
 	store := configDirStore(t)
-	h.Require.NoError(store.SetAPIKeyUser("https://api.example.com", "alice", "key-xyz", nil))
+	h.Require.NoError(store.SetAPIKeyProfile("alice", "https://app.example.com", "key-xyz", true, nil))
 
 	h.Require.NoError(h.Execute("auth", "status", "--output", "json"))
 	var got map[string]string
 	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &got))
-	h.Require.Equal("alice", got["user"])
+	h.Require.Equal("alice", got["profile"])
 	h.Require.Equal("api_key", got["auth_type"])
-	h.Require.Equal("https://api.example.com", got["host"])
+	h.Require.Equal("https://app.example.com", got["remote_url"])
 }
 
-func Test_Auth_Logout_NoActiveUser(t *testing.T) {
+func Test_Auth_Status_EphemeralEnvAPIKey(t *testing.T) {
+	h := newAuthHarness(t)
+	t.Setenv("BASETEN_API_KEY", "env-key")
+
+	h.Require.NoError(h.Execute("auth", "status"))
+	h.Require.Contains(h.Stdout.String(), "BASETEN_API_KEY")
+}
+
+func Test_Auth_Status_ProfileFlagSelects(t *testing.T) {
+	h := newAuthHarness(t)
+
+	store := configDirStore(t)
+	h.Require.NoError(store.SetAPIKeyProfile("alice", "https://app.example.com", "key-a", true, nil))
+	h.Require.NoError(store.SetAPIKeyProfile("bob", "https://app.other.example.com", "key-b", false, nil))
+
+	h.Require.NoError(h.Execute("auth", "status", "--profile", "bob", "--output", "json"))
+	var got map[string]string
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &got))
+	h.Require.Equal("bob", got["profile"])
+}
+
+func Test_Auth_Logout_NoCurrentProfile(t *testing.T) {
 	h := newAuthHarness(t)
 	h.Require.Error(h.Execute("auth", "logout"))
 	h.Require.Equal(1, h.ExitCode)
-	h.Require.Contains(h.Stderr.String(), "no active user")
+	h.Require.Contains(h.Stderr.String(), "no current profile")
 }
 
-func Test_Auth_Logout_RemovesActiveUser(t *testing.T) {
+func Test_Auth_Logout_RemovesCurrentProfile(t *testing.T) {
 	h := newAuthHarness(t)
-	setTestRemote(t, "https://api.example.com")
 
 	store := configDirStore(t)
-	h.Require.NoError(store.SetAPIKeyUser("https://api.example.com", "alice", "key-xyz", nil))
+	h.Require.NoError(store.SetAPIKeyProfile("alice", "https://app.example.com", "key-xyz", true, nil))
 
 	h.Require.NoError(h.Execute("auth", "logout"))
 	h.Require.Contains(h.Stdout.String(), "alice")
 
-	_, _, ok := configDirStore(t).ActiveUser("https://api.example.com")
-	h.Require.False(ok, "user should be removed")
+	_, _, ok := configDirStore(t).CurrentProfile()
+	h.Require.False(ok, "profile should be removed")
+}
+
+func Test_Auth_Logout_ProfileFlagSelects(t *testing.T) {
+	h := newAuthHarness(t)
+
+	store := configDirStore(t)
+	h.Require.NoError(store.SetAPIKeyProfile("alice", "https://app.example.com", "key-a", true, nil))
+	h.Require.NoError(store.SetAPIKeyProfile("bob", "https://app.example.com", "key-b", false, nil))
+
+	h.Require.NoError(h.Execute("auth", "logout", "--profile", "bob"))
+
+	_, ok := configDirStore(t).GetProfile("bob")
+	h.Require.False(ok, "named profile should be removed")
+	name, _, ok := configDirStore(t).CurrentProfile()
+	h.Require.True(ok, "current profile must be untouched")
+	h.Require.Equal("alice", name)
 }
 
 func Test_Auth_Logout_APIKey_SkipsServerCall(t *testing.T) {
@@ -131,10 +165,10 @@ func Test_Auth_Logout_APIKey_SkipsServerCall(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
-	setTestRemote(t, srv.URL)
+	pointManagementAt(t, srv.URL)
 
 	store := configDirStore(t)
-	h.Require.NoError(store.SetAPIKeyUser(srv.URL, "alice", "key-xyz", nil))
+	h.Require.NoError(store.SetAPIKeyProfile("alice", srv.URL, "key-xyz", true, nil))
 
 	h.Require.NoError(h.Execute("auth", "logout"))
 	h.Require.Equal(0, calls, "API key logout should not call server")
@@ -149,18 +183,18 @@ func Test_Auth_Logout_OAuth_CallsRevokeEndpoint(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(srv.Close)
-	setTestRemote(t, srv.URL)
+	pointManagementAt(t, srv.URL)
 
 	store := configDirStore(t)
 	cred := auth.OAuthCredential{AccessToken: "at_abc", RefreshToken: "rt_abc"}
-	h.Require.NoError(store.SetOAuthUser(srv.URL, "alice", cred, nil))
+	h.Require.NoError(store.SetOAuthProfile("alice", srv.URL, cred, true, nil))
 
 	h.Require.NoError(h.Execute("auth", "logout"))
 	h.Require.Equal("/v1/users/auth/logout", gotPath)
 	h.Require.Equal("Bearer at_abc", gotAuth)
 
-	_, _, ok := configDirStore(t).ActiveUser(srv.URL)
-	h.Require.False(ok, "user should be removed")
+	_, _, ok := configDirStore(t).CurrentProfile()
+	h.Require.False(ok, "profile should be removed")
 }
 
 func Test_Auth_Logout_OAuth_WarnsOnServerFailureButStillRemoves(t *testing.T) {
@@ -169,47 +203,45 @@ func Test_Auth_Logout_OAuth_WarnsOnServerFailureButStillRemoves(t *testing.T) {
 		http.Error(w, `{"code":"VALIDATION_ERROR","message":"nope"}`, http.StatusBadRequest)
 	}))
 	t.Cleanup(srv.Close)
-	setTestRemote(t, srv.URL)
+	pointManagementAt(t, srv.URL)
 
 	store := configDirStore(t)
 	cred := auth.OAuthCredential{AccessToken: "at_abc", RefreshToken: "rt_abc"}
-	h.Require.NoError(store.SetOAuthUser(srv.URL, "alice", cred, nil))
+	h.Require.NoError(store.SetOAuthProfile("alice", srv.URL, cred, true, nil))
 
 	h.Require.NoError(h.Execute("auth", "logout"))
 	h.Require.Contains(h.Stderr.String(), "warning")
 
-	_, _, ok := configDirStore(t).ActiveUser(srv.URL)
-	h.Require.False(ok, "user should still be removed after server failure")
+	_, _, ok := configDirStore(t).CurrentProfile()
+	h.Require.False(ok, "profile should still be removed after server failure")
 }
 
-func Test_Auth_Switch_RequiresUserNonInteractive(t *testing.T) {
+func Test_Auth_Switch_RequiresProfileNonInteractive(t *testing.T) {
 	h := newAuthHarness(t)
 	err := h.Execute("auth", "switch")
-	h.Require.ErrorContains(err, "--user")
+	h.Require.ErrorContains(err, "--profile")
 }
 
-func Test_Auth_Switch_UpdatesActiveUser(t *testing.T) {
+func Test_Auth_Switch_UpdatesCurrentProfile(t *testing.T) {
 	h := newAuthHarness(t)
-	setTestRemote(t, "https://api.example.com")
 
 	store := configDirStore(t)
-	h.Require.NoError(store.SetAPIKeyUser("https://api.example.com", "alice", "key-alice", nil))
-	h.Require.NoError(store.SetAPIKeyUser("https://api.example.com", "bob", "key-bob", nil))
+	h.Require.NoError(store.SetAPIKeyProfile("alice", "https://app.example.com", "key-alice", true, nil))
+	h.Require.NoError(store.SetAPIKeyProfile("bob", "https://app.example.com", "key-bob", true, nil))
 
-	h.Require.NoError(h.Execute("auth", "switch", "--user", "alice"))
+	h.Require.NoError(h.Execute("auth", "switch", "--profile", "alice"))
 
-	label, _, _ := configDirStore(t).ActiveUser("https://api.example.com")
-	h.Require.Equal("alice", label)
+	name, _, _ := configDirStore(t).CurrentProfile()
+	h.Require.Equal("alice", name)
 }
 
-func Test_Auth_Switch_UnknownUserFails(t *testing.T) {
+func Test_Auth_Switch_UnknownProfileFails(t *testing.T) {
 	h := newAuthHarness(t)
-	setTestRemote(t, "https://api.example.com")
 
 	store := configDirStore(t)
-	h.Require.NoError(store.SetAPIKeyUser("https://api.example.com", "alice", "key-alice", nil))
+	h.Require.NoError(store.SetAPIKeyProfile("alice", "https://app.example.com", "key-alice", true, nil))
 
-	h.Require.Error(h.Execute("auth", "switch", "--user", "ghost"))
+	h.Require.Error(h.Execute("auth", "switch", "--profile", "ghost"))
 	h.Require.Equal(1, h.ExitCode)
 	h.Require.Contains(h.Stderr.String(), "not found")
 }
@@ -217,47 +249,64 @@ func Test_Auth_Switch_UnknownUserFails(t *testing.T) {
 func Test_Auth_Login_APIKey_Stdin(t *testing.T) {
 	h := newAuthHarness(t)
 	srv := newUserInfoServer(t)
-	setTestRemote(t, srv.URL)
+	pointManagementAt(t, srv.URL)
 
 	h.Stdin.WriteString("secret-api-key\n")
-	h.Require.NoError(h.Execute("auth", "login", "--with-api-key", "--label", "my-laptop"))
+	h.Require.NoError(h.Execute("auth", "login", "--with-api-key", "--profile", "my-laptop"))
 
 	h.Require.Equal("Api-Key secret-api-key", srv.LastAuthHeader)
 	h.Require.Contains(h.Stdout.String(), "user@example.com")
+	h.Require.Contains(h.Stdout.String(), "my-laptop")
 
 	store := configDirStore(t)
-	label, entry, ok := store.ActiveUser(srv.URL)
+	name, profile, ok := store.CurrentProfile()
 	h.Require.True(ok)
-	h.Require.Equal("my-laptop", label)
-	h.Require.Equal(auth.AuthTypeAPIKey, entry.AuthType)
+	h.Require.Equal("my-laptop", name)
+	h.Require.Equal(auth.AuthTypeAPIKey, profile.AuthType)
 
-	got, err := store.GetAPIKey(srv.URL, "my-laptop")
+	got, err := store.GetAPIKey("my-laptop")
 	h.Require.NoError(err)
 	h.Require.Equal("secret-api-key", got)
 }
 
+func Test_Auth_Login_APIKey_NoSwitchKeepsCurrent(t *testing.T) {
+	h := newAuthHarness(t)
+	srv := newUserInfoServer(t)
+	pointManagementAt(t, srv.URL)
+
+	store := configDirStore(t)
+	h.Require.NoError(store.SetAPIKeyProfile("existing", srv.URL, "key-existing", true, nil))
+
+	h.Stdin.WriteString("secret-api-key\n")
+	h.Require.NoError(h.Execute("auth", "login", "--with-api-key", "--profile", "my-laptop", "--no-switch"))
+
+	name, _, ok := configDirStore(t).CurrentProfile()
+	h.Require.True(ok)
+	h.Require.Equal("existing", name, "--no-switch must not move the current pointer")
+}
+
 func Test_Auth_Login_APIKey_EmptyFails(t *testing.T) {
 	h := newAuthHarness(t)
-	setTestRemote(t, "http://127.0.0.1:1")
+	pointManagementAt(t, "http://127.0.0.1:1")
 
 	h.Stdin.WriteString("\n")
-	err := h.Execute("auth", "login", "--with-api-key", "--label", "my-laptop")
+	err := h.Execute("auth", "login", "--with-api-key", "--profile", "my-laptop")
 	h.Require.ErrorContains(err, "empty")
 }
 
-func Test_Auth_Login_APIKey_RequiresLabelNonInteractive(t *testing.T) {
+func Test_Auth_Login_APIKey_RequiresProfileNonInteractive(t *testing.T) {
 	h := newAuthHarness(t)
 	srv := newUserInfoServer(t)
-	setTestRemote(t, srv.URL)
+	pointManagementAt(t, srv.URL)
 
 	h.Stdin.WriteString("secret-api-key\n")
 	err := h.Execute("auth", "login", "--with-api-key")
-	h.Require.ErrorContains(err, "--label")
+	h.Require.ErrorContains(err, "--profile")
 }
 
-func Test_Auth_Login_APIKey_RejectsWebAndKeyFlags(t *testing.T) {
+func Test_Auth_Login_RejectsWebAndKeyFlags(t *testing.T) {
 	h := newAuthHarness(t)
-	err := h.Execute("auth", "login", "--web", "--with-api-key", "--label", "x")
+	err := h.Execute("auth", "login", "--web", "--with-api-key", "--profile", "x")
 	h.Require.ErrorContains(err, "mutually exclusive")
 }
 
@@ -324,7 +373,7 @@ func newDeviceAuthServer(t *testing.T) *deviceAuthServer {
 func Test_Auth_Login_Web_DeviceFlow(t *testing.T) {
 	h := newAuthHarness(t)
 	srv := newDeviceAuthServer(t)
-	setTestRemote(t, srv.URL)
+	pointManagementAt(t, srv.URL)
 
 	h.Require.NoError(h.Execute("auth", "login", "--web"))
 
@@ -334,13 +383,25 @@ func Test_Auth_Login_Web_DeviceFlow(t *testing.T) {
 	h.Require.Contains(h.Stdout.String(), "user@example.com")
 
 	store := configDirStore(t)
-	label, entry, ok := store.ActiveUser(srv.URL)
+	name, profile, ok := store.CurrentProfile()
 	h.Require.True(ok)
-	h.Require.Equal("user@example.com", label)
-	h.Require.Equal(auth.AuthTypeOAuth, entry.AuthType)
+	h.Require.Contains(name, "user@example.com", "profile is named after the email")
+	h.Require.Equal(auth.AuthTypeOAuth, profile.AuthType)
 
-	cred, err := store.GetOAuthCredential(srv.URL, label)
+	cred, err := store.GetOAuthCredential(name)
 	h.Require.NoError(err)
 	h.Require.Equal("access-xyz", cred.AccessToken)
 	h.Require.Equal("refresh-xyz", cred.RefreshToken)
+}
+
+func Test_Auth_Login_Web_ProfileFlagOverridesName(t *testing.T) {
+	h := newAuthHarness(t)
+	srv := newDeviceAuthServer(t)
+	pointManagementAt(t, srv.URL)
+
+	h.Require.NoError(h.Execute("auth", "login", "--web", "--profile", "work"))
+
+	name, _, ok := configDirStore(t).CurrentProfile()
+	h.Require.True(ok)
+	h.Require.Equal("work", name)
 }

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -192,10 +192,6 @@ func buildCommand(def cmd.Command, parentPath string, options *ExecuteOptions) *
 			if f := flagsVal.FieldByName("CommandFlags"); f.IsValid() {
 				cmdFlags = f.Interface().(cmd.CommandFlags)
 			}
-			remote, err := NewRemote(cmdFlags.RemoteURL)
-			if err != nil {
-				return err
-			}
 			ctx := &CommandContext{
 				Context:      c.Context(),
 				Command:      c,
@@ -204,7 +200,7 @@ func buildCommand(def cmd.Command, parentPath string, options *ExecuteOptions) *
 				Stdout:       options.Stdout,
 				Stderr:       options.Stderr,
 				ExitWithCode: options.ExitWithCode,
-				Remote:       remote,
+				authInfo:     authInfo{profileFlag: cmdFlags.Profile},
 			}
 
 			// Resolve --jq and --output, populating ctx.

--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -495,8 +495,12 @@ func waitModelPushDeployment(
 }
 
 func writeModelPushResult(ctx *CommandContext, created *managementapi.CreatedModelDeployment, environment *string) error {
-	predictURL := ctx.Remote.PredictURL(created.Model.Id, created.Deployment.Id, created.Deployment.IsDevelopment)
-	logsURL := ctx.Remote.LogsURL(created.Model.Id, created.Deployment.Id)
+	remote, err := ctx.authInfo.Remote()
+	if err != nil {
+		return err
+	}
+	predictURL := remote.PredictURL(created.Model.Id, created.Deployment.Id, created.Deployment.IsDevelopment)
+	logsURL := remote.LogsURL(created.Model.Id, created.Deployment.Id)
 
 	// Narrative goes first so a user piping JSON to a file or jq sees the
 	// human summary on stderr before the JSON object lands on stdout.

--- a/internal/cmd/command_context.go
+++ b/internal/cmd/command_context.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -35,7 +36,6 @@ type CommandContext struct {
 	Stdout       io.Writer
 	Stderr       io.Writer
 	ExitWithCode func(int)
-	Remote       *Remote
 	// JQQuery is a compiled --jq expression installed by the framework. When
 	// non-nil, [OutputJSON] and [JSONArrayWriter.Write] route their input
 	// through the query before encoding. Leaves should not set this directly.
@@ -43,6 +43,10 @@ type CommandContext struct {
 
 	verbose bool
 	jqErr   error
+
+	// authInfo lazily resolves the remote and auth session. Use the Remote and
+	// Session accessors; do not read its cached fields directly.
+	authInfo authInfo
 }
 
 // Output writes to stdout.
@@ -329,16 +333,18 @@ func NewAuthStore(insecureStorage bool) (*auth.Store, error) {
 // NewManagementClient creates a management API client that resolves
 // credentials via the auth store (env var > stored credential).
 func (c *CommandContext) NewManagementClient() (*client.ManagementClient, error) {
-	store, err := NewAuthStore(false)
+	remote, err := c.authInfo.Remote()
 	if err != nil {
 		return nil, err
 	}
-	mgmtURL := c.Remote.ManagementURL()
+	session, err := c.authInfo.Session()
+	if err != nil {
+		return nil, err
+	}
+	mgmtURL := remote.ManagementURL()
 	transport := &auth.Transport{
-		Store:       store,
-		Host:        c.Remote.RemoteURL(),
+		Session:     session,
 		OAuthConfig: OAuthConfig(mgmtURL),
-		EnvAPIKey:   os.Getenv("BASETEN_API_KEY"),
 		Base:        c.httpClient().Transport,
 	}
 	return client.NewManagementClient(client.ManagementClientOptions{
@@ -348,11 +354,12 @@ func (c *CommandContext) NewManagementClient() (*client.ManagementClient, error)
 	})
 }
 
-// NewManagementClientWithAuth creates a management API client with a specific
-// auth header. Used during login to validate a credential before storing it.
-func (c *CommandContext) NewManagementClientWithAuth(authHeader string) (*client.ManagementClient, error) {
+// NewManagementClientWithAuth creates a management API client against mgmtURL
+// with a specific auth header. Used during login to validate a credential
+// before storing it, before any profile exists.
+func (c *CommandContext) NewManagementClientWithAuth(mgmtURL, authHeader string) (*client.ManagementClient, error) {
 	return client.NewManagementClient(client.ManagementClientOptions{
-		BaseURL:   c.Remote.ManagementURL(),
+		BaseURL:   mgmtURL,
 		DeferAuth: true,
 		HTTPClient: &staticAuthClient{
 			header: authHeader,
@@ -364,23 +371,25 @@ func (c *CommandContext) NewManagementClientWithAuth(authHeader string) (*client
 // NewInferenceClient creates an inference API client that resolves
 // credentials via the auth store.
 func (c *CommandContext) NewInferenceClient(flags cmd.InferenceClientFlags) (*client.InferenceClient, error) {
-	store, err := NewAuthStore(false)
+	remote, err := c.authInfo.Remote()
 	if err != nil {
 		return nil, err
 	}
-	mgmtURL := c.Remote.ManagementURL()
+	session, err := c.authInfo.Session()
+	if err != nil {
+		return nil, err
+	}
+	mgmtURL := remote.ManagementURL()
 	transport := &auth.Transport{
-		Store:       store,
-		Host:        c.Remote.RemoteURL(),
+		Session:     session,
 		OAuthConfig: OAuthConfig(mgmtURL),
-		EnvAPIKey:   os.Getenv("BASETEN_API_KEY"),
 		Base:        c.httpClient().Transport,
 	}
-	baseURL, err := c.Remote.InferenceBaseURL(flags.ModelID, flags.ChainID, flags.Environment)
+	baseURL, err := remote.InferenceBaseURL(flags.ModelID, flags.ChainID, flags.Environment)
 	if err != nil {
 		return nil, err
 	}
-	hostHeader, hostOverride, err := c.Remote.InferenceHostHeader(flags.ModelID, flags.ChainID, flags.Environment)
+	hostHeader, hostOverride, err := remote.InferenceHostHeader(flags.ModelID, flags.ChainID, flags.Environment)
 	if err != nil {
 		return nil, err
 	}
@@ -496,4 +505,44 @@ func (c *hostHeaderClient) Do(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
 	req.Host = c.host
 	return c.base.Do(req)
+}
+
+// authInfo lazily resolves and caches the remote and auth session for one
+// invocation. Because the selected profile carries the remote URL, both are
+// resolved together by resolve (guarded by once). The remote and session
+// fields are caches; callers use the Remote and Session accessors.
+type authInfo struct {
+	profileFlag string
+
+	once    sync.Once
+	err     error
+	remote  *Remote
+	session *auth.Session
+}
+
+func (a *authInfo) resolve() error {
+	a.once.Do(func() {
+		if a.session, a.err = auth.ResolveSession(a.profileFlag); a.err != nil {
+			return
+		}
+		a.remote, a.err = NewRemote(a.session.RemoteURL())
+	})
+	return a.err
+}
+
+// Remote returns the remote for this invocation, derived from the selected
+// profile (or ephemeral env credentials, or the default).
+func (a *authInfo) Remote() (*Remote, error) {
+	if err := a.resolve(); err != nil {
+		return nil, err
+	}
+	return a.remote, nil
+}
+
+// Session returns the auth session for this invocation.
+func (a *authInfo) Session() (*auth.Session, error) {
+	if err := a.resolve(); err != nil {
+		return nil, err
+	}
+	return a.session, nil
 }

--- a/internal/cmd/remote.go
+++ b/internal/cmd/remote.go
@@ -16,6 +16,7 @@ type Remote struct {
 	remoteURL           string
 	scheme              string
 	baseHost            string
+	hostLabel           string
 	managementAPIHost   string
 	inferenceBaseURL    string
 	inferenceHostSuffix string
@@ -42,6 +43,7 @@ func NewRemote(remoteURL string) (*Remote, error) {
 	r.remoteURL = u.Scheme + "://" + u.Host
 	r.scheme = u.Scheme
 	r.baseHost = strings.TrimPrefix(u.Host, "app.")
+	r.hostLabel = strings.TrimPrefix(u.Hostname(), "app.")
 
 	switch r.remoteURL {
 	case "https://app.baseten.co":
@@ -72,8 +74,15 @@ func NewRemote(remoteURL string) (*Remote, error) {
 	return r, nil
 }
 
-// RemoteURL returns the raw remote URL (suitable as the auth store key).
+// RemoteURL returns the raw remote URL.
 func (r *Remote) RemoteURL() string { return r.remoteURL }
+
+// IsDefault reports whether this is the default Baseten remote.
+func (r *Remote) IsDefault() bool { return r.remoteURL == "https://app.baseten.co" }
+
+// HostLabel returns the remote's host without the "app." prefix or any port,
+// used to disambiguate profile names across non-default remotes.
+func (r *Remote) HostLabel() string { return r.hostLabel }
 
 // ManagementURL returns the base URL for the REST management API.
 func (r *Remote) ManagementURL() string {


### PR DESCRIPTION
## :rocket: What

- Replaces the two-level `(host, label)` + mutable `active_user` auth model with flat, self-contained **named profiles**, each bundling a remote URL + credential.
- Adds `--profile NAME` (global) for a per-call auth override with no state mutation - the main ask, since `auth switch` was too stateful.
- Selection precedence (most specific wins, no errors): `--profile` > `BASETEN_API_KEY` (+optional `BASETEN_REMOTE_URL`, ephemeral) > `BASETEN_PROFILE` > current profile.
- `auth login` now stores a profile (OAuth named after your email, API key requires explicit `--profile`), takes `--remote-url`, and `--no-switch` to store without making it current. `auth switch`/`logout`/`status` operate on profiles.
- Drops the global `--remote-url` flag; the remote now rides on the selected profile.
- Not back-compat: CLI is unstable. Old `auth.json` `hosts` data and prior keyring entries are ignored (new keyring service `baseten-profile`), so users re-login once.

## :computer: How

- `internal/auth/store.go`: `auth.json` is now `{version, current, profiles}`; keyring keyed by profile name.
- `internal/auth/transport.go`: new `Session` type + `ResolveSession` (the precedence logic); `Transport` drives off a resolved `Session`.
- `CommandContext` resolves remote + session once, lazily, via a memoized `authInfo` (profile carries the remote, so they resolve together); clients build from it.
- Unknown `auth.json` keys are silently dropped (Go `json.Unmarshal`), giving clean takeover of the old file.

## :microscope: Testing

- Rewrote store/transport/auth-command unit tests for the profile model; full suite, `go vet` (incl. `-tags e2e`), and `gofmt` are clean.
- Manually exercised login (OAuth + API key), per-call `--profile`, `BASETEN_PROFILE`, ephemeral `BASETEN_API_KEY`, switch/logout, non-default-remote naming, and old-file takeover.