### PR TITLE
Add model-api commands (fetch, list, predict)

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -34,6 +34,7 @@ var Root = Command{
 		commandAPI,
 		commandAuth,
 		commandModel,
+		commandModelAPI,
 		commandOrg,
 		commandTruss,
 		commandVersion,

--- a/cmd/command.model_api.go
+++ b/cmd/command.model_api.go
@@ -1,0 +1,126 @@
+package cmd
+
+import "github.com/basetenlabs/baseten-go/client/managementapi"
+
+var commandModelAPI = Command{
+	Name:    "model-api",
+	Summary: "Manage Model APIs",
+	Description: "List and inspect Baseten Model APIs.\n\n" +
+		"Authentication is via 'baseten auth login' or the BASETEN_API_KEY environment variable.",
+	Children: []Command{
+		{
+			Name:    "fetch",
+			Summary: "Fetch a Model API",
+			Description: "Fetch a single Model API by name.\n\n" +
+				"The name is the stable, URL-safe slug used as the Model API's public identifier.",
+			Flags: ModelAPIFetchFlags{},
+			Output: &CommandOutput[managementapi.ModelAPI]{
+				TextDescription: "Field-per-line summary of the Model API.",
+				Examples: []CommandExample{
+					{
+						Description: "Fetch a Model API by name.",
+						Command:     "baseten model-api fetch --name <name>",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the Model API's invoke URL.",
+					Command:     "baseten model-api fetch --name <name> --jq '.invoke_url'",
+				},
+			},
+		},
+		{
+			Name:    "list",
+			Summary: "List Model APIs the workspace has added",
+			Description: "List the Model APIs the workspace has added.\n\n" +
+				"Pass --all to browse the full visible catalog instead of just the added ones.",
+			Flags: ModelAPIListFlags{},
+			Output: &CommandOutput[ModelAPIList]{
+				TextDescription: "Table with columns: NAME, DISPLAY NAME, FAMILY, CONTEXT, ADDED. " +
+					"When no Model APIs match, prints \"No Model APIs found.\" to stderr.",
+				Examples: []CommandExample{
+					{
+						Description: "List the Model APIs the workspace has added.",
+						Command:     "baseten model-api list",
+					},
+					{
+						Description: "Browse the full visible catalog.",
+						Command:     "baseten model-api list --all",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print just the Model API names.",
+					Command:     "baseten model-api list --jq '.items[].name'",
+				},
+			},
+		},
+		{
+			Name:    "predict",
+			Summary: "Run an inference request against a Model API",
+			Description: "POST an inference request to a Model API and write the response to " +
+				"stdout.\n\n" +
+				"The request is sent to --url, which defaults to the OpenAI chat-completions " +
+				"endpoint on the shared inference host. Override it for other shapes (e.g. " +
+				"/v1/messages, /v1/embeddings) or different hosts.\n\n" +
+				"--content is the simple path: it builds an OpenAI chat-completions body with a " +
+				"single user message and --name as the model, and prints just the assistant's " +
+				"reply. It is only valid for OpenAI chat URLs and requires --name.\n\n" +
+				"--data and --file send a request body verbatim, so any format the endpoint " +
+				"accepts works (OpenAI, Anthropic, embeddings, custom). The response is written " +
+				"as-is: JSON is pretty-printed, streams and binary bodies are passed through.",
+			Flags: ModelAPIPredictFlags{},
+			Output: &CommandOutput[JSONUndefined]{
+				TextDescription: "With --content, the assistant message text. With --data/--file, the " +
+					"response body as-is (pretty-printed JSON, or a raw stream/binary body).",
+				JSONDescription: "Under --output json, --content emits the full chat-completions " +
+					"response. For --data/--file, a streamed response becomes one JSON record per " +
+					"chunk under --output jsonl, and a binary body is base64-encoded under a 'body' key.",
+				Examples: []CommandExample{
+					{
+						Description: "Send a single user message.",
+						Command:     `baseten model-api predict --name <name> --content "hello"`,
+					},
+					{
+						Description: "Send a full OpenAI-shaped body and stream it as JSONL.",
+						Command:     `baseten model-api predict --name <name> --data '{"model":"<name>","messages":[{"role":"user","content":"hi"}],"stream":true}' --output jsonl`,
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Extract the assistant's message content.",
+					Command:     `baseten model-api predict --name <name> --content "hi" --jq '.choices[0].message.content'`,
+				},
+			},
+		},
+	},
+}
+
+// ModelAPIList is the JSON output of `baseten model-api list`: the Model APIs
+// aggregated across all pages.
+type ModelAPIList struct {
+	Items []managementapi.ModelAPI `json:"items"`
+}
+
+// ModelAPIFetchFlags configures `baseten model-api fetch`.
+type ModelAPIFetchFlags struct {
+	CommandFlags
+
+	Name string `flag:"name" desc:"Name of the Model API (its stable, URL-safe slug)." required:"true"`
+}
+
+// ModelAPIListFlags configures `baseten model-api list`.
+type ModelAPIListFlags struct {
+	CommandFlags
+
+	All bool `flag:"all" desc:"Browse the full visible catalog instead of only the Model APIs the workspace has added."`
+}
+
+// ModelAPIPredictFlags configures `baseten model-api predict`.
+type ModelAPIPredictFlags struct {
+	CommandFlags
+
+	URL  string `flag:"url" desc:"Endpoint to POST the request to." default:"https://inference.baseten.co/v1/chat/completions"`
+	Name string `flag:"name" desc:"Name of the Model API (its stable, URL-safe slug). Required with --content, where it sets the request's model." `
+
+	Content string `flag:"content" desc:"Single user message; builds an OpenAI chat-completions request and prints the assistant's reply. Only valid for OpenAI chat URLs and requires --name." oneof:"predict-input"`
+	Data    string `flag:"data" desc:"Inline request body, sent verbatim." oneof:"predict-input"`
+	File    string `flag:"file" desc:"Path to a file containing the request body, sent verbatim. Use '-' for stdin." oneof:"predict-input"`
+}

--- a/cmd/command.model_api.go
+++ b/cmd/command.model_api.go
@@ -9,22 +9,21 @@ var commandModelAPI = Command{
 		"Authentication is via 'baseten auth login' or the BASETEN_API_KEY environment variable.",
 	Children: []Command{
 		{
-			Name:    "fetch",
-			Summary: "Fetch a Model API",
-			Description: "Fetch a single Model API by name.\n\n" +
-				"The name is the stable, URL-safe slug used as the Model API's public identifier.",
-			Flags: ModelAPIFetchFlags{},
+			Name:        "fetch",
+			Summary:     "Fetch a Model API",
+			Description: "Fetch a single Model API by name.",
+			Flags:       ModelAPIFetchFlags{},
 			Output: &CommandOutput[managementapi.ModelAPI]{
 				TextDescription: "Field-per-line summary of the Model API.",
 				Examples: []CommandExample{
 					{
 						Description: "Fetch a Model API by name.",
-						Command:     "baseten model-api fetch --name <name>",
+						Command:     "baseten model-api fetch --model <name>",
 					},
 				},
 				JQExample: CommandExample{
 					Description: "Print the Model API's invoke URL.",
-					Command:     "baseten model-api fetch --name <name> --jq '.invoke_url'",
+					Command:     "baseten model-api fetch --model <name> --jq '.invoke_url'",
 				},
 			},
 		},
@@ -35,7 +34,7 @@ var commandModelAPI = Command{
 				"Pass --all to browse the full visible catalog instead of just the added ones.",
 			Flags: ModelAPIListFlags{},
 			Output: &CommandOutput[ModelAPIList]{
-				TextDescription: "Table with columns: NAME, DISPLAY NAME, FAMILY, CONTEXT, ADDED. " +
+				TextDescription: "Table with columns: NAME, CONTEXT, $/1M IN, $/1M OUT, ADDED. " +
 					"When no Model APIs match, prints \"No Model APIs found.\" to stderr.",
 				Examples: []CommandExample{
 					{
@@ -62,8 +61,8 @@ var commandModelAPI = Command{
 				"endpoint on the shared inference host. Override it for other shapes (e.g. " +
 				"/v1/messages, /v1/embeddings) or different hosts.\n\n" +
 				"--content is the simple path: it builds an OpenAI chat-completions body with a " +
-				"single user message and --name as the model, and prints just the assistant's " +
-				"reply. It is only valid for OpenAI chat URLs and requires --name.\n\n" +
+				"single user message and --model as the model, and prints just the assistant's " +
+				"reply. It is only valid for OpenAI chat URLs and requires --model.\n\n" +
 				"--data and --file send a request body verbatim, so any format the endpoint " +
 				"accepts works (OpenAI, Anthropic, embeddings, custom). The response is written " +
 				"as-is: JSON is pretty-printed, streams and binary bodies are passed through.",
@@ -77,16 +76,16 @@ var commandModelAPI = Command{
 				Examples: []CommandExample{
 					{
 						Description: "Send a single user message.",
-						Command:     `baseten model-api predict --name <name> --content "hello"`,
+						Command:     `baseten model-api predict --model <name> --content "hello"`,
 					},
 					{
 						Description: "Send a full OpenAI-shaped body and stream it as JSONL.",
-						Command:     `baseten model-api predict --name <name> --data '{"model":"<name>","messages":[{"role":"user","content":"hi"}],"stream":true}' --output jsonl`,
+						Command:     `baseten model-api predict --model <name> --data '{"model":"<name>","messages":[{"role":"user","content":"hi"}],"stream":true}' --output jsonl`,
 					},
 				},
 				JQExample: CommandExample{
 					Description: "Extract the assistant's message content.",
-					Command:     `baseten model-api predict --name <name> --content "hi" --jq '.choices[0].message.content'`,
+					Command:     `baseten model-api predict --model <name> --content "hi" --jq '.choices[0].message.content'`,
 				},
 			},
 		},
@@ -103,7 +102,7 @@ type ModelAPIList struct {
 type ModelAPIFetchFlags struct {
 	CommandFlags
 
-	Name string `flag:"name" desc:"Name of the Model API (its stable, URL-safe slug)." required:"true"`
+	Model string `flag:"model" desc:"Name of the Model API to fetch." required:"true"`
 }
 
 // ModelAPIListFlags configures `baseten model-api list`.
@@ -117,10 +116,10 @@ type ModelAPIListFlags struct {
 type ModelAPIPredictFlags struct {
 	CommandFlags
 
-	URL  string `flag:"url" desc:"Endpoint to POST the request to." default:"https://inference.baseten.co/v1/chat/completions"`
-	Name string `flag:"name" desc:"Name of the Model API (its stable, URL-safe slug). Required with --content, where it sets the request's model." `
+	URL   string `flag:"url" desc:"Endpoint to POST the request to. Defaults to https://inference.baseten.co/v1/chat/completions."`
+	Model string `flag:"model" desc:"Name of the Model API. Required with --content, where it sets the request's model." `
 
-	Content string `flag:"content" desc:"Single user message; builds an OpenAI chat-completions request and prints the assistant's reply. Only valid for OpenAI chat URLs and requires --name." oneof:"predict-input"`
+	Content string `flag:"content" desc:"Single user message; builds an OpenAI chat-completions request and prints the assistant's reply. Only valid for OpenAI chat URLs and requires --model." oneof:"predict-input"`
 	Data    string `flag:"data" desc:"Inline request body, sent verbatim." oneof:"predict-input"`
 	File    string `flag:"file" desc:"Path to a file containing the request body, sent verbatim. Use '-' for stdin." oneof:"predict-input"`
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.1.0
+	github.com/basetenlabs/baseten-go v0.1.1-0.20260612182021-5272680f54ac
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPn
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/basetenlabs/baseten-go v0.1.0 h1:jOnntq9cZP+8YBUN9G0hQx6Ms7A9F5ujLUNcPD9LsLE=
 github.com/basetenlabs/baseten-go v0.1.0/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.1.1-0.20260612182021-5272680f54ac h1:HdgJfIcH+PQpc0mPQQvcaMRsYHFUUPWbMWc78p53XHQ=
+github.com/basetenlabs/baseten-go v0.1.1-0.20260612182021-5272680f54ac/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,6 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.1.0 h1:jOnntq9cZP+8YBUN9G0hQx6Ms7A9F5ujLUNcPD9LsLE=
-github.com/basetenlabs/baseten-go v0.1.0/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/basetenlabs/baseten-go v0.1.1-0.20260612182021-5272680f54ac h1:HdgJfIcH+PQpc0mPQQvcaMRsYHFUUPWbMWc78p53XHQ=
 github.com/basetenlabs/baseten-go v0.1.1-0.20260612182021-5272680f54ac/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=

--- a/internal/cmd/command.model.go
+++ b/internal/cmd/command.model.go
@@ -131,7 +131,10 @@ func commandModelList(ctx *CommandContext, flags *cmd.ModelListFlags) error {
 			m.CreatedAt.UTC().Format(time.RFC3339),
 		})
 	}
-	ctx.OutputTable([]string{"ID", "NAME", "TEAM", "DEPLOYMENTS", "CREATED"}, rows)
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"ID", "NAME", "TEAM", "DEPLOYMENTS", "CREATED"},
+		Rows:    rows,
+	})
 	return nil
 }
 

--- a/internal/cmd/command.model_api.go
+++ b/internal/cmd/command.model_api.go
@@ -1,0 +1,252 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-cli/internal/auth"
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+)
+
+func init() {
+	Register("model-api fetch", commandModelAPIFetch)
+	Register("model-api list", commandModelAPIList)
+	Register("model-api predict", commandModelAPIPredict)
+}
+
+func commandModelAPIList(ctx *CommandContext, flags *cmd.ModelAPIListFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+
+	// The catalog is small, so walk every page and aggregate into one list
+	// rather than exposing cursors. By default restrict to the Model APIs the
+	// workspace has added; --all browses the full visible catalog.
+	params := managementapi.GetV1ModelApisParams{}
+	if !flags.All {
+		addedOnly := true
+		params.AddedOnly = &addedOnly
+	}
+	var items []managementapi.ModelAPI
+	for {
+		resp, err := cl.API().GetModelApis(ctx, params)
+		if err != nil {
+			return fmt.Errorf("list model APIs: %w", err)
+		}
+		items = append(items, resp.Items...)
+		if !resp.Pagination.HasMore || resp.Pagination.Cursor == nil {
+			break
+		}
+		params.Cursor = resp.Pagination.Cursor
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(cmd.ModelAPIList{Items: items})
+		return nil
+	}
+	if len(items) == 0 {
+		ctx.LogLine("No Model APIs found.")
+		return nil
+	}
+	rows := make([][]string, 0, len(items))
+	for _, m := range items {
+		family := ""
+		if m.ModelFamily != nil {
+			family = *m.ModelFamily
+		}
+		added := ""
+		if m.OrgDetails != nil {
+			added = "yes"
+		}
+		rows = append(rows, []string{
+			m.Name, m.DisplayName, family, fmt.Sprintf("%d", m.ContextLength), added,
+		})
+	}
+	ctx.OutputTable([]string{"NAME", "DISPLAY NAME", "FAMILY", "CONTEXT", "ADDED"}, rows)
+	return nil
+}
+
+func commandModelAPIFetch(ctx *CommandContext, flags *cmd.ModelAPIFetchFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	m, err := cl.API().GetModelApisModelApiName(ctx, flags.Name)
+	if err != nil {
+		return fmt.Errorf("fetch model API %s: %w", flags.Name, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(m)
+		return nil
+	}
+	ctx.Outputf("Name:            %s\n", m.Name)
+	ctx.Outputf("Display Name:    %s\n", m.DisplayName)
+	if m.ModelFamily != nil {
+		ctx.Outputf("Family:          %s\n", *m.ModelFamily)
+	}
+	if m.Description != "" {
+		ctx.Outputf("Description:     %s\n", m.Description)
+	}
+	ctx.Outputf("Release Date:    %s\n", m.ReleaseDate)
+	ctx.Outputf("Context Length:  %d\n", m.ContextLength)
+	ctx.Outputf("Input Cost:      $%s / 1M tokens\n", modelAPICurrencyString(m.CostPerMillionInputTokens))
+	ctx.Outputf("Output Cost:     $%s / 1M tokens\n", modelAPICurrencyString(m.CostPerMillionOutputTokens))
+	ctx.Outputf("Invoke URL:      %s\n", m.InvokeUrl)
+	if len(m.RateLimits) > 0 {
+		ctx.Outputf("Rate Limits:     %s\n", modelAPIRateLimitsString(m.RateLimits))
+	}
+	if m.OrgDetails != nil {
+		ctx.Outputf("Added:           %s\n", m.OrgDetails.AddedAt.UTC().Format(time.RFC3339))
+		if m.OrgDetails.LastUsedAt != nil {
+			ctx.Outputf("Last Used:       %s\n", m.OrgDetails.LastUsedAt.UTC().Format(time.RFC3339))
+		}
+	}
+	return nil
+}
+
+func commandModelAPIPredict(ctx *CommandContext, flags *cmd.ModelAPIPredictFlags) error {
+	payload, err := modelAPIPredictBody(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	// Build a transport that injects the active credential, then POST straight
+	// to --url. No management lookup is needed: the model is selected by the
+	// request body, not the URL path.
+	store, err := NewAuthStore(false)
+	if err != nil {
+		return err
+	}
+	// TODO(cretz): https://github.com/basetenlabs/baseten-cli/pull/17 reworks client
+	// and auth construction. Once it lands, build this transport via the shared helper
+	// rather than duplicating NewManagementClient's setup here.
+	transport := &auth.Transport{
+		Store:       store,
+		Host:        ctx.Remote.RemoteURL(),
+		OAuthConfig: OAuthConfig(ctx.Remote.ManagementURL()),
+		EnvAPIKey:   os.Getenv("BASETEN_API_KEY"),
+		Base:        ctx.httpClient().Transport,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, flags.URL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := transport.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// --content opts into chat-aware text output: print just the assistant's
+	// reply. Under --output json the full response is emitted via the verbatim
+	// path below.
+	if flags.Content != "" && !ctx.JSON {
+		return writeModelAPIChatText(ctx, resp)
+	}
+
+	// Verbatim path: hand the response to the shared predict writer, which
+	// pretty-prints JSON and passes streams and binary bodies through.
+	contentType := strings.TrimSpace(strings.SplitN(resp.Header.Get("Content-Type"), ";", 2)[0])
+	streaming := false
+	for _, te := range resp.TransferEncoding {
+		if te == "chunked" {
+			streaming = true
+		}
+	}
+	return writePredictResponse(ctx, &predictResponse{
+		body:        &statusAwareBody{ReadCloser: resp.Body, status: resp.StatusCode},
+		contentType: contentType,
+		streaming:   streaming,
+	})
+}
+
+// modelAPIPredictBody resolves the request body from exactly one of --content,
+// --data, or --file. --content builds a single-message OpenAI chat-completions
+// request with --name as the model; --data and --file are verbatim.
+func modelAPIPredictBody(ctx *CommandContext, flags *cmd.ModelAPIPredictFlags) ([]byte, error) {
+	switch {
+	case flags.Content != "":
+		if flags.Name == "" {
+			return nil, cmd.NewErrUsagef("--content requires --name")
+		}
+		return json.Marshal(map[string]any{
+			"model": flags.Name,
+			"messages": []map[string]string{
+				{"role": "user", "content": flags.Content},
+			},
+		})
+	case flags.Data != "":
+		return []byte(flags.Data), nil
+	case flags.File == "-":
+		body, err := io.ReadAll(ctx.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading stdin: %w", err)
+		}
+		return body, nil
+	case flags.File != "":
+		body, err := os.ReadFile(flags.File)
+		if err != nil {
+			return nil, fmt.Errorf("opening input file: %w", err)
+		}
+		return body, nil
+	default:
+		return nil, cmd.NewErrUsagef("one of --content, --data, or --file is required")
+	}
+}
+
+// writeModelAPIChatText prints the assistant message from an OpenAI
+// chat-completions response. Non-2xx responses and bodies that don't match the
+// expected shape are surfaced as-is.
+func writeModelAPIChatText(ctx *CommandContext, resp *http.Response) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		ctx.Log(string(body))
+		return fmt.Errorf("request failed with status %d", resp.StatusCode)
+	}
+	var parsed struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil || len(parsed.Choices) == 0 {
+		// Not the expected chat shape; pass the body through unchanged.
+		ctx.Output(string(body))
+		return nil
+	}
+	ctx.OutputLine(parsed.Choices[0].Message.Content)
+	return nil
+}
+
+// modelAPICurrencyString renders a cost union (number or string) as a plain
+// decimal string, dropping the JSON quoting when the value arrives as a string.
+func modelAPICurrencyString(m json.Marshaler) string {
+	b, err := m.MarshalJSON()
+	if err != nil {
+		return ""
+	}
+	return strings.Trim(string(b), `"`)
+}
+
+func modelAPIRateLimitsString(limits []managementapi.RateLimit) string {
+	parts := make([]string, 0, len(limits))
+	for _, l := range limits {
+		parts = append(parts, fmt.Sprintf("%d per %s (%s)", l.Threshold, l.Unit, l.Type))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/cmd/command.model_api.go
+++ b/internal/cmd/command.model_api.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/basetenlabs/baseten-cli/cmd"
-	"github.com/basetenlabs/baseten-cli/internal/auth"
 	"github.com/basetenlabs/baseten-go/client/managementapi"
 )
 
@@ -58,19 +57,22 @@ func commandModelAPIList(ctx *CommandContext, flags *cmd.ModelAPIListFlags) erro
 	}
 	rows := make([][]string, 0, len(items))
 	for _, m := range items {
-		family := ""
-		if m.ModelFamily != nil {
-			family = *m.ModelFamily
-		}
 		added := ""
 		if m.OrgDetails != nil {
 			added = "yes"
 		}
 		rows = append(rows, []string{
-			m.Name, m.DisplayName, family, fmt.Sprintf("%d", m.ContextLength), added,
+			m.Name, fmt.Sprintf("%d", m.ContextLength),
+			modelAPICurrencyString(m.CostPerMillionInputTokens),
+			modelAPICurrencyString(m.CostPerMillionOutputTokens),
+			added,
 		})
 	}
-	ctx.OutputTable([]string{"NAME", "DISPLAY NAME", "FAMILY", "CONTEXT", "ADDED"}, rows)
+	ctx.OutputTable(TableOutput{
+		Headers:             []string{"NAME", "CONTEXT", "$/1M IN", "$/1M OUT", "ADDED"},
+		Rows:                rows,
+		RightAlignedColumns: []int{1, 2, 3},
+	})
 	return nil
 }
 
@@ -79,9 +81,9 @@ func commandModelAPIFetch(ctx *CommandContext, flags *cmd.ModelAPIFetchFlags) er
 	if err != nil {
 		return err
 	}
-	m, err := cl.API().GetModelApisModelApiName(ctx, flags.Name)
+	m, err := cl.API().GetModelApisModelApiName(ctx, flags.Model)
 	if err != nil {
-		return fmt.Errorf("fetch model API %s: %w", flags.Name, err)
+		return fmt.Errorf("fetch model API %s: %w", flags.Model, err)
 	}
 
 	if ctx.JSON {
@@ -120,24 +122,20 @@ func commandModelAPIPredict(ctx *CommandContext, flags *cmd.ModelAPIPredictFlags
 	}
 
 	// Build a transport that injects the active credential, then POST straight
-	// to --url. No management lookup is needed: the model is selected by the
-	// request body, not the URL path.
-	store, err := NewAuthStore(false)
+	// to the target URL. No management lookup is needed: the model is selected
+	// by the request body, not the URL path.
+	transport, remote, err := ctx.AuthTransport()
 	if err != nil {
 		return err
 	}
-	// TODO(cretz): https://github.com/basetenlabs/baseten-cli/pull/17 reworks client
-	// and auth construction. Once it lands, build this transport via the shared helper
-	// rather than duplicating NewManagementClient's setup here.
-	transport := &auth.Transport{
-		Store:       store,
-		Host:        ctx.Remote.RemoteURL(),
-		OAuthConfig: OAuthConfig(ctx.Remote.ManagementURL()),
-		EnvAPIKey:   os.Getenv("BASETEN_API_KEY"),
-		Base:        ctx.httpClient().Transport,
+
+	// Default to the remote's chat-completions endpoint when --url is unset.
+	url := flags.URL
+	if url == "" {
+		url = remote.ModelAPIInferenceURL() + "/v1/chat/completions"
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, flags.URL, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
@@ -173,15 +171,15 @@ func commandModelAPIPredict(ctx *CommandContext, flags *cmd.ModelAPIPredictFlags
 
 // modelAPIPredictBody resolves the request body from exactly one of --content,
 // --data, or --file. --content builds a single-message OpenAI chat-completions
-// request with --name as the model; --data and --file are verbatim.
+// request with --model as the model; --data and --file are verbatim.
 func modelAPIPredictBody(ctx *CommandContext, flags *cmd.ModelAPIPredictFlags) ([]byte, error) {
 	switch {
 	case flags.Content != "":
-		if flags.Name == "" {
-			return nil, cmd.NewErrUsagef("--content requires --name")
+		if flags.Model == "" {
+			return nil, cmd.NewErrUsagef("--content requires --model")
 		}
 		return json.Marshal(map[string]any{
-			"model": flags.Name,
+			"model": flags.Model,
 			"messages": []map[string]string{
 				{"role": "user", "content": flags.Content},
 			},

--- a/internal/cmd/command.model_api_test.go
+++ b/internal/cmd/command.model_api_test.go
@@ -41,11 +41,16 @@ func Test_ModelApi_List_Rows(t *testing.T) {
 	h.Require.NoError(h.Execute("model-api", "list"))
 	out := h.Stdout.String()
 	h.Require.Contains(out, "NAME")
-	h.Require.Contains(out, "DISPLAY NAME")
 	h.Require.Contains(out, "CONTEXT")
+	h.Require.Contains(out, "$/1M IN")
+	h.Require.Contains(out, "$/1M OUT")
 	h.Require.Contains(out, "llama-3")
-	h.Require.Contains(out, "Llama 3")
 	h.Require.Contains(out, "8192")
+	h.Require.Contains(out, "0.5")
+	h.Require.Contains(out, "1.5")
+	// Display name and family were dropped from the list table.
+	h.Require.NotContains(out, "DISPLAY NAME")
+	h.Require.NotContains(out, "Llama 3")
 }
 
 func Test_ModelApi_List_JSON(t *testing.T) {
@@ -117,7 +122,7 @@ func Test_ModelApi_Fetch_Text(t *testing.T) {
 	fixture["rate_limits"] = []any{map[string]any{"threshold": 100, "type": "requests", "unit": "minute"}}
 	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/llama-3", 200, fixture)
 
-	h.Require.NoError(h.Execute("model-api", "fetch", "--name", "llama-3"))
+	h.Require.NoError(h.Execute("model-api", "fetch", "--model", "llama-3"))
 	out := h.Stdout.String()
 	h.Require.Contains(out, "Name:")
 	h.Require.Contains(out, "llama-3")
@@ -132,7 +137,7 @@ func Test_ModelApi_Fetch_JSON(t *testing.T) {
 	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/llama-3", 200,
 		modelAPIFixture("llama-3", "Llama 3", "llama"))
 
-	h.Require.NoError(h.Execute("model-api", "fetch", "--name", "llama-3", "--output", "json"))
+	h.Require.NoError(h.Execute("model-api", "fetch", "--model", "llama-3", "--output", "json"))
 	h.Require.Contains(h.Stdout.String(), `"name": "llama-3"`)
 }
 
@@ -144,7 +149,7 @@ func Test_ModelApi_Predict_Content(t *testing.T) {
 	})
 
 	err := h.Execute("model-api", "predict", "--url", m.URL+"/v1/chat/completions",
-		"--name", "llama-3", "--content", "hi")
+		"--model", "llama-3", "--content", "hi")
 	h.Require.NoError(err)
 	h.Require.Equal("hello there\n", h.Stdout.String())
 
@@ -162,15 +167,15 @@ func Test_ModelApi_Predict_ContentJSONFullEnvelope(t *testing.T) {
 	})
 
 	err := h.Execute("model-api", "predict", "--url", m.URL+"/v1/chat/completions",
-		"--name", "llama-3", "--content", "hi", "--output", "json")
+		"--model", "llama-3", "--content", "hi", "--output", "json")
 	h.Require.NoError(err)
 	h.Require.Contains(h.Stdout.String(), `"choices"`)
 }
 
-func Test_ModelApi_Predict_ContentRequiresName(t *testing.T) {
+func Test_ModelApi_Predict_ContentRequiresModel(t *testing.T) {
 	h := NewCommandHarness(t)
 	err := h.Execute("model-api", "predict", "--content", "hi")
-	h.Require.ErrorContains(err, "--content requires --name")
+	h.Require.ErrorContains(err, "--content requires --model")
 }
 
 func Test_ModelApi_Predict_DataVerbatim(t *testing.T) {
@@ -190,12 +195,12 @@ func Test_ModelApi_Predict_DataVerbatim(t *testing.T) {
 
 func Test_ModelApi_Predict_InputRequired(t *testing.T) {
 	h := NewCommandHarness(t)
-	err := h.Execute("model-api", "predict", "--name", "llama-3")
+	err := h.Execute("model-api", "predict", "--model", "llama-3")
 	h.Require.Error(err)
 }
 
 func Test_ModelApi_Predict_InputExclusive(t *testing.T) {
 	h := NewCommandHarness(t)
-	err := h.Execute("model-api", "predict", "--name", "llama-3", "--content", "hi", "--data", "{}")
+	err := h.Execute("model-api", "predict", "--model", "llama-3", "--content", "hi", "--data", "{}")
 	h.Require.Error(err)
 }

--- a/internal/cmd/command.model_api_test.go
+++ b/internal/cmd/command.model_api_test.go
@@ -1,0 +1,201 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func modelAPIFixture(name, display, family string) map[string]any {
+	return map[string]any{
+		"name":                           name,
+		"display_name":                   display,
+		"description":                    "A test Model API.",
+		"model_family":                   family,
+		"release_date":                   "2025-01-01",
+		"context_length":                 8192,
+		"cost_per_million_input_tokens":  0.5,
+		"cost_per_million_output_tokens": 1.5,
+		"invoke_url":                     "https://inference.baseten.co",
+		"rate_limits":                    []any{},
+	}
+}
+
+func Test_ModelApi_List_Empty(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis", 200,
+		map[string]any{"items": []any{}, "pagination": map[string]any{"has_more": false}})
+
+	h.Require.NoError(h.Execute("model-api", "list"))
+	h.Require.Equal("", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "No Model APIs found.")
+}
+
+func Test_ModelApi_List_Rows(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis", 200, map[string]any{
+		"items":      []any{modelAPIFixture("llama-3", "Llama 3", "llama")},
+		"pagination": map[string]any{"has_more": false},
+	})
+
+	h.Require.NoError(h.Execute("model-api", "list"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "NAME")
+	h.Require.Contains(out, "DISPLAY NAME")
+	h.Require.Contains(out, "CONTEXT")
+	h.Require.Contains(out, "llama-3")
+	h.Require.Contains(out, "Llama 3")
+	h.Require.Contains(out, "8192")
+}
+
+func Test_ModelApi_List_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis", 200, map[string]any{
+		"items":      []any{modelAPIFixture("llama-3", "Llama 3", "llama")},
+		"pagination": map[string]any{"has_more": false},
+	})
+
+	h.Require.NoError(h.Execute("model-api", "list", "--output", "json"))
+	h.Require.Contains(h.Stdout.String(), `"name": "llama-3"`)
+}
+
+func Test_ModelApi_List_DefaultRestrictsToAdded(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	var query []string
+	m.SetRouteFunc("GET", "/v1/model_apis", func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.Query()["added_only"]
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}, "pagination": map[string]any{"has_more": false}})
+	})
+
+	h.Require.NoError(h.Execute("model-api", "list"))
+	h.Require.Equal([]string{"true"}, query)
+}
+
+func Test_ModelApi_List_AllBrowsesCatalog(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	var query []string
+	m.SetRouteFunc("GET", "/v1/model_apis", func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.Query()["added_only"]
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}, "pagination": map[string]any{"has_more": false}})
+	})
+
+	h.Require.NoError(h.Execute("model-api", "list", "--all"))
+	h.Require.Empty(query)
+}
+
+func Test_ModelApi_List_Paginates(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRouteFunc("GET", "/v1/model_apis", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items":      []any{modelAPIFixture("a", "A", "fam")},
+				"pagination": map[string]any{"has_more": true, "cursor": "page2"},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items":      []any{modelAPIFixture("b", "B", "fam")},
+			"pagination": map[string]any{"has_more": false},
+		})
+	})
+
+	h.Require.NoError(h.Execute("model-api", "list"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "a")
+	h.Require.Contains(out, "b")
+}
+
+func Test_ModelApi_Fetch_Text(t *testing.T) {
+	h := NewCommandHarness(t)
+	fixture := modelAPIFixture("llama-3", "Llama 3", "llama")
+	fixture["rate_limits"] = []any{map[string]any{"threshold": 100, "type": "requests", "unit": "minute"}}
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/llama-3", 200, fixture)
+
+	h.Require.NoError(h.Execute("model-api", "fetch", "--name", "llama-3"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "Name:")
+	h.Require.Contains(out, "llama-3")
+	h.Require.Contains(out, "Context Length:")
+	h.Require.Contains(out, "8192")
+	h.Require.Contains(out, "$0.5 / 1M tokens")
+	h.Require.Contains(out, "100 per minute (requests)")
+}
+
+func Test_ModelApi_Fetch_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/llama-3", 200,
+		modelAPIFixture("llama-3", "Llama 3", "llama"))
+
+	h.Require.NoError(h.Execute("model-api", "fetch", "--name", "llama-3", "--output", "json"))
+	h.Require.Contains(h.Stdout.String(), `"name": "llama-3"`)
+}
+
+func Test_ModelApi_Predict_Content(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", "/v1/chat/completions", 200, map[string]any{
+		"choices": []any{map[string]any{"message": map[string]any{"role": "assistant", "content": "hello there"}}},
+	})
+
+	err := h.Execute("model-api", "predict", "--url", m.URL+"/v1/chat/completions",
+		"--name", "llama-3", "--content", "hi")
+	h.Require.NoError(err)
+	h.Require.Equal("hello there\n", h.Stdout.String())
+
+	call := m.FindCall("POST", "/v1/chat/completions")
+	h.Require.NotNil(call)
+	body := call.BodyJSON(t)
+	h.Require.Equal("llama-3", body["model"])
+}
+
+func Test_ModelApi_Predict_ContentJSONFullEnvelope(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", "/v1/chat/completions", 200, map[string]any{
+		"choices": []any{map[string]any{"message": map[string]any{"content": "hi"}}},
+	})
+
+	err := h.Execute("model-api", "predict", "--url", m.URL+"/v1/chat/completions",
+		"--name", "llama-3", "--content", "hi", "--output", "json")
+	h.Require.NoError(err)
+	h.Require.Contains(h.Stdout.String(), `"choices"`)
+}
+
+func Test_ModelApi_Predict_ContentRequiresName(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model-api", "predict", "--content", "hi")
+	h.Require.ErrorContains(err, "--content requires --name")
+}
+
+func Test_ModelApi_Predict_DataVerbatim(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", "/v1/chat/completions", 200, map[string]any{"ok": true})
+
+	err := h.Execute("model-api", "predict", "--url", m.URL+"/v1/chat/completions",
+		"--data", `{"model":"x","messages":[]}`)
+	h.Require.NoError(err)
+
+	call := m.FindCall("POST", "/v1/chat/completions")
+	h.Require.NotNil(call)
+	h.Require.Equal(`{"model":"x","messages":[]}`, call.Body)
+	h.Require.Contains(h.Stdout.String(), `"ok"`)
+}
+
+func Test_ModelApi_Predict_InputRequired(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model-api", "predict", "--name", "llama-3")
+	h.Require.Error(err)
+}
+
+func Test_ModelApi_Predict_InputExclusive(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model-api", "predict", "--name", "llama-3", "--content", "hi", "--data", "{}")
+	h.Require.Error(err)
+}

--- a/internal/cmd/command.model_deployment.go
+++ b/internal/cmd/command.model_deployment.go
@@ -68,10 +68,10 @@ func commandModelDeploymentList(ctx *CommandContext, flags *cmd.ModelDeploymentL
 			d.CreatedAt.UTC().Format(time.RFC3339),
 		})
 	}
-	ctx.OutputTable(
-		[]string{"ID", "NAME", "ENVIRONMENT", "STATUS", "INSTANCE", "REPLICAS", "CREATED"},
-		rows,
-	)
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"ID", "NAME", "ENVIRONMENT", "STATUS", "INSTANCE", "REPLICAS", "CREATED"},
+		Rows:    rows,
+	})
 	return nil
 }
 

--- a/internal/cmd/command.model_environment.go
+++ b/internal/cmd/command.model_environment.go
@@ -44,10 +44,10 @@ func commandModelEnvironmentList(ctx *CommandContext, flags *cmd.ModelEnvironmen
 			string(e.CurrentDeployment.Status),
 		})
 	}
-	ctx.OutputTable(
-		[]string{"NAME", "CURRENT DEPLOYMENT", "STATUS"},
-		rows,
-	)
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"NAME", "CURRENT DEPLOYMENT", "STATUS"},
+		Rows:    rows,
+	})
 	return nil
 }
 

--- a/internal/cmd/command.org_apikey.go
+++ b/internal/cmd/command.org_apikey.go
@@ -61,7 +61,10 @@ func commandOrgAPIKeyList(ctx *CommandContext, _ *cmd.OrgAPIKeyListFlags) error 
 		}
 		rows = append(rows, []string{name, k.Prefix + "****", apiKeyTypeFromBackend[k.Type], team})
 	}
-	ctx.OutputTable([]string{"NAME", "KEY", "TYPE", "TEAM"}, rows)
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"NAME", "KEY", "TYPE", "TEAM"},
+		Rows:    rows,
+	})
 	return nil
 }
 

--- a/internal/cmd/command.org_secret.go
+++ b/internal/cmd/command.org_secret.go
@@ -50,7 +50,10 @@ func commandOrgSecretList(ctx *CommandContext, flags *cmd.OrgSecretListFlags) er
 	for _, s := range secrets.Secrets {
 		rows = append(rows, []string{s.Name, s.TeamName, s.CreatedAt.UTC().Format(time.RFC3339)})
 	}
-	ctx.OutputTable([]string{"NAME", "TEAM", "CREATED"}, rows)
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"NAME", "TEAM", "CREATED"},
+		Rows:    rows,
+	})
 	return nil
 }
 

--- a/internal/cmd/command_context.go
+++ b/internal/cmd/command_context.go
@@ -128,10 +128,23 @@ func (c *CommandContext) NewJSONArrayWriter() *JSONArrayWriter {
 	}
 }
 
+// TableOutput describes a borderless table for OutputTable.
+type TableOutput struct {
+	Headers []string
+	Rows    [][]string
+	// RightAlignedColumns lists column indices whose header and cells are
+	// right-aligned; columns absent from the list default to left-aligned.
+	RightAlignedColumns []int
+}
+
 // OutputTable writes a borderless table to stdout with bold headers. Header
 // styling auto-degrades when stdout is not a terminal.
-func (c *CommandContext) OutputTable(headers []string, rows [][]string) {
+func (c *CommandContext) OutputTable(out TableOutput) {
 	renderer := lipgloss.NewRenderer(c.Stdout)
+	rightAligned := make(map[int]bool, len(out.RightAlignedColumns))
+	for _, col := range out.RightAlignedColumns {
+		rightAligned[col] = true
+	}
 	headerStyle := renderer.NewStyle().Bold(true).PaddingRight(2)
 	cellStyle := renderer.NewStyle().PaddingRight(2)
 	t := table.New().
@@ -143,13 +156,17 @@ func (c *CommandContext) OutputTable(headers []string, rows [][]string) {
 		BorderHeader(false).
 		BorderColumn(false).
 		BorderRow(false).
-		Headers(headers...).
-		Rows(rows...).
-		StyleFunc(func(row, _ int) lipgloss.Style {
+		Headers(out.Headers...).
+		Rows(out.Rows...).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			style := cellStyle
 			if row == table.HeaderRow {
-				return headerStyle
+				style = headerStyle
 			}
-			return cellStyle
+			if rightAligned[col] {
+				style = style.Align(lipgloss.Right)
+			}
+			return style
 		})
 	panicOnOutputError(fmt.Fprintln(c.Stdout, t.Render()))
 }
@@ -330,25 +347,36 @@ func NewAuthStore(insecureStorage bool) (*auth.Store, error) {
 	}), nil
 }
 
-// NewManagementClient creates a management API client that resolves
-// credentials via the auth store (env var > stored credential).
-func (c *CommandContext) NewManagementClient() (*client.ManagementClient, error) {
+// AuthTransport builds an HTTP transport that injects the active session's
+// credential on every request, regardless of the request host. Shared by the
+// SDK clients and by commands that POST to non-SDK hosts (e.g. a Model API URL).
+// The resolved remote is returned alongside so callers can derive URLs without
+// resolving it again.
+func (c *CommandContext) AuthTransport() (*auth.Transport, *Remote, error) {
 	remote, err := c.authInfo.Remote()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	session, err := c.authInfo.Session()
 	if err != nil {
+		return nil, nil, err
+	}
+	return &auth.Transport{
+		Session:     session,
+		OAuthConfig: OAuthConfig(remote.ManagementURL()),
+		Base:        c.httpClient().Transport,
+	}, remote, nil
+}
+
+// NewManagementClient creates a management API client that resolves
+// credentials via the auth store (env var > stored credential).
+func (c *CommandContext) NewManagementClient() (*client.ManagementClient, error) {
+	transport, remote, err := c.AuthTransport()
+	if err != nil {
 		return nil, err
 	}
-	mgmtURL := remote.ManagementURL()
-	transport := &auth.Transport{
-		Session:     session,
-		OAuthConfig: OAuthConfig(mgmtURL),
-		Base:        c.httpClient().Transport,
-	}
 	return client.NewManagementClient(client.ManagementClientOptions{
-		BaseURL:    mgmtURL,
+		BaseURL:    remote.ManagementURL(),
 		DeferAuth:  true,
 		HTTPClient: transport,
 	})
@@ -371,19 +399,9 @@ func (c *CommandContext) NewManagementClientWithAuth(mgmtURL, authHeader string)
 // NewInferenceClient creates an inference API client that resolves
 // credentials via the auth store.
 func (c *CommandContext) NewInferenceClient(flags cmd.InferenceClientFlags) (*client.InferenceClient, error) {
-	remote, err := c.authInfo.Remote()
+	transport, remote, err := c.AuthTransport()
 	if err != nil {
 		return nil, err
-	}
-	session, err := c.authInfo.Session()
-	if err != nil {
-		return nil, err
-	}
-	mgmtURL := remote.ManagementURL()
-	transport := &auth.Transport{
-		Session:     session,
-		OAuthConfig: OAuthConfig(mgmtURL),
-		Base:        c.httpClient().Transport,
 	}
 	baseURL, err := remote.InferenceBaseURL(flags.ModelID, flags.ChainID, flags.Environment)
 	if err != nil {

--- a/internal/cmd/remote.go
+++ b/internal/cmd/remote.go
@@ -13,13 +13,14 @@ import (
 // to derive every URL the CLI talks to. Construct once via NewRemote at the
 // start of a command; callers use the methods rather than reading env directly.
 type Remote struct {
-	remoteURL           string
-	scheme              string
-	baseHost            string
-	hostLabel           string
-	managementAPIHost   string
-	inferenceBaseURL    string
-	inferenceHostSuffix string
+	remoteURL             string
+	scheme                string
+	baseHost              string
+	hostLabel             string
+	managementAPIHost     string
+	inferenceBaseURL      string
+	inferenceHostSuffix   string
+	inferenceModelAPIHost string
 }
 
 // NewRemote resolves the remote URL (flag arg, then BASETEN_REMOTE_URL, then
@@ -48,16 +49,21 @@ func NewRemote(remoteURL string) (*Remote, error) {
 	switch r.remoteURL {
 	case "https://app.baseten.co":
 		r.managementAPIHost = "api.baseten.co"
+		r.inferenceModelAPIHost = "inference.baseten.co"
 	case "https://app.staging.baseten.co":
 		r.managementAPIHost = "api.staging.baseten.co"
+		r.inferenceModelAPIHost = "inference.staging.baseten.co"
 	case "https://app.dev.baseten.co":
 		r.managementAPIHost = "api.mc-dev.baseten.co"
+		r.inferenceModelAPIHost = "inference.mc-dev.baseten.co"
 	case "http://localhost:8000":
 		r.managementAPIHost = "api.localhost:8000"
 		r.inferenceBaseURL = "http://localhost:9090"
 		r.inferenceHostSuffix = "api.dev.baseten.co"
+		r.inferenceModelAPIHost = "localhost:9090"
 	default:
 		r.managementAPIHost = "api." + r.baseHost
+		r.inferenceModelAPIHost = "inference." + r.baseHost
 	}
 
 	if v := os.Getenv("BASETEN_MANAGEMENT_API_URL_OVERRIDE"); v != "" {
@@ -87,6 +93,13 @@ func (r *Remote) HostLabel() string { return r.hostLabel }
 // ManagementURL returns the base URL for the REST management API.
 func (r *Remote) ManagementURL() string {
 	return r.scheme + "://" + r.managementAPIHost
+}
+
+// ModelAPIInferenceURL returns the base URL for Model API (shared endpoint)
+// inference on this remote, e.g. https://inference.baseten.co. OpenAI-shaped
+// routes (e.g. /v1/chat/completions) live underneath it.
+func (r *Remote) ModelAPIInferenceURL() string {
+	return r.scheme + "://" + r.inferenceModelAPIHost
 }
 
 // InferenceBaseURL returns the base URL (no path) for inference calls. When

--- a/internal/e2e-tests/model_test.go
+++ b/internal/e2e-tests/model_test.go
@@ -303,8 +303,8 @@ func (l *lifecycle) Logs(t *testing.T) {
 		return lines
 	}
 
-	// Loki can lag a few seconds after the deployment goes ACTIVE; poll until
-	// the info marker lands.
+	// Loki can lag well past the deployment going ACTIVE before the load()
+	// log lines are queryable; poll generously until the info marker lands.
 	var lines []logLine
 	require.Eventually(t, func() bool {
 		got, err := l.collectLogs(t)
@@ -313,7 +313,7 @@ func (l *lifecycle) Logs(t *testing.T) {
 		}
 		lines = got
 		return contains(lines, e2eLogInfoWord)
-	}, 10*time.Second, time.Second, "info log line never appeared")
+	}, 90*time.Second, 3*time.Second, "info log line never appeared")
 
 	t.Run("AllLevels", func(t *testing.T) {
 		require.True(t, contains(lines, e2eLogInfoWord), "info line missing")


### PR DESCRIPTION
## :rocket: What

Adds the `model-api` command group: `fetch` (single Model API by name), `list` (workspace-added, `--all` for full catalog), and `predict` (inference via `--content`, or verbatim `--data`/`--file`)

Depends on https://github.com/basetenlabs/baseten-go/pull/9

## :computer: How

Management client for fetch/list, direct inference POST for predict (model selected by `--model`). List renders `NAME` / `CONTEXT` / `$/1M IN` / `$/1M OUT` / `ADDED` with cost columns right-aligned via a new `TableOutput` struct on `OutputTable`.

## :microscope: Testing

Unit tests cover list (rows, JSON, pagination, added-only), fetch (text/JSON), and predict (content, verbatim, validation). `go test ./...` green.