### PR TITLE
Remove --promote flag from model push

### DIFF
--- a/cmd/command.model.go
+++ b/cmd/command.model.go
@@ -183,8 +183,7 @@ type ModelPushFlags struct {
 
 	DryRun bool `flag:"dry-run" desc:"Validate the push and request upload credentials without uploading or creating anything."`
 
-	Promote        bool   `flag:"promote" desc:"Promote the new deployment to the production environment."`
-	Environment    string `flag:"environment" desc:"Stable environment to push to. Mutually exclusive with --promote."`
+	Environment    string `flag:"environment" desc:"Stable environment to push to."`
 	DeploymentName string `flag:"deployment-name" desc:"Human-readable name for the new deployment."`
 
 	NoBuildCache bool   `flag:"no-build-cache" desc:"Force a full rebuild without using cached layers."`

--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -34,9 +34,6 @@ func init() {
 }
 
 func commandModelPush(ctx *CommandContext, flags *cmd.ModelPushFlags) error {
-	if flags.Promote && flags.Environment != "" {
-		return cmd.NewErrUsagef("--promote and --environment are mutually exclusive")
-	}
 	if flags.Watch || flags.WatchHotReload || flags.WatchKeepalive {
 		return errors.New("--watch, --watch-hot-reload, and --watch-keepalive are not yet implemented")
 	}
@@ -260,11 +257,7 @@ func applyModelPushEnvironmentFlags(deployment *managementapi.DeploymentArchiveP
 		name := flags.DeploymentName
 		deployment.DeploymentName = &name
 	}
-	switch {
-	case flags.Promote:
-		env := "production"
-		deployment.EnvironmentName = &env
-	case flags.Environment != "":
+	if flags.Environment != "" {
 		env := flags.Environment
 		deployment.EnvironmentName = &env
 	}

--- a/internal/cmd/command.model_push_test.go
+++ b/internal/cmd/command.model_push_test.go
@@ -402,13 +402,6 @@ func Test_Model_Push_Validation(t *testing.T) {
 		h.Require.ErrorContains(err, "model_name is required")
 	})
 
-	t.Run("promote_and_environment", func(t *testing.T) {
-		h := newModelPushHarness(t)
-		dir := h.WriteModelDir(modelPushMinimalConfig)
-		err := h.Execute("model", "push", "--dir", dir, "--promote", "--environment", "staging")
-		h.Require.ErrorContains(err, "mutually exclusive")
-	})
-
 	t.Run("labels_invalid_json", func(t *testing.T) {
 		h := newModelPushHarness(t)
 		dir := h.WriteModelDir(modelPushMinimalConfig)

--- a/internal/e2e-tests/model_test.go
+++ b/internal/e2e-tests/model_test.go
@@ -45,7 +45,7 @@ type lifecycle struct {
 }
 
 // newLifecycle runs the env-gate, materializes the truss source, performs the
-// initial --promote push, and registers cleanup. Fatals on setup failure so
+// initial push to production, and registers cleanup. Fatals on setup failure so
 // sub-tests can assume valid state.
 func newLifecycle(t *testing.T) *lifecycle {
 	apiKey := os.Getenv("BASETEN_E2E_TEST_API_KEY")
@@ -80,7 +80,7 @@ func newLifecycle(t *testing.T) *lifecycle {
 		}
 	})
 
-	pushOut := mustCLI(t, "model", "push", "--dir", l.modelDir, "--promote", "--wait", "--output", "json")
+	pushOut := mustCLI(t, "model", "push", "--dir", l.modelDir, "--environment", "production", "--wait", "--output", "json")
 	var initial pushedDeployment
 	require.NoError(t, json.Unmarshal([]byte(pushOut), &initial))
 	require.Equal(t, l.modelName, initial.Model.Name)
@@ -426,7 +426,7 @@ func (l *lifecycle) ModelPredict(t *testing.T) {
 }
 
 func (l *lifecycle) Redeploy(t *testing.T) {
-	out := mustCLI(t, "model", "push", "--dir", l.modelDir, "--promote", "--wait", "--output", "json")
+	out := mustCLI(t, "model", "push", "--dir", l.modelDir, "--environment", "production", "--wait", "--output", "json")
 	var redeploy pushedDeployment
 	require.NoError(t, json.Unmarshal([]byte(out), &redeploy))
 	require.Equal(t, l.modelID, redeploy.Model.ID, "redeploy should reuse existing model")


### PR DESCRIPTION
## :rocket: What

`--promote` is just shortcut for `--environment production` and we don't want the separate flag anymore.

## :computer: How

Removed the `--promote` flag

## :microscope: Testing

Adjusted tests