### PR TITLE
Add model deployment metrics command

### DIFF
--- a/cmd/command.model_deployment.go
+++ b/cmd/command.model_deployment.go
@@ -229,12 +229,10 @@ var commandModelDeployment = Command{
 			Name:    "metrics",
 			Summary: "Fetch metrics for a deployment",
 			Description: "Fetch metrics for a model deployment.\n\n" +
-				"--mode current (the default) returns an instantaneous snapshot; summary " +
-				"aggregates a window into a single value per metric; series returns evenly-" +
-				"spaced points across a window, drawn as sparklines (use --no-chart for a " +
-				"per-step table). Scope the window with --start/--end or --since (max 7 days); " +
-				"only meaningful for summary and series. Restrict to specific metrics with " +
-				"repeated --metric; omitted returns the default set.",
+				"--mode selects what you get back: a current snapshot, a windowed " +
+				"summary, or a series; see its flag help for details. Scope the window " +
+				"with --start/--end or --since (max 7 days), which only apply to " +
+				"summary and series.",
 			Flags: ModelDeploymentMetricsFlags{},
 			Output: &CommandOutput[managementapi.GetDeploymentMetricsResponse]{
 				TextDescription: "For current/summary, a table with columns METRIC, one column per " +

--- a/cmd/command.model_deployment.go
+++ b/cmd/command.model_deployment.go
@@ -225,6 +225,44 @@ var commandModelDeployment = Command{
 				},
 			},
 		},
+		{
+			Name:    "metrics",
+			Summary: "Fetch metrics for a deployment",
+			Description: "Fetch metrics for a model deployment.\n\n" +
+				"--mode current (the default) returns an instantaneous snapshot; summary " +
+				"aggregates a window into a single value per metric; series returns evenly-" +
+				"spaced points across a window, drawn as sparklines (use --no-chart for a " +
+				"per-step table). Scope the window with --start/--end or --since (max 7 days); " +
+				"only meaningful for summary and series. Restrict to specific metrics with " +
+				"repeated --metric; omitted returns the default set.",
+			Flags: ModelDeploymentMetricsFlags{},
+			Output: &CommandOutput[managementapi.GetDeploymentMetricsResponse]{
+				TextDescription: "For current/summary, a table with columns METRIC, one column per " +
+					"label dimension (e.g. QUANTILE, STAT), and VALUE; summary COUNTER values show " +
+					"\"total (rate/s)\". For series, a sparkline per metric label set with its " +
+					"min-max range and end value, or a per-step table under --no-chart.",
+				JSONDescription: "The metrics response: metric_descriptors, index-mapped metric_values, " +
+					"the resolved mode, and the returned window.",
+				Examples: []CommandExample{
+					{
+						Description: "Show a current snapshot of the default metrics.",
+						Command:     "baseten model deployment metrics --model-name <model-name> --deployment-id <deployment-id>",
+					},
+					{
+						Description: "Summarize request volume and latency over the last hour.",
+						Command:     "baseten model deployment metrics --model-id <model-id> --deployment-id <deployment-id> --mode summary --since 1h --metric baseten_inference_requests_total --metric baseten_end_to_end_response_time_seconds",
+					},
+					{
+						Description: "Plot a series over the last 6 hours.",
+						Command:     "baseten model deployment metrics --model-id <model-id> --deployment-id <deployment-id> --mode series --since 6h",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the metric names returned.",
+					Command:     "baseten model deployment metrics --model-id <model-id> --deployment-id <deployment-id> --jq '.metric_descriptors[].name'",
+				},
+			},
+		},
 		commandModelDeploymentReplica,
 	},
 }
@@ -322,4 +360,20 @@ type ModelDeploymentLogsFlags struct {
 	SearchPattern string   `flag:"search-pattern" desc:"RE2 regular expression matched against the log message. Prefer --includes and --excludes for plain substring matches."`
 	Replica       string   `flag:"replica" desc:"Only return logs emitted by this replica (5-char short ID)."`
 	RequestID     string   `flag:"request-id" desc:"Only return logs tagged with this inference request ID."`
+}
+
+// ModelDeploymentMetricsFlags configures `baseten model deployment metrics`.
+type ModelDeploymentMetricsFlags struct {
+	CommandFlags
+	ModelDeploymentIDFlags
+
+	Mode string `flag:"mode" desc:"Aggregation mode. 'current' returns an instantaneous snapshot at now; 'summary' aggregates the whole window into one value per metric; 'series' returns evenly-spaced points across the window. --start/--end/--since are only meaningful for summary and series." enum:"current,summary,series" default:"current"`
+
+	Start time.Time     `flag:"start" desc:"Start of the metrics time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the start to one hour before the end. Window must be at most 7 days."`
+	End   time.Time     `flag:"end" desc:"End of the metrics time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the end to now. Window must be at most 7 days."`
+	Since time.Duration `flag:"since" desc:"Shortcut for a window from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
+
+	Metric []string `flag:"metric" desc:"Name of a metric to return; see https://docs.baseten.co/observability/export-metrics/supported-metrics for the available names. May be repeated. When omitted, a default set is returned."`
+
+	NoChart bool `flag:"no-chart" desc:"For --mode series, emit a per-step table instead of sparklines."`
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.1.1-0.20260612182021-5272680f54ac
+	github.com/basetenlabs/baseten-go v0.1.1-0.20260622142726-3a525cf7e7b8
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.1.1-0.20260612182021-5272680f54ac h1:HdgJfIcH+PQpc0mPQQvcaMRsYHFUUPWbMWc78p53XHQ=
-github.com/basetenlabs/baseten-go v0.1.1-0.20260612182021-5272680f54ac/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.1.1-0.20260622142726-3a525cf7e7b8 h1:pbqyUx5ZPcQ03oG3Q/jmS9m/r37yUKAaPjnbPZ7SPVg=
+github.com/basetenlabs/baseten-go v0.1.1-0.20260622142726-3a525cf7e7b8/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/internal/cmd/command.model_deployment_metrics.go
+++ b/internal/cmd/command.model_deployment_metrics.go
@@ -94,7 +94,7 @@ func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeployme
 
 	// current is a point-in-time snapshot with no window. For the windowed modes,
 	// report the resolved window (the server backfills a missing bound and it may
-	// be historical) on stderr so it stays out of the table/JSON on stdout.
+	// be historical) on stderr so it stays out of the table on stdout.
 	if resp.Mode != managementapi.DeploymentMetricMode_CURRENT {
 		ctx.LogLine(deploymentMetricsWindowLine(resp))
 	}
@@ -286,7 +286,12 @@ func deploymentMetricsLabelKeys(descriptors []managementapi.DeploymentMetricDesc
 	seen := map[string]bool{}
 	for _, d := range descriptors {
 		for _, labelSet := range d.LabelSets {
+			labelKeys := make([]string, 0, len(labelSet))
 			for k := range labelSet {
+				labelKeys = append(labelKeys, k)
+			}
+			slices.Sort(labelKeys)
+			for _, k := range labelKeys {
 				if !seen[k] {
 					seen[k] = true
 					keys = append(keys, k)

--- a/internal/cmd/command.model_deployment_metrics.go
+++ b/internal/cmd/command.model_deployment_metrics.go
@@ -1,0 +1,510 @@
+package cmd
+
+import (
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+)
+
+func init() {
+	Register("model deployment metrics", commandModelDeploymentMetrics)
+}
+
+func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeploymentMetricsFlags) error {
+	mode := managementapi.DeploymentMetricMode(strings.ToUpper(flags.Mode))
+
+	hasStart := !flags.Start.IsZero()
+	hasEnd := !flags.End.IsZero()
+	// Use Changed rather than the zero value so explicit --since 0 fails the
+	// positive-duration check below instead of being silently dropped.
+	hasSince := ctx.Command.Flags().Changed("since")
+
+	if mode == managementapi.DeploymentMetricMode_CURRENT && (hasStart || hasEnd || hasSince) {
+		return cmd.NewErrUsagef("--start, --end, and --since are only valid with --mode summary or series")
+	}
+	if hasSince && (hasStart || hasEnd) {
+		return cmd.NewErrUsagef("--since cannot be combined with --start or --end")
+	}
+
+	api, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := ResolveModelRef(ctx, api.API(), flags.ModelRefFlags)
+	if err != nil {
+		return err
+	}
+
+	params := managementapi.GetV1ModelsModelIdDeploymentsDeploymentIdMetricsParams{Mode: &mode}
+	if hasSince {
+		if flags.Since <= 0 {
+			return cmd.NewErrUsagef("--since must be a positive duration")
+		}
+		if flags.Since > maxLogTimeRange {
+			return cmd.NewErrUsagef("--since must be at most 7d")
+		}
+		now := ctx.Now()
+		s := int(now.Add(-flags.Since).UnixMilli())
+		e := int(now.UnixMilli())
+		params.StartEpochMillis, params.EndEpochMillis = &s, &e
+	} else if hasStart || hasEnd {
+		// Send only the bounds given and leave the other nil so the server
+		// backfills it. Validate the window client-side only when both are given.
+		if hasStart {
+			s := int(flags.Start.UnixMilli())
+			params.StartEpochMillis = &s
+		}
+		if hasEnd {
+			e := int(flags.End.UnixMilli())
+			params.EndEpochMillis = &e
+		}
+		if hasStart && hasEnd {
+			if !flags.Start.Before(flags.End) {
+				return cmd.NewErrUsagef("--start must be earlier than --end")
+			}
+			if flags.End.Sub(flags.Start) > maxLogTimeRange {
+				return cmd.NewErrUsagef("metrics time range must be at most 7 days; narrow --start/--end or use --since")
+			}
+		}
+	}
+	if len(flags.Metric) > 0 {
+		params.Metrics = &flags.Metric
+	}
+
+	resp, err := api.API().GetModelsDeploymentsMetrics(ctx, ref.ID, flags.DeploymentID, params)
+	if err != nil {
+		return err
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(resp)
+		return nil
+	}
+
+	if len(resp.MetricDescriptors) == 0 {
+		ctx.LogLine("No metrics found.")
+		return nil
+	}
+
+	// current is a point-in-time snapshot with no window. For the windowed modes,
+	// report the resolved window (the server backfills a missing bound and it may
+	// be historical) on stderr so it stays out of the table/JSON on stdout.
+	if resp.Mode != managementapi.DeploymentMetricMode_CURRENT {
+		ctx.LogLine(deploymentMetricsWindowLine(resp))
+	}
+
+	switch resp.Mode {
+	case managementapi.DeploymentMetricMode_SERIES:
+		if flags.NoChart {
+			headers, rows, rightAligned := deploymentMetricsSeriesTable(resp)
+			ctx.OutputTable(TableOutput{Headers: headers, Rows: rows, RightAlignedColumns: rightAligned})
+			return nil
+		}
+		for _, line := range deploymentMetricsChartLines(resp) {
+			ctx.OutputLine(line)
+		}
+		return nil
+	case managementapi.DeploymentMetricMode_CURRENT, managementapi.DeploymentMetricMode_SUMMARY:
+		headers, rows, rightAligned := deploymentMetricsSnapshotRows(resp)
+		ctx.OutputTable(TableOutput{Headers: headers, Rows: rows, RightAlignedColumns: rightAligned})
+		return nil
+	default:
+		return fmt.Errorf("unexpected metrics mode %q in response", resp.Mode)
+	}
+}
+
+// deploymentMetricsWindowLine summarizes the returned window for summary/series
+// modes: resolved start/end in local time plus duration, and the step interval
+// when the server reports one (SERIES only).
+func deploymentMetricsWindowLine(resp *managementapi.GetDeploymentMetricsResponse) string {
+	start := time.UnixMilli(int64(resp.StartEpochMillis)).Local()
+	end := time.UnixMilli(int64(resp.EndEpochMillis)).Local()
+	line := fmt.Sprintf("Window: %s – %s local (%s)",
+		start.Format("2006-01-02 15:04"), end.Format("2006-01-02 15:04"),
+		deploymentMetricsHumanizeDuration(end.Sub(start)))
+	if resp.StepSeconds != nil {
+		line += fmt.Sprintf(" · %s/step",
+			deploymentMetricsHumanizeDuration(time.Duration(*resp.StepSeconds)*time.Second))
+	}
+	return line
+}
+
+// deploymentMetricsHumanizeDuration renders a duration compactly, omitting
+// zero-valued units: whole days as "<N>d", otherwise non-zero h/m/s components
+// (e.g. "30s", "10m", "1h30m").
+func deploymentMetricsHumanizeDuration(d time.Duration) string {
+	if d <= 0 {
+		return "0s"
+	}
+	if d%(24*time.Hour) == 0 {
+		return fmt.Sprintf("%dd", d/(24*time.Hour))
+	}
+	var b strings.Builder
+	if h := d / time.Hour; h > 0 {
+		fmt.Fprintf(&b, "%dh", h)
+		d -= h * time.Hour
+	}
+	if m := d / time.Minute; m > 0 {
+		fmt.Fprintf(&b, "%dm", m)
+		d -= m * time.Minute
+	}
+	if s := d / time.Second; s > 0 {
+		fmt.Fprintf(&b, "%ds", s)
+	}
+	return b.String()
+}
+
+// deploymentMetricsSnapshotRows builds the current/summary table: one row per
+// (metric, label set), with a column per label key seen across descriptors and
+// a trailing VALUE column. In summary mode, COUNTER values render as
+// "total (rate/s)" where the rate is the window total divided by its duration.
+func deploymentMetricsSnapshotRows(resp *managementapi.GetDeploymentMetricsResponse) (headers []string, rows [][]string, rightAligned []int) {
+	labelKeys := deploymentMetricsLabelKeys(resp.MetricDescriptors)
+	headers = append(headers, "METRIC")
+	for _, k := range labelKeys {
+		headers = append(headers, strings.ToUpper(k))
+	}
+	headers = append(headers, "VALUE")
+	valueCol := len(headers) - 1
+	rightAligned = []int{valueCol}
+
+	windowSeconds := float64(resp.EndEpochMillis-resp.StartEpochMillis) / 1000
+	var values *managementapi.DeploymentMetricValueSet
+	if len(resp.MetricValues) > 0 {
+		values = &resp.MetricValues[0]
+	}
+
+	for di, d := range resp.MetricDescriptors {
+		for li, labelSet := range d.LabelSets {
+			row := make([]string, len(headers))
+			row[0] = d.Name
+			for ki, k := range labelKeys {
+				row[1+ki] = labelSet[k]
+			}
+			v := deploymentMetricsValueAt(values, di, li)
+			if resp.Mode == managementapi.DeploymentMetricMode_SUMMARY &&
+				d.Kind == managementapi.DeploymentMetricKind_COUNTER {
+				row[valueCol] = deploymentMetricsFormatCounter(v, d.UnitHint, windowSeconds)
+			} else {
+				row[valueCol] = deploymentMetricsFormatValue(v, d.UnitHint)
+			}
+			rows = append(rows, row)
+		}
+	}
+	return headers, rows, rightAligned
+}
+
+// deploymentMetricsChartLines renders the default series view: a header line per
+// metric, then one sparkline per label set with its min-max range and the
+// trailing ("end") value. The window may be historical, so the last point is
+// labeled "end", not "now".
+func deploymentMetricsChartLines(resp *managementapi.GetDeploymentMetricsResponse) []string {
+	var lines []string
+	for di, d := range resp.MetricDescriptors {
+		lines = append(lines, fmt.Sprintf("%s  [%s · %s]", d.Name, d.Kind, strings.ToLower(string(d.UnitHint))))
+
+		shorts := make([]string, len(d.LabelSets))
+		labelWidth := 0
+		for li, labelSet := range d.LabelSets {
+			shorts[li] = deploymentMetricsLabelShort(labelSet)
+			if len(shorts[li]) > labelWidth {
+				labelWidth = len(shorts[li])
+			}
+		}
+
+		suffix := deploymentMetricsUnitSuffix(d.UnitHint)
+		for li := range d.LabelSets {
+			series := deploymentMetricsSeriesValues(resp.MetricValues, di, li)
+			var b strings.Builder
+			b.WriteString("  ")
+			if labelWidth > 0 {
+				fmt.Fprintf(&b, "%-*s  ", labelWidth, shorts[li])
+			}
+			b.WriteString(deploymentMetricsSparkline(series))
+			if lo, hi, ok := deploymentMetricsRange(series); ok {
+				fmt.Fprintf(&b, "   %s%s – %s%s",
+					deploymentMetricsHumanize(lo), suffix, deploymentMetricsHumanize(hi), suffix)
+			}
+			if end := deploymentMetricsLastValue(series); end != nil {
+				fmt.Fprintf(&b, "   end %s", deploymentMetricsFormatValue(end, d.UnitHint))
+			}
+			lines = append(lines, b.String())
+		}
+		lines = append(lines, "")
+	}
+	// Drop the trailing separator.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// deploymentMetricsSeriesTable is the --no-chart fallback for series mode: one
+// row per (metric, label set) with a value column per time step, headed by the
+// step's local start time.
+func deploymentMetricsSeriesTable(resp *managementapi.GetDeploymentMetricsResponse) (headers []string, rows [][]string, rightAligned []int) {
+	labelKeys := deploymentMetricsLabelKeys(resp.MetricDescriptors)
+	headers = append(headers, "METRIC")
+	for _, k := range labelKeys {
+		headers = append(headers, strings.ToUpper(k))
+	}
+	firstStepCol := len(headers)
+	for _, vs := range resp.MetricValues {
+		headers = append(headers, time.UnixMilli(int64(vs.StartEpochMillis)).Local().Format("15:04"))
+	}
+	for col := firstStepCol; col < len(headers); col++ {
+		rightAligned = append(rightAligned, col)
+	}
+
+	for di, d := range resp.MetricDescriptors {
+		for li, labelSet := range d.LabelSets {
+			row := make([]string, len(headers))
+			row[0] = d.Name
+			for ki, k := range labelKeys {
+				row[1+ki] = labelSet[k]
+			}
+			for si := range resp.MetricValues {
+				row[firstStepCol+si] = deploymentMetricsFormatValue(
+					deploymentMetricsValueAt(&resp.MetricValues[si], di, li), d.UnitHint)
+			}
+			rows = append(rows, row)
+		}
+	}
+	return headers, rows, rightAligned
+}
+
+// deploymentMetricsLabelKeys returns the union of label keys across descriptors
+// in first-seen order, so the table has a stable column per label dimension.
+func deploymentMetricsLabelKeys(descriptors []managementapi.DeploymentMetricDescriptor) []string {
+	var keys []string
+	seen := map[string]bool{}
+	for _, d := range descriptors {
+		for _, labelSet := range d.LabelSets {
+			for k := range labelSet {
+				if !seen[k] {
+					seen[k] = true
+					keys = append(keys, k)
+				}
+			}
+		}
+	}
+	return keys
+}
+
+// deploymentMetricsLabelShort renders a label set as a compact series label:
+// quantiles as "p50"/"p99", a lone value as itself, otherwise sorted "k=v" pairs.
+func deploymentMetricsLabelShort(labelSet map[string]string) string {
+	if q, ok := labelSet["quantile"]; ok && len(labelSet) == 1 {
+		if f, err := strconv.ParseFloat(q, 64); err == nil {
+			return fmt.Sprintf("p%g", f*100)
+		}
+	}
+	if len(labelSet) == 1 {
+		for _, v := range labelSet {
+			return v
+		}
+	}
+	keys := make([]string, 0, len(labelSet))
+	for k := range labelSet {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+labelSet[k])
+	}
+	return strings.Join(parts, ",")
+}
+
+// deploymentMetricsValueAt reads the value for descriptor di / label set li from
+// a single value set, guarding the index-mapped slices. nil means no data.
+func deploymentMetricsValueAt(values *managementapi.DeploymentMetricValueSet, di, li int) *float32 {
+	if values == nil || di >= len(values.Values) || li >= len(values.Values[di]) {
+		return nil
+	}
+	return values.Values[di][li]
+}
+
+// deploymentMetricsSeriesValues collects descriptor di / label set li across all
+// time steps, preserving nil gaps.
+func deploymentMetricsSeriesValues(steps []managementapi.DeploymentMetricValueSet, di, li int) []*float32 {
+	series := make([]*float32, len(steps))
+	for si := range steps {
+		series[si] = deploymentMetricsValueAt(&steps[si], di, li)
+	}
+	return series
+}
+
+// deploymentMetricsLastValue returns the last non-nil point, or nil if none.
+func deploymentMetricsLastValue(series []*float32) *float32 {
+	for i := len(series) - 1; i >= 0; i-- {
+		if series[i] != nil {
+			return series[i]
+		}
+	}
+	return nil
+}
+
+// deploymentMetricsRange returns the min and max of the non-nil points; ok is
+// false when the series has no data.
+func deploymentMetricsRange(series []*float32) (lo, hi float64, ok bool) {
+	for _, v := range series {
+		if v == nil {
+			continue
+		}
+		f := float64(*v)
+		if !ok {
+			lo, hi, ok = f, f, true
+			continue
+		}
+		lo = math.Min(lo, f)
+		hi = math.Max(hi, f)
+	}
+	return lo, hi, ok
+}
+
+var deploymentMetricsSparkRunes = []rune("▁▂▃▄▅▆▇█")
+
+// deploymentMetricsMaxSparkWidth caps the rune width of a sparkline. The backend
+// step count is large and unbounded (a 6h window is ~360 steps), so longer series
+// are downsampled to this many buckets to avoid terminal wrapping.
+const deploymentMetricsMaxSparkWidth = 60
+
+// deploymentMetricsNullRune marks a no-data point so leading gaps don't read as
+// layout whitespace.
+const deploymentMetricsNullRune = '·'
+
+// deploymentMetricsDownsample aggregates series into at most max contiguous
+// buckets, averaging each bucket's non-nil points. A bucket with no data stays
+// nil so gaps are preserved. Series at or below max are returned unchanged.
+func deploymentMetricsDownsample(series []*float32, max int) []*float32 {
+	if len(series) <= max {
+		return series
+	}
+	out := make([]*float32, max)
+	for i := range out {
+		start := i * len(series) / max
+		end := (i + 1) * len(series) / max
+		var sum float64
+		var n int
+		for _, v := range series[start:end] {
+			if v != nil {
+				sum += float64(*v)
+				n++
+			}
+		}
+		if n > 0 {
+			avg := float32(sum / float64(n))
+			out[i] = &avg
+		}
+	}
+	return out
+}
+
+// deploymentMetricsSparkline renders a series as block-rune sparkline, scaled to
+// the series' own min-max. Series wider than deploymentMetricsMaxSparkWidth are
+// downsampled. nil points render as a gap; a flat series renders at the lowest
+// level.
+func deploymentMetricsSparkline(series []*float32) string {
+	series = deploymentMetricsDownsample(series, deploymentMetricsMaxSparkWidth)
+	lo, hi, ok := deploymentMetricsRange(series)
+	if !ok {
+		return "(no data)"
+	}
+	span := hi - lo
+	var b strings.Builder
+	for _, v := range series {
+		if v == nil {
+			b.WriteRune(deploymentMetricsNullRune)
+			continue
+		}
+		idx := 0
+		if span > 0 {
+			idx = int((float64(*v)-lo)/span*float64(len(deploymentMetricsSparkRunes)-1) + 0.5)
+			if idx < 0 {
+				idx = 0
+			}
+			if idx >= len(deploymentMetricsSparkRunes) {
+				idx = len(deploymentMetricsSparkRunes) - 1
+			}
+		}
+		b.WriteRune(deploymentMetricsSparkRunes[idx])
+	}
+	return b.String()
+}
+
+// deploymentMetricsFormatValue formats a single value with its unit suffix; nil
+// renders as "-".
+func deploymentMetricsFormatValue(v *float32, unit managementapi.DeploymentMetricUnitHint) string {
+	if v == nil {
+		return "-"
+	}
+	return deploymentMetricsHumanize(float64(*v)) + deploymentMetricsUnitSuffix(unit)
+}
+
+// deploymentMetricsFormatCounter formats a COUNTER summary value as the window
+// total plus its per-second rate, e.g. "1.2k (340.5/s)".
+func deploymentMetricsFormatCounter(total *float32, unit managementapi.DeploymentMetricUnitHint, windowSeconds float64) string {
+	if total == nil {
+		return "-"
+	}
+	t := float64(*total)
+	out := deploymentMetricsHumanize(t) + deploymentMetricsUnitSuffix(unit)
+	if windowSeconds > 0 {
+		out += fmt.Sprintf(" (%s/s)", deploymentMetricsHumanize(t/windowSeconds))
+	}
+	return out
+}
+
+// deploymentMetricsUnitSuffix is the short value suffix for a unit hint. COUNT
+// and RATIO are dimensionless and carry no suffix; unknown hints are omitted.
+func deploymentMetricsUnitSuffix(unit managementapi.DeploymentMetricUnitHint) string {
+	switch unit {
+	case managementapi.DeploymentMetricUnitHint_SECONDS:
+		return "s"
+	case managementapi.DeploymentMetricUnitHint_PER_SECOND:
+		return "/s"
+	case managementapi.DeploymentMetricUnitHint_BYTES:
+		return "B"
+	case managementapi.DeploymentMetricUnitHint_MEBIBYTES:
+		return "MiB"
+	case managementapi.DeploymentMetricUnitHint_COUNT, managementapi.DeploymentMetricUnitHint_RATIO:
+		return ""
+	default:
+		return ""
+	}
+}
+
+// deploymentMetricsHumanize renders a number compactly with a k/M/G suffix for
+// large magnitudes, trimming trailing zeros. Display-only; not exact.
+func deploymentMetricsHumanize(f float64) string {
+	abs := math.Abs(f)
+	switch {
+	case abs >= 1e9:
+		return deploymentMetricsTrim(f/1e9) + "G"
+	case abs >= 1e6:
+		return deploymentMetricsTrim(f/1e6) + "M"
+	case abs >= 1e3:
+		return deploymentMetricsTrim(f/1e3) + "k"
+	default:
+		return deploymentMetricsTrim(f)
+	}
+}
+
+func deploymentMetricsTrim(f float64) string {
+	s := strconv.FormatFloat(f, 'f', 3, 64)
+	if strings.Contains(s, ".") {
+		s = strings.TrimRight(s, "0")
+		s = strings.TrimRight(s, ".")
+	}
+	if s == "-0" {
+		s = "0"
+	}
+	return s
+}

--- a/internal/cmd/command.model_deployment_metrics_test.go
+++ b/internal/cmd/command.model_deployment_metrics_test.go
@@ -1,0 +1,306 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/basetenlabs/baseten-cli/internal/cmd"
+)
+
+const metricsPath = "/v1/models/m/deployments/d/metrics"
+
+// metricsResponse builds a GetDeploymentMetricsResponse body.
+func metricsResponse(mode string, startMs, endMs int, descriptors []any, valueSets []any) map[string]any {
+	return map[string]any{
+		"mode":               mode,
+		"start_epoch_millis": startMs,
+		"end_epoch_millis":   endMs,
+		"step_seconds":       nil,
+		"metric_descriptors": descriptors,
+		"metric_values":      valueSets,
+	}
+}
+
+func metricsDescriptor(name, kind, unit string, labelSets ...map[string]string) map[string]any {
+	sets := make([]any, len(labelSets))
+	for i, ls := range labelSets {
+		sets[i] = ls
+	}
+	return map[string]any{"name": name, "kind": kind, "unit_hint": unit, "label_sets": sets}
+}
+
+func metricsValueSet(startMs int, values ...[]any) map[string]any {
+	vs := make([]any, len(values))
+	for i, v := range values {
+		vs[i] = v
+	}
+	return map[string]any{"start_epoch_millis": startMs, "values": vs}
+}
+
+func Test_Model_Deployment_Metrics_CurrentWithSinceRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--since", "1h")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "only valid with --mode summary or series")
+}
+
+func Test_Model_Deployment_Metrics_CurrentWithStartRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--start", "2026-05-14")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "only valid with --mode summary or series")
+}
+
+func Test_Model_Deployment_Metrics_SinceWithStartRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--mode", "summary",
+		"--since", "1h", "--start", "2026-05-14")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "--since cannot be combined")
+}
+
+func Test_Model_Deployment_Metrics_StartAfterEndRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--mode", "series",
+		"--start", "2026-05-14T13:00:00", "--end", "2026-05-14T12:00:00")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "--start must be earlier")
+}
+
+func Test_Model_Deployment_Metrics_WindowOver7DaysRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--mode", "series",
+		"--start", "2026-05-01", "--end", "2026-05-10")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "at most 7 days")
+}
+
+func Test_Model_Deployment_Metrics_SinceNotPositiveRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--mode", "summary", "--since", "0")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "must be a positive duration")
+}
+
+func Test_Model_Deployment_Metrics_ModeAndMetricsSent(t *testing.T) {
+	h := NewCommandHarness(t)
+	api := h.MockManagementAPI()
+	var gotQuery url.Values
+	api.SetRouteFunc("GET", metricsPath, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(metricsResponse("SUMMARY", 0, 3600000, []any{}, []any{}))
+	})
+	fixed := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	h.Context = cmd.WithNow(h.Context, func() time.Time { return fixed })
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--mode", "summary", "--since", "1h",
+		"--metric", "baseten_inference_requests_total", "--metric", "baseten_replicas_active")
+	h.Require.NoError(err)
+	// Mode is uppercased before sending.
+	h.Require.Equal("SUMMARY", gotQuery.Get("mode"))
+	h.Require.Equal(int(fixed.Add(-time.Hour).UnixMilli()), mustAtoi(t, gotQuery.Get("start_epoch_millis")))
+	h.Require.Equal(int(fixed.UnixMilli()), mustAtoi(t, gotQuery.Get("end_epoch_millis")))
+	call := api.FindCall("GET", metricsPath)
+	h.Require.NotNil(call)
+	h.Require.Contains(call.Path, "/metrics")
+	// Both metric names are present in the query regardless of array encoding.
+	raw := gotQuery.Encode()
+	h.Require.Contains(raw, "baseten_inference_requests_total")
+	h.Require.Contains(raw, "baseten_replicas_active")
+}
+
+func Test_Model_Deployment_Metrics_CurrentSnapshotTable(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", metricsPath, 200, metricsResponse("CURRENT", 0, 0,
+		[]any{
+			metricsDescriptor("baseten_replicas_active", "GAUGE", "COUNT", map[string]string{}),
+			metricsDescriptor("baseten_end_to_end_response_time_seconds", "HISTOGRAM", "SECONDS",
+				map[string]string{"quantile": "0.5"}, map[string]string{"quantile": "0.99"}, map[string]string{"stat": "avg"}),
+		},
+		[]any{metricsValueSet(0, []any{3}, []any{0.12, 0.55, 0.18})},
+	))
+	err := h.Execute("model", "deployment", "metrics", "--model-id", "m", "--deployment-id", "d")
+	h.Require.NoError(err)
+	out := h.Stdout.String()
+	h.Require.Contains(out, "METRIC")
+	h.Require.Contains(out, "QUANTILE")
+	h.Require.Contains(out, "STAT")
+	h.Require.Contains(out, "baseten_replicas_active")
+	h.Require.Contains(out, "0.12s")
+	h.Require.Contains(out, "0.18s")
+	// current is a point-in-time snapshot: no window line.
+	h.Require.NotContains(h.Stderr.String(), "Window:")
+}
+
+func Test_Model_Deployment_Metrics_SummaryCounterShowsRate(t *testing.T) {
+	h := NewCommandHarness(t)
+	// 3600 total over a 1h window -> 1/s, humanized total 3.6k.
+	h.MockManagementAPI().SetRoute("GET", metricsPath, 200, metricsResponse("SUMMARY", 0, 3600000,
+		[]any{metricsDescriptor("baseten_inference_requests_total", "COUNTER", "COUNT", map[string]string{})},
+		[]any{metricsValueSet(0, []any{3600})},
+	))
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--mode", "summary", "--since", "1h")
+	h.Require.NoError(err)
+	h.Require.Contains(h.Stdout.String(), "3.6k (1/s)")
+	// summary reports the resolved window on stderr, with no step (SERIES only).
+	stderr := h.Stderr.String()
+	h.Require.Contains(stderr, "Window:")
+	h.Require.Contains(stderr, "(1h)")
+	h.Require.NotContains(stderr, "steps")
+}
+
+func Test_Model_Deployment_Metrics_SeriesWindowReportsStep(t *testing.T) {
+	h := NewCommandHarness(t)
+	resp := metricsResponse("SERIES", 0, 3600000,
+		[]any{metricsDescriptor("baseten_inference_requests_total", "COUNTER", "COUNT", map[string]string{})},
+		[]any{metricsValueSet(0, []any{0}), metricsValueSet(1, []any{5}), metricsValueSet(2, []any{10})},
+	)
+	// 30s is the ≤1h resolution; it must render as "30s", not "3" (a naive
+	// trailing-"0s" trim mangles the significant zero).
+	resp["step_seconds"] = 30
+	h.MockManagementAPI().SetRoute("GET", metricsPath, 200, resp)
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--mode", "series", "--since", "1h")
+	h.Require.NoError(err)
+	stderr := h.Stderr.String()
+	h.Require.Contains(stderr, "Window:")
+	h.Require.Contains(stderr, "30s/step")
+}
+
+func Test_Model_Deployment_Metrics_SeriesChart(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", metricsPath, 200, metricsResponse("SERIES", 0, 3600000,
+		[]any{metricsDescriptor("baseten_inference_requests_total", "COUNTER", "COUNT", map[string]string{})},
+		[]any{metricsValueSet(0, []any{0}), metricsValueSet(1, []any{5}), metricsValueSet(2, []any{10})},
+	))
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--mode", "series", "--since", "1h")
+	h.Require.NoError(err)
+	out := h.Stdout.String()
+	h.Require.Contains(out, "baseten_inference_requests_total  [COUNTER · count]")
+	h.Require.Contains(out, "▁▅█")
+	h.Require.Contains(out, "0 – 10")
+	h.Require.Contains(out, "end 10")
+}
+
+func Test_Model_Deployment_Metrics_SeriesNoChartTable(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", metricsPath, 200, metricsResponse("SERIES", 0, 3600000,
+		[]any{metricsDescriptor("baseten_inference_requests_total", "COUNTER", "COUNT", map[string]string{})},
+		[]any{metricsValueSet(0, []any{0}), metricsValueSet(1, []any{5}), metricsValueSet(2, []any{10})},
+	))
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--mode", "series", "--since", "1h", "--no-chart")
+	h.Require.NoError(err)
+	out := h.Stdout.String()
+	h.Require.Contains(out, "METRIC")
+	h.Require.Contains(out, "baseten_inference_requests_total")
+	h.Require.Contains(out, "10")
+	// Sparklines suppressed.
+	h.Require.NotContains(out, "█")
+}
+
+func Test_Model_Deployment_Metrics_SeriesChartDownsampledAndNullGap(t *testing.T) {
+	h := NewCommandHarness(t)
+	// 120 steps exceed the 60-rune cap, so the sparkline is downsampled. The
+	// first 10 steps are no-data and must render as the null gap rune.
+	steps := make([]any, 120)
+	for i := range steps {
+		if i < 10 {
+			steps[i] = metricsValueSet(i, []any{nil})
+			continue
+		}
+		steps[i] = metricsValueSet(i, []any{i})
+	}
+	h.MockManagementAPI().SetRoute("GET", metricsPath, 200, metricsResponse("SERIES", 0, 3600000,
+		[]any{metricsDescriptor("baseten_inference_requests_total", "COUNTER", "COUNT", map[string]string{})},
+		steps,
+	))
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--mode", "series", "--since", "1h")
+	h.Require.NoError(err)
+	spark := findSparklineLine(t, h.Stdout.String())
+	h.Require.Equal(60, utf8.RuneCountInString(spark))
+	h.Require.Contains(spark, "·")
+}
+
+func Test_Model_Deployment_Metrics_SeriesChartShortSeriesNotDownsampled(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", metricsPath, 200, metricsResponse("SERIES", 0, 3600000,
+		[]any{metricsDescriptor("baseten_inference_requests_total", "COUNTER", "COUNT", map[string]string{})},
+		[]any{metricsValueSet(0, []any{0}), metricsValueSet(1, []any{5}), metricsValueSet(2, []any{10})},
+	))
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--mode", "series", "--since", "1h")
+	h.Require.NoError(err)
+	spark := findSparklineLine(t, h.Stdout.String())
+	h.Require.Equal(3, utf8.RuneCountInString(spark))
+}
+
+// findSparklineLine returns the longest contiguous run of sparkline block runes
+// and the null gap rune found in the output (the sparkline shares its line with
+// the range and end columns).
+func findSparklineLine(t *testing.T, out string) string {
+	t.Helper()
+	var best, cur string
+	for _, r := range out {
+		if strings.ContainsRune("▁▂▃▄▅▆▇█·", r) {
+			cur += string(r)
+			if utf8.RuneCountInString(cur) > utf8.RuneCountInString(best) {
+				best = cur
+			}
+			continue
+		}
+		cur = ""
+	}
+	if best == "" {
+		t.Fatalf("no sparkline found in output:\n%s", out)
+	}
+	return best
+}
+
+func Test_Model_Deployment_Metrics_JSONPassthrough(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", metricsPath, 200, metricsResponse("CURRENT", 0, 0,
+		[]any{metricsDescriptor("baseten_replicas_active", "GAUGE", "COUNT", map[string]string{})},
+		[]any{metricsValueSet(0, []any{3})},
+	))
+	err := h.Execute("model", "deployment", "metrics",
+		"--model-id", "m", "--deployment-id", "d", "--output", "json")
+	h.Require.NoError(err)
+	out := strings.TrimSpace(h.Stdout.String())
+	h.Require.True(strings.HasPrefix(out, "{"))
+	h.Require.Contains(out, `"metric_descriptors"`)
+	h.Require.Contains(out, "baseten_replicas_active")
+}
+
+func Test_Model_Deployment_Metrics_NoneFound(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", metricsPath, 200, metricsResponse("CURRENT", 0, 0, []any{}, []any{}))
+	err := h.Execute("model", "deployment", "metrics", "--model-id", "m", "--deployment-id", "d")
+	h.Require.NoError(err)
+	h.Require.Contains(h.Stderr.String(), "No metrics found.")
+}
+
+func mustAtoi(t *testing.T, s string) int {
+	t.Helper()
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		t.Fatalf("not an int: %q", s)
+	}
+	return v
+}

--- a/internal/e2e-tests/model_test.go
+++ b/internal/e2e-tests/model_test.go
@@ -30,6 +30,7 @@ func TestE2EModelLifecycle(t *testing.T) {
 	t.Run("Logs", l.Logs)
 	t.Run("Environment", l.Environment)
 	t.Run("ModelPredict", l.ModelPredict)
+	t.Run("Metrics", l.Metrics)
 	t.Run("Redeploy", l.Redeploy)
 	t.Run("Delete", l.Delete)
 }
@@ -422,6 +423,48 @@ func (l *lifecycle) ModelPredict(t *testing.T) {
 			concat = append(concat, b...)
 		}
 		require.Equal(t, []byte("alphabetagamma"), concat)
+	})
+}
+
+func (l *lifecycle) Metrics(t *testing.T) {
+	type metricsResp struct {
+		Mode              string `json:"mode"`
+		MetricDescriptors []struct {
+			Name string `json:"name"`
+		} `json:"metric_descriptors"`
+	}
+	hasDescriptor := func(r metricsResp, name string) bool {
+		for _, d := range r.MetricDescriptors {
+			if d.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+
+	// current is a point-in-time snapshot. baseten_replicas_active is always
+	// registered for a deployment, so the descriptor must appear; its value may
+	// be 0, so this asserts shape only, never a value.
+	t.Run("Current", func(t *testing.T) {
+		out := mustCLI(t, "model", "deployment", "metrics",
+			"--model-id", l.modelID, "--deployment-id", l.initialDeploymentID, "--output", "json")
+		var resp metricsResp
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.Equal(t, "CURRENT", resp.Mode)
+		require.True(t, hasDescriptor(resp, "baseten_replicas_active"),
+			"baseten_replicas_active missing from current snapshot")
+	})
+
+	// series exercises the windowed path; assert only the envelope shape (mode +
+	// descriptors present), not values, which may be empty this soon after deploy.
+	t.Run("Series", func(t *testing.T) {
+		out := mustCLI(t, "model", "deployment", "metrics",
+			"--model-id", l.modelID, "--deployment-id", l.initialDeploymentID,
+			"--mode", "series", "--since", "1h", "--output", "json")
+		var resp metricsResp
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.Equal(t, "SERIES", resp.Mode)
+		require.NotEmpty(t, resp.MetricDescriptors)
 	})
 }
 


### PR DESCRIPTION
## :rocket: What

- Adds `baseten model deployment metrics`, fronting `GET /v1/models/{model_id}/deployments/{deployment_id}/metrics`.
- Three views via `--mode`: `current` snapshot, windowed `summary`, `series`.
- Time-window flags (`--start`/`--end`/`--since`) mirror `model deployment logs`.
- `--metric` (repeatable) filters by name; `--no-chart` swaps the series sparkline for a per-step table.

Uses updated baseten-go from https://github.com/basetenlabs/baseten-go/pull/10

## :computer: How

- Branches on metric kind (GAUGE/COUNTER/HISTOGRAM) and mode, never on a metric name, so adding a backend metric needs no CLI change.
- Inverts the bucket-major REST envelope per descriptor: label sets become rows, unit hints become value suffixes.
- Series render as a per-series autoscaled sparkline, downsampled to a fixed width cap, with `·` marking no-data points.
- COUNTER summaries show the window total plus a derived per-second rate.
- For summary/series, the resolved window (server may backfill a bound) prints to stderr, keeping the table/JSON clean on stdout.
- `--output json`/`--jq` pass the typed envelope through unchanged.

## :microscope: Testing

- 17 in-process harness tests: flag validation, each mode's rendering, sparkline downsampling and null gaps, the window line, JSON passthrough.
- New `Metrics` step in the model lifecycle e2e asserts the `current` and `series` envelope shape against staging (verified green).
- E2e asserts presence, not values, since a fresh deployment's metrics may be zero.