### PR TITLE
💥 Replace -all with --added-only on model-api list

### DIFF
--- a/cmd/command.model_api.go
+++ b/cmd/command.model_api.go
@@ -29,21 +29,21 @@ var commandModelAPI = Command{
 		},
 		{
 			Name:    "list",
-			Summary: "List Model APIs the workspace has added",
-			Description: "List the Model APIs the workspace has added.\n\n" +
-				"Pass --all to browse the full visible catalog instead of just the added ones.",
+			Summary: "List Model APIs",
+			Description: "List the Model APIs in the full visible catalog.\n\n" +
+				"Pass --added-only to restrict to just the Model APIs the workspace has added.",
 			Flags: ModelAPIListFlags{},
 			Output: &CommandOutput[ModelAPIList]{
 				TextDescription: "Table with columns: NAME, CONTEXT, $/1M IN, $/1M OUT, ADDED. " +
 					"When no Model APIs match, prints \"No Model APIs found.\" to stderr.",
 				Examples: []CommandExample{
 					{
-						Description: "List the Model APIs the workspace has added.",
+						Description: "List the full visible catalog of Model APIs.",
 						Command:     "baseten model-api list",
 					},
 					{
-						Description: "Browse the full visible catalog.",
-						Command:     "baseten model-api list --all",
+						Description: "List only the Model APIs the workspace has added.",
+						Command:     "baseten model-api list --added-only",
 					},
 				},
 				JQExample: CommandExample{
@@ -109,7 +109,7 @@ type ModelAPIDescribeFlags struct {
 type ModelAPIListFlags struct {
 	CommandFlags
 
-	All bool `flag:"all" desc:"Browse the full visible catalog instead of only the Model APIs the workspace has added."`
+	AddedOnly bool `flag:"added-only" desc:"Restrict to the Model APIs the workspace has added instead of the full visible catalog."`
 }
 
 // ModelAPIPredictFlags configures `baseten model-api predict`.

--- a/internal/cmd/command.model_api.go
+++ b/internal/cmd/command.model_api.go
@@ -27,13 +27,9 @@ func commandModelAPIList(ctx *CommandContext, flags *cmd.ModelAPIListFlags) erro
 	}
 
 	// The catalog is small, so walk every page and aggregate into one list
-	// rather than exposing cursors. By default restrict to the Model APIs the
-	// workspace has added; --all browses the full visible catalog.
-	params := managementapi.GetV1ModelApisParams{}
-	if !flags.All {
-		addedOnly := true
-		params.AddedOnly = &addedOnly
-	}
+	// rather than exposing cursors. By default browse the full visible catalog;
+	// --added-only restricts to the Model APIs the workspace has added.
+	params := managementapi.GetV1ModelApisParams{AddedOnly: &flags.AddedOnly}
 	var items []managementapi.ModelAPI
 	for {
 		resp, err := cl.API().GetModelApis(ctx, params)

--- a/internal/cmd/command.model_api_test.go
+++ b/internal/cmd/command.model_api_test.go
@@ -64,7 +64,7 @@ func Test_ModelApi_List_JSON(t *testing.T) {
 	h.Require.Contains(h.Stdout.String(), `"name": "llama-3"`)
 }
 
-func Test_ModelApi_List_DefaultRestrictsToAdded(t *testing.T) {
+func Test_ModelApi_List_DefaultBrowsesCatalog(t *testing.T) {
 	h := NewCommandHarness(t)
 	m := h.MockManagementAPI()
 	var query []string
@@ -75,10 +75,10 @@ func Test_ModelApi_List_DefaultRestrictsToAdded(t *testing.T) {
 	})
 
 	h.Require.NoError(h.Execute("model-api", "list"))
-	h.Require.Equal([]string{"true"}, query)
+	h.Require.Equal([]string{"false"}, query)
 }
 
-func Test_ModelApi_List_AllBrowsesCatalog(t *testing.T) {
+func Test_ModelApi_List_AddedOnlyRestrictsToAdded(t *testing.T) {
 	h := NewCommandHarness(t)
 	m := h.MockManagementAPI()
 	var query []string
@@ -88,8 +88,8 @@ func Test_ModelApi_List_AllBrowsesCatalog(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}, "pagination": map[string]any{"has_more": false}})
 	})
 
-	h.Require.NoError(h.Execute("model-api", "list", "--all"))
-	h.Require.Empty(query)
+	h.Require.NoError(h.Execute("model-api", "list", "--added-only"))
+	h.Require.Equal([]string{"true"}, query)
 }
 
 func Test_ModelApi_List_Paginates(t *testing.T) {


### PR DESCRIPTION
## :rocket: What

Default model-api listing to show full catalog instead of added only. It makes the most sense to show all model APIs usable since adding one is not an explicit step (you just use it and it gets added)

💥 This is a backwards incompatible change

## :computer: How

Remove `--all` from `model-api list`, default to that behavior, and add `--added-only` to only list added ones

## :microscope: Testing

Updated tests to confirm behavior