### PR TITLE
Publish Homebrew formula to basetenlabs/baseten tap on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)
-          if ! grep -qF "Or install $TAG with a one-liner:" README.md; then
+          if ! grep -qF "releases/download/$TAG/" README.md; then
             echo "README.md install instructions do not reference latest release $TAG; please update them."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,18 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: Generate a token scoped to homebrew-baseten
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.APP_HOMEBREW_UPDATER_CLIENT_ID }}
+          private-key: ${{ secrets.APP_HOMEBREW_UPDATER_PRIVATE_KEY }}
+          owner: basetenlabs
+          repositories: homebrew-baseten
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,13 +47,27 @@ release:
   draft: false
   prerelease: auto
 
+# Publishes Formula/baseten.rb to the basetenlabs/homebrew-baseten tap on each
+# release. Uses the deprecated `brews` (formula) rather than `homebrew_casks`
+# because the formula installs on both macOS and Linuxbrew.
+brews:
+  - name: baseten
+    repository:
+      owner: basetenlabs
+      name: homebrew-baseten
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/basetenlabs/baseten-cli"
+    description: "CLI for the Baseten Inference Platform"
+    license: MIT
+    skip_upload: auto
+    test: |
+      system "#{bin}/baseten", "--version"
+
 # TODO: Publish a Docker image to the official Baseten Docker Hub namespace.
 # dockers:
 #   - image_templates:
 #       - "baseten/baseten-cli:{{ .Version }}"
 #       - "baseten/baseten-cli:latest"
 #     dockerfile: Dockerfile
-
-# TODO: After first stable release, submit a Homebrew formula to
-# homebrew/homebrew-core. goreleaser can only publish to a custom tap, not
-# homebrew-core, so the initial submission is a manual PR.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,7 +59,7 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
     homepage: "https://github.com/basetenlabs/baseten-cli"
-    description: "CLI for the Baseten Inference Platform"
+    description: "CLI for Baseten"
     license: MIT
     skip_upload: auto
     test: |

--- a/README.md
+++ b/README.md
@@ -10,21 +10,25 @@ CLI for the [Baseten Inference Platform](https://baseten.co).
 
 ## Installation
 
-Download the [latest release](https://github.com/basetenlabs/baseten-cli/releases/latest) for your platform, extract the archive, and place the `baseten` executable on your `PATH`.
+### Homebrew (macOS and Linux)
 
-Or install v0.2.0 with a one-liner:
+```bash
+# Add and trust the tap
+brew tap basetenlabs/baseten
+brew trust basetenlabs/baseten
 
-### Linux (x64)
+# Install the CLI
+brew install baseten
+```
 
-    curl -sL https://github.com/basetenlabs/baseten-cli/releases/download/v0.2.0/baseten_0.2.0_linux_amd64.tar.gz \
-      | sudo tar xz -C /usr/local/bin baseten
+### Prebuilt binaries
 
-### macOS (arm64)
+Download the [latest release](https://github.com/basetenlabs/baseten-cli/releases/latest) for Windows, macOS, or Linux, extract the archive, and place the `baseten` executable on your `PATH`.
 
-    curl -sL https://github.com/basetenlabs/baseten-cli/releases/download/v0.2.0/baseten_0.2.0_darwin_arm64.tar.gz \
-      | sudo tar xz -C /usr/local/bin baseten
+<details>
+<summary>Windows, macOS, and Linux one-liners</summary>
 
-### Windows (x64)
+#### Windows (x64)
 
 PowerShell:
 
@@ -33,6 +37,18 @@ PowerShell:
       -OutFile baseten.zip; Expand-Archive -Force baseten.zip .
 
 Then move `baseten.exe` to a directory on your `PATH`.
+
+#### macOS (arm64)
+
+    curl -sL https://github.com/basetenlabs/baseten-cli/releases/download/v0.2.0/baseten_0.2.0_darwin_arm64.tar.gz \
+      | sudo tar xz -C /usr/local/bin baseten
+
+#### Linux (x64)
+
+    curl -sL https://github.com/basetenlabs/baseten-cli/releases/download/v0.2.0/baseten_0.2.0_linux_amd64.tar.gz \
+      | sudo tar xz -C /usr/local/bin baseten
+
+</details>
 
 ## Usage
 


### PR DESCRIPTION
## :rocket: What

- Publishes a Homebrew formula to the `basetenlabs/homebrew-baseten` tap on each release, enabling `brew tap basetenlabs/baseten && brew install baseten`.
- Updates the README to lead with Homebrew install, with prebuilt-binary one-liners collapsed below.

⚠️ DO NOT MERGE until https://github.com/basetenlabs/homebrew-baseten/pull/1 has landed and has been independently tested.

## :computer: How

- Adds a `brews:` block to `.goreleaser.yaml` (formula, not cask, so it installs on both macOS and Linuxbrew) targeting the tap repo.
- Wires a `HOMEBREW_TAP_TOKEN` secret into the release workflow for the cross-repo push.

## :microscope: Testing

- Ran `goreleaser release --skip=publish` locally to confirm the formula generates correctly.
- Verified `brew install baseten` works from the generated formula (published v0.2.0 SHAs) via a local tap.
- Cross-repo push will be exercised by the next release tag.