### PR TITLE
Add model environment logs command and switch deployment logs to GET

### DIFF
--- a/cmd/command.model.go
+++ b/cmd/command.model.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "github.com/basetenlabs/baseten-go/client/managementapi"
+import (
+	"time"
+
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+)
 
 var commandModel = Command{
 	Name:    "model",
@@ -202,6 +206,24 @@ type ModelRefFlags struct {
 	ModelID   string `flag:"model-id" desc:"ID of the model." oneof:"model-ref"`
 	ModelName string `flag:"model-name" desc:"Name of the model. Use --team to disambiguate when the same name exists in multiple teams." oneof:"model-ref"`
 	Team      string `flag:"team" desc:"Team name or ID. Only valid with --model-name."`
+}
+
+// LogFlags is the shared log-query flag set for `baseten model deployment logs`
+// and `baseten model environment logs`. Both commands accept the same window,
+// filter, and tail flags; only the log source differs.
+type LogFlags struct {
+	Tail bool `flag:"tail" desc:"Stream new logs as they arrive until the deployment leaves a runnable state or you interrupt with Ctrl-C. Cannot be combined with the time-range or filter flags. For machine-readable streaming, prefer --output jsonl over --output json."`
+
+	Start time.Time     `flag:"start" desc:"Start of the log time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the start to 30 minutes before the end. Window must be at most 7 days."`
+	End   time.Time     `flag:"end" desc:"End of the log time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the end to now. Window must be at most 7 days."`
+	Since time.Duration `flag:"since" desc:"Shortcut for fetching logs from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
+
+	MinLevel      string   `flag:"min-level" desc:"Only return logs at or above this severity level." enum:"debug,info,warning,error"`
+	Includes      []string `flag:"includes" desc:"Case-sensitive substring that must appear in the log message. May be repeated; all must match."`
+	Excludes      []string `flag:"excludes" desc:"Case-sensitive substring; lines containing it are dropped. May be repeated."`
+	SearchPattern string   `flag:"search-pattern" desc:"RE2 regular expression matched against the log message. Prefer --includes and --excludes for plain substring matches."`
+	Replica       string   `flag:"replica" desc:"Only return logs emitted by this replica (5-char short ID)."`
+	RequestID     string   `flag:"request-id" desc:"Only return logs tagged with this inference request ID."`
 }
 
 // ModelPushFlags configures `baseten model push`.

--- a/cmd/command.model_deployment.go
+++ b/cmd/command.model_deployment.go
@@ -345,19 +345,7 @@ type ModelDeploymentPromoteFlags struct {
 type ModelDeploymentLogsFlags struct {
 	CommandFlags
 	ModelDeploymentIDFlags
-
-	Tail bool `flag:"tail" desc:"Stream new logs as they arrive until the deployment leaves a runnable state or you interrupt with Ctrl-C. Cannot be combined with the time-range or filter flags. For machine-readable streaming, prefer --output jsonl over --output json."`
-
-	Start time.Time     `flag:"start" desc:"Start of the log time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the start to 30 minutes before the end. Window must be at most 7 days."`
-	End   time.Time     `flag:"end" desc:"End of the log time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the end to now. Window must be at most 7 days."`
-	Since time.Duration `flag:"since" desc:"Shortcut for fetching logs from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
-
-	MinLevel      string   `flag:"min-level" desc:"Only return logs at or above this severity level." enum:"debug,info,warning,error"`
-	Includes      []string `flag:"includes" desc:"Case-sensitive substring that must appear in the log message. May be repeated; all must match."`
-	Excludes      []string `flag:"excludes" desc:"Case-sensitive substring; lines containing it are dropped. May be repeated."`
-	SearchPattern string   `flag:"search-pattern" desc:"RE2 regular expression matched against the log message. Prefer --includes and --excludes for plain substring matches."`
-	Replica       string   `flag:"replica" desc:"Only return logs emitted by this replica (5-char short ID)."`
-	RequestID     string   `flag:"request-id" desc:"Only return logs tagged with this inference request ID."`
+	LogFlags
 }
 
 // ModelDeploymentMetricsFlags configures `baseten model deployment metrics`.

--- a/cmd/command.model_environment.go
+++ b/cmd/command.model_environment.go
@@ -87,6 +87,36 @@ var commandModelEnvironment = Command{
 				},
 			},
 		},
+		{
+			Name:    "logs",
+			Summary: "Stream or tail logs for an environment",
+			Description: "Fetch logs for a model environment, spanning every deployment that " +
+				"was active on the environment across the time range.\n\n" +
+				"By default returns logs from the server's default recent window. " +
+				"Use --start/--end or --since to scope the window (max 7 days). " +
+				"Use --tail to stream live logs until the environment's current " +
+				"deployment leaves a runnable state or you interrupt with Ctrl-C.\n\n" +
+				"For machine-readable streaming, prefer --output jsonl over --output json.",
+			Flags: ModelEnvironmentLogsFlags{},
+			Output: &CommandOutput[managementapi.Log]{
+				JSONArrayStreamed: true,
+				TextDescription:   "One line per log record: \"[YYYY-MM-DD HH:MM:SS]: (replica) message\".",
+				Examples: []CommandExample{
+					{
+						Description: "Print logs for the production environment over the last hour.",
+						Command:     "baseten model environment logs --model-id <model-id> --environment production --since 1h",
+					},
+					{
+						Description: "Tail live logs until the environment's current deployment leaves a runnable state.",
+						Command:     "baseten model environment logs --model-id <model-id> --environment production --tail",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Stream just the log messages as a JSONL stream.",
+					Command:     "baseten model environment logs --model-id <model-id> --environment production --output jsonl --jq '.message'",
+				},
+			},
+		},
 	},
 }
 
@@ -121,4 +151,11 @@ type ModelEnvironmentDeactivateFlags struct {
 	ModelEnvironmentFlags
 
 	Yes bool `flag:"yes" desc:"Skip the interactive confirmation prompt. Required when stdin is not a terminal."`
+}
+
+// ModelEnvironmentLogsFlags configures `baseten model environment logs`.
+type ModelEnvironmentLogsFlags struct {
+	CommandFlags
+	ModelEnvironmentFlags
+	LogFlags
 }

--- a/internal/cmd/command.model_deployment_logs.go
+++ b/internal/cmd/command.model_deployment_logs.go
@@ -24,6 +24,66 @@ func init() {
 }
 
 func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentLogsFlags) error {
+	api, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := ResolveModelRef(ctx, api.API(), flags.ModelRefFlags)
+	if err != nil {
+		return err
+	}
+
+	fetchLogs := func(q logQuery) (*managementapi.GetLogsResponse, error) {
+		return api.API().GetModelsDeploymentsLogs(ctx, ref.ID, flags.DeploymentID, deploymentLogParams(q))
+	}
+	fetchStatus := func() (*managementapi.Deployment, error) {
+		return api.API().GetModelsDeploymentsDeploymentId(ctx, ref.ID, flags.DeploymentID)
+	}
+	return runLogsCommand(ctx, &flags.LogFlags, fetchLogs, fetchStatus)
+}
+
+// logQuery is the transport-neutral set of log-query parameters shared by the
+// deployment and environment logs endpoints. Each command maps it onto its own
+// generated query-params type.
+type logQuery struct {
+	StartEpochMillis *int
+	EndEpochMillis   *int
+	MinLevel         *managementapi.LogLevel
+	Includes         *[]string
+	Excludes         *[]string
+	SearchPattern    *string
+	Replica          *string
+	RequestId        *string
+}
+
+// logFetcher fetches a page of logs for the given query.
+type logFetcher func(q logQuery) (*managementapi.GetLogsResponse, error)
+
+// statusFetcher resolves the deployment whose status gates a --tail loop. For a
+// deployment command it is the deployment itself; for an environment command it
+// is the environment's current deployment.
+type statusFetcher func() (*managementapi.Deployment, error)
+
+// deploymentLogParams maps a transport-neutral logQuery onto the deployment
+// logs GET query-params type.
+func deploymentLogParams(q logQuery) managementapi.GetV1ModelsModelIdDeploymentsDeploymentIdLogsParams {
+	return managementapi.GetV1ModelsModelIdDeploymentsDeploymentIdLogsParams{
+		StartEpochMillis: q.StartEpochMillis,
+		EndEpochMillis:   q.EndEpochMillis,
+		MinLevel:         q.MinLevel,
+		Includes:         q.Includes,
+		Excludes:         q.Excludes,
+		SearchPattern:    q.SearchPattern,
+		Replica:          q.Replica,
+		RequestId:        q.RequestId,
+	}
+}
+
+// runLogsCommand implements the shared logs command flow for both deployment and
+// environment logs. It validates the flags, resolves the time window and
+// filters, and either tails or fetches a single window via the supplied
+// fetchers. fetchStatus is only used by the --tail path.
+func runLogsCommand(ctx *CommandContext, flags *cmd.LogFlags, fetchLogs logFetcher, fetchStatus statusFetcher) error {
 	hasStart := !flags.Start.IsZero()
 	hasEnd := !flags.End.IsZero()
 	// Use Changed rather than the zero value so explicit --since 0 fails
@@ -38,22 +98,9 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 		return cmd.NewErrUsagef("--since cannot be combined with --start or --end")
 	}
 
-	api, err := ctx.NewManagementClient()
-	if err != nil {
-		return err
-	}
-	ref, err := ResolveModelRef(ctx, api.API(), flags.ModelRefFlags)
-	if err != nil {
-		return err
-	}
-
 	if flags.Tail {
-		res := TailDeploymentLogs(ctx, TailDeploymentLogsOptions{
-			API:          api.API(),
-			ModelID:      ref.ID,
-			DeploymentID: flags.DeploymentID,
-		})
-		if err := emitDeploymentLogs(ctx, res.Logs); err != nil {
+		res := tailLogs(ctx, tailLogsOptions{FetchLogs: fetchLogs, FetchStatus: fetchStatus})
+		if err := emitLogs(ctx, res.Logs); err != nil {
 			return err
 		}
 		if dep := res.FinalFetchedDeployment(); dep != nil {
@@ -64,7 +111,7 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 
 	// Resolve --start/--end/--since into epoch-millis bounds. Nil bounds mean
 	// "server default"; unset start/end/since pass nils.
-	var req managementapi.GetDeploymentLogsRequest
+	var q logQuery
 	if hasSince {
 		if flags.Since <= 0 {
 			return cmd.NewErrUsagef("--since must be a positive duration")
@@ -75,18 +122,18 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 		now := ctx.Now()
 		s := int(now.Add(-flags.Since).UnixMilli())
 		e := int(now.UnixMilli())
-		req.StartEpochMillis, req.EndEpochMillis = &s, &e
+		q.StartEpochMillis, q.EndEpochMillis = &s, &e
 	} else if hasStart || hasEnd {
 		// Send only the bounds given and leave the other nil so the server
 		// backfills it (missing end -> now, missing start -> 30m before end).
 		// Validate the window client-side only when both bounds are given.
 		if hasStart {
 			s := int(flags.Start.UnixMilli())
-			req.StartEpochMillis = &s
+			q.StartEpochMillis = &s
 		}
 		if hasEnd {
 			e := int(flags.End.UnixMilli())
-			req.EndEpochMillis = &e
+			q.EndEpochMillis = &e
 		}
 		if hasStart && hasEnd {
 			if !flags.Start.Before(flags.End) {
@@ -100,30 +147,30 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 
 	if flags.MinLevel != "" {
 		level := managementapi.LogLevel(strings.ToUpper(flags.MinLevel))
-		req.MinLevel = &level
+		q.MinLevel = &level
 	}
 	if len(flags.Includes) > 0 {
-		req.Includes = &flags.Includes
+		q.Includes = &flags.Includes
 	}
 	if len(flags.Excludes) > 0 {
-		req.Excludes = &flags.Excludes
+		q.Excludes = &flags.Excludes
 	}
 	if flags.SearchPattern != "" {
-		req.SearchPattern = &flags.SearchPattern
+		q.SearchPattern = &flags.SearchPattern
 	}
 	if flags.Replica != "" {
-		req.Replica = &flags.Replica
+		q.Replica = &flags.Replica
 	}
 	if flags.RequestID != "" {
-		req.RequestId = &flags.RequestID
+		q.RequestId = &flags.RequestID
 	}
 
-	resp, err := api.API().PostModelsDeploymentsLogs(ctx, ref.ID, flags.DeploymentID, req)
+	resp, err := fetchLogs(q)
 	if err != nil {
 		return err
 	}
 
-	return emitDeploymentLogs(ctx, func(yield func(*managementapi.Log, error) bool) {
+	return emitLogs(ctx, func(yield func(*managementapi.Log, error) bool) {
 		for i := range resp.Logs {
 			if !yield(&resp.Logs[i], nil) {
 				return
@@ -132,12 +179,11 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 	})
 }
 
-// emitDeploymentLogs drains an iterator of log records onto stdout in the
-// caller-selected output mode. For ctx.JSON (both json and jsonl) it uses a
-// JSON array writer so jsonl streams one record per line and json buffers
-// into a single closed array. For text it formats each line via
-// FormatDeploymentLogLine.
-func emitDeploymentLogs(ctx *CommandContext, logs iter.Seq2[*managementapi.Log, error]) error {
+// emitLogs drains an iterator of log records onto stdout in the caller-selected
+// output mode. For ctx.JSON (both json and jsonl) it uses a JSON array writer so
+// jsonl streams one record per line and json buffers into a single closed
+// array. For text it formats each line via FormatDeploymentLogLine.
+func emitLogs(ctx *CommandContext, logs iter.Seq2[*managementapi.Log, error]) error {
 	if ctx.JSON {
 		w := ctx.NewJSONArrayWriter()
 		defer w.Close()
@@ -209,14 +255,48 @@ type TailDeploymentLogsResult struct {
 	FinalFetchedDeployment func() *managementapi.Deployment
 }
 
-// TailDeploymentLogs polls a deployment's logs and streams new records until
-// the status leaves the runnable set or the context is cancelled. The
-// runnable set is {BUILDING, DEPLOYING, LOADING_MODEL, UPDATING, WAKING_UP}
-// plus ACTIVE when StopOnActive is false (default). Any other status,
-// including unknown ones, stops the tail. Dedup is by (timestamp, message,
-// replica) across overlapping clock-skew windows. Clock-and-sleep behavior
-// is taken from ctx (overridable via WithNow / WithSleep for tests).
+// TailDeploymentLogs tails a specific deployment's logs. It is a thin adapter
+// over tailLogs that wires the deployment logs and describe endpoints.
 func TailDeploymentLogs(ctx *CommandContext, opts TailDeploymentLogsOptions) *TailDeploymentLogsResult {
+	return tailLogs(ctx, tailLogsOptions{
+		FetchLogs: func(q logQuery) (*managementapi.GetLogsResponse, error) {
+			return opts.API.GetModelsDeploymentsLogs(ctx, opts.ModelID, opts.DeploymentID, deploymentLogParams(q))
+		},
+		FetchStatus: func() (*managementapi.Deployment, error) {
+			return opts.API.GetModelsDeploymentsDeploymentId(ctx, opts.ModelID, opts.DeploymentID)
+		},
+		StopOnActive:  opts.StopOnActive,
+		WarmupTimeout: opts.WarmupTimeout,
+	})
+}
+
+// tailLogsOptions configures tailLogs, the transport-neutral tail loop shared by
+// the deployment and environment logs commands.
+type tailLogsOptions struct {
+	// FetchLogs fetches a poll window of logs. Required.
+	FetchLogs logFetcher
+	// FetchStatus resolves the deployment whose status gates the tail.
+	// Required.
+	FetchStatus statusFetcher
+
+	// StopOnActive stops the tail when the deployment reaches ACTIVE. By
+	// default ACTIVE is treated as a runnable state and tailing continues.
+	StopOnActive bool
+
+	// WarmupTimeout is how long to silently retry 404s from the logs API at
+	// the start of the tail, before any successful poll. Zero means no
+	// warmup retries.
+	WarmupTimeout time.Duration
+}
+
+// tailLogs polls logs and streams new records until the gating deployment's
+// status leaves the runnable set or the context is cancelled. The runnable set
+// is {BUILDING, DEPLOYING, LOADING_MODEL, UPDATING, WAKING_UP} plus ACTIVE when
+// StopOnActive is false (default). Any other status, including unknown ones,
+// stops the tail. Dedup is by (timestamp, message, replica) across overlapping
+// clock-skew windows. Clock-and-sleep behavior is taken from ctx (overridable
+// via WithNow / WithSleep for tests).
+func tailLogs(ctx *CommandContext, opts tailLogsOptions) *TailDeploymentLogsResult {
 	var finalFetched *managementapi.Deployment
 
 	seq := func(yield func(*managementapi.Log, error) bool) {
@@ -241,8 +321,7 @@ func TailDeploymentLogs(ctx *CommandContext, opts TailDeploymentLogsOptions) *Ta
 				startMs = &v
 			}
 			endMs := int(nowMs + deploymentLogClockSkewBuffer.Milliseconds())
-			resp, err := opts.API.PostModelsDeploymentsLogs(ctx, opts.ModelID, opts.DeploymentID,
-				managementapi.GetDeploymentLogsRequest{StartEpochMillis: startMs, EndEpochMillis: &endMs})
+			resp, err := opts.FetchLogs(logQuery{StartEpochMillis: startMs, EndEpochMillis: &endMs})
 			if err != nil {
 				// Brand-new deployments may 404 on the logs index for a few
 				// seconds after creation; retry quietly within the warmup
@@ -294,7 +373,7 @@ func TailDeploymentLogs(ctx *CommandContext, opts TailDeploymentLogsOptions) *Ta
 			// TODO: should the management logs API return current status so
 			// we can drop this extra round-trip per poll?
 			if len(seen) > 0 {
-				dep, err := opts.API.GetModelsDeploymentsDeploymentId(ctx, opts.ModelID, opts.DeploymentID)
+				dep, err := opts.FetchStatus()
 				if err != nil {
 					yield(nil, fmt.Errorf("fetch deployment status: %w", err))
 					return

--- a/internal/cmd/command.model_deployment_logs_test.go
+++ b/internal/cmd/command.model_deployment_logs_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -33,6 +34,16 @@ func logsResponse(logs ...map[string]any) map[string]any {
 		logs = []map[string]any{}
 	}
 	return map[string]any{"logs": logs}
+}
+
+// captureLogsQuery registers a GET logs route that records the request query
+// and responds with the given logs.
+func captureLogsQuery(api *MockManagementAPI, path string, gotQuery *url.Values, logs ...map[string]any) {
+	api.SetRouteFunc("GET", path, func(w http.ResponseWriter, r *http.Request) {
+		*gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(logsResponse(logs...))
+	})
 }
 
 func Test_Model_Deployment_Logs_TailWithStartRejected(t *testing.T) {
@@ -82,8 +93,8 @@ func Test_Model_Deployment_Logs_SinceOver7DaysRejected(t *testing.T) {
 
 func Test_Model_Deployment_Logs_FiltersSent(t *testing.T) {
 	h := NewCommandHarness(t)
-	api := h.MockManagementAPI()
-	api.SetRoute("POST", logsLogsPath, 200, logsResponse())
+	var gotQuery url.Values
+	captureLogsQuery(h.MockManagementAPI(), logsLogsPath, &gotQuery)
 	err := h.Execute("model", "deployment", "logs",
 		"--model-id", "m", "--deployment-id", "d",
 		"--min-level", "info",
@@ -93,25 +104,24 @@ func Test_Model_Deployment_Logs_FiltersSent(t *testing.T) {
 		"--replica", "g00r0",
 		"--request-id", "req-123")
 	h.Require.NoError(err)
-	req := api.FindCall("POST", logsLogsPath).BodyJSON(h.T)
 	// --min-level is uppercased before sending.
-	h.Require.Equal("INFO", req["min_level"])
-	h.Require.Equal([]any{"warn", "fail"}, req["includes"])
-	h.Require.Equal([]any{"healthz"}, req["excludes"])
-	h.Require.Equal(".*timeout", req["search_pattern"])
-	h.Require.Equal("g00r0", req["replica"])
-	h.Require.Equal("req-123", req["request_id"])
+	h.Require.Equal("INFO", gotQuery.Get("min_level"))
+	h.Require.Equal([]string{"warn", "fail"}, gotQuery["includes"])
+	h.Require.Equal([]string{"healthz"}, gotQuery["excludes"])
+	h.Require.Equal(".*timeout", gotQuery.Get("search_pattern"))
+	h.Require.Equal("g00r0", gotQuery.Get("replica"))
+	h.Require.Equal("req-123", gotQuery.Get("request_id"))
 }
 
 func Test_Model_Deployment_Logs_FiltersOmittedWhenUnset(t *testing.T) {
 	h := NewCommandHarness(t)
-	api := h.MockManagementAPI()
-	api.SetRoute("POST", logsLogsPath, 200, logsResponse())
+	var gotQuery url.Values
+	captureLogsQuery(h.MockManagementAPI(), logsLogsPath, &gotQuery)
 	err := h.Execute("model", "deployment", "logs", "--model-id", "m", "--deployment-id", "d")
 	h.Require.NoError(err)
-	req := api.FindCall("POST", logsLogsPath).BodyJSON(h.T)
-	for _, field := range []string{"min_level", "includes", "excludes", "search_pattern", "replica", "request_id"} {
-		h.Require.Nil(req[field], "expected %s to be omitted", field)
+	for _, field := range []string{"min_level", "includes", "excludes", "search_pattern", "replica", "request_id", "start_epoch_millis", "end_epoch_millis"} {
+		_, ok := gotQuery[field]
+		h.Require.False(ok, "expected %s to be omitted", field)
 	}
 }
 
@@ -137,7 +147,7 @@ func Test_Model_Deployment_Logs_OneShotText(t *testing.T) {
 	// local timezone, so format the expected string against time.Local.
 	logAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
 	ts := logAt.UnixNano()
-	h.MockManagementAPI().SetRoute("POST", logsLogsPath, 200, logsResponse(
+	h.MockManagementAPI().SetRoute("GET", logsLogsPath, 200, logsResponse(
 		map[string]any{"timestamp": strconv.FormatInt(ts, 10), "message": "hello", "replica": "r-1"},
 		map[string]any{"timestamp": strconv.FormatInt(ts+int64(time.Second), 10), "message": "world", "replica": nil},
 	))
@@ -151,7 +161,7 @@ func Test_Model_Deployment_Logs_OneShotText(t *testing.T) {
 
 func Test_Model_Deployment_Logs_OneShotJSON(t *testing.T) {
 	h := NewCommandHarness(t)
-	h.MockManagementAPI().SetRoute("POST", logsLogsPath, 200, logsResponse(
+	h.MockManagementAPI().SetRoute("GET", logsLogsPath, 200, logsResponse(
 		map[string]any{"timestamp": "1", "message": "hi", "replica": nil},
 	))
 	err := h.Execute("model", "deployment", "logs",
@@ -165,7 +175,7 @@ func Test_Model_Deployment_Logs_OneShotJSON(t *testing.T) {
 
 func Test_Model_Deployment_Logs_OneShotJSONL(t *testing.T) {
 	h := NewCommandHarness(t)
-	h.MockManagementAPI().SetRoute("POST", logsLogsPath, 200, logsResponse(
+	h.MockManagementAPI().SetRoute("GET", logsLogsPath, 200, logsResponse(
 		map[string]any{"timestamp": "1", "message": "a", "replica": nil},
 		map[string]any{"timestamp": "2", "message": "b", "replica": nil},
 	))
@@ -182,68 +192,61 @@ func Test_Model_Deployment_Logs_OneShotJSONL(t *testing.T) {
 
 func Test_Model_Deployment_Logs_SinceBoundsSent(t *testing.T) {
 	h := NewCommandHarness(t)
-	api := h.MockManagementAPI()
-	api.SetRoute("POST", logsLogsPath, 200, logsResponse())
+	var gotQuery url.Values
+	captureLogsQuery(h.MockManagementAPI(), logsLogsPath, &gotQuery)
 	fixed := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
 	h.Context = cmd.WithNow(h.Context, func() time.Time { return fixed })
 	err := h.Execute("model", "deployment", "logs",
 		"--model-id", "m", "--deployment-id", "d", "--since", "30m")
 	h.Require.NoError(err)
-	call := api.FindCall("POST", logsLogsPath)
-	h.Require.NotNil(call)
-	req := call.BodyJSON(h.T)
-	endMs := fixed.UnixMilli()
-	startMs := fixed.Add(-30 * time.Minute).UnixMilli()
-	h.Require.Equal(float64(startMs), req["start_epoch_millis"])
-	h.Require.Equal(float64(endMs), req["end_epoch_millis"])
+	h.Require.Equal(int(fixed.UnixMilli()), mustAtoi(t, gotQuery.Get("end_epoch_millis")))
+	h.Require.Equal(int(fixed.Add(-30*time.Minute).UnixMilli()), mustAtoi(t, gotQuery.Get("start_epoch_millis")))
 }
 
 func Test_Model_Deployment_Logs_SinceWithDaySuffix(t *testing.T) {
 	h := NewCommandHarness(t)
-	api := h.MockManagementAPI()
-	api.SetRoute("POST", logsLogsPath, 200, logsResponse())
+	var gotQuery url.Values
+	captureLogsQuery(h.MockManagementAPI(), logsLogsPath, &gotQuery)
 	fixed := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
 	h.Context = cmd.WithNow(h.Context, func() time.Time { return fixed })
 	err := h.Execute("model", "deployment", "logs",
 		"--model-id", "m", "--deployment-id", "d", "--since", "3d")
 	h.Require.NoError(err)
-	req := api.FindCall("POST", logsLogsPath).BodyJSON(h.T)
-	startMs := fixed.Add(-3 * 24 * time.Hour).UnixMilli()
-	h.Require.Equal(float64(startMs), req["start_epoch_millis"])
+	h.Require.Equal(int(fixed.Add(-3*24*time.Hour).UnixMilli()), mustAtoi(t, gotQuery.Get("start_epoch_millis")))
 }
 
 func Test_Model_Deployment_Logs_StartOnlyDefersEndToServer(t *testing.T) {
 	h := NewCommandHarness(t)
-	api := h.MockManagementAPI()
-	api.SetRoute("POST", logsLogsPath, 200, logsResponse())
+	var gotQuery url.Values
+	captureLogsQuery(h.MockManagementAPI(), logsLogsPath, &gotQuery)
 	start := time.Date(2026, 5, 13, 11, 0, 0, 0, time.Local)
 	err := h.Execute("model", "deployment", "logs",
 		"--model-id", "m", "--deployment-id", "d", "--start", "2026-05-13T11:00:00")
 	h.Require.NoError(err)
-	req := api.FindCall("POST", logsLogsPath).BodyJSON(h.T)
 	// Only --start is sent; end is left for the server to backfill.
-	h.Require.Equal(float64(start.UnixMilli()), req["start_epoch_millis"])
-	h.Require.Nil(req["end_epoch_millis"])
+	h.Require.Equal(int(start.UnixMilli()), mustAtoi(t, gotQuery.Get("start_epoch_millis")))
+	_, ok := gotQuery["end_epoch_millis"]
+	h.Require.False(ok)
 }
 
 func Test_Model_Deployment_Logs_EndOnlyDefersStartToServer(t *testing.T) {
 	h := NewCommandHarness(t)
-	api := h.MockManagementAPI()
-	api.SetRoute("POST", logsLogsPath, 200, logsResponse())
+	var gotQuery url.Values
+	captureLogsQuery(h.MockManagementAPI(), logsLogsPath, &gotQuery)
 	end := time.Date(2026, 5, 14, 12, 0, 0, 0, time.Local)
 	err := h.Execute("model", "deployment", "logs",
 		"--model-id", "m", "--deployment-id", "d", "--end", "2026-05-14T12:00:00")
 	h.Require.NoError(err)
-	req := api.FindCall("POST", logsLogsPath).BodyJSON(h.T)
 	// Only --end is sent; start is left for the server to backfill.
-	h.Require.Equal(float64(end.UnixMilli()), req["end_epoch_millis"])
-	h.Require.Nil(req["start_epoch_millis"])
+	h.Require.Equal(int(end.UnixMilli()), mustAtoi(t, gotQuery.Get("end_epoch_millis")))
+	_, ok := gotQuery["start_epoch_millis"]
+	h.Require.False(ok)
 }
 
 func Test_Model_Deployment_Logs_TailTerminatesOnStopStatus(t *testing.T) {
 	h := NewCommandHarness(t)
 	api := h.MockManagementAPI()
-	api.SetRoute("POST", logsLogsPath, 200, logsResponse(
+	api.SetRoute("GET", logsLogsPath, 200, logsResponse(
 		map[string]any{"timestamp": "1", "message": "build started", "replica": nil},
 	))
 	api.SetRoute("GET", logsDeployPath, 200, logsDeployment("BUILD_FAILED"))
@@ -258,7 +261,7 @@ func Test_Model_Deployment_Logs_TailTerminatesOnStopStatus(t *testing.T) {
 func Test_Model_Deployment_Logs_TailStopsOnUnknownStatus(t *testing.T) {
 	h := NewCommandHarness(t)
 	api := h.MockManagementAPI()
-	api.SetRoute("POST", logsLogsPath, 200, logsResponse(
+	api.SetRoute("GET", logsLogsPath, 200, logsResponse(
 		map[string]any{"timestamp": "1", "message": "alive", "replica": nil},
 	))
 	api.SetRoute("GET", logsDeployPath, 200, logsDeployment("SOME_NEW_STATE"))
@@ -274,7 +277,7 @@ func Test_Model_Deployment_Logs_TailDedupesAcrossPolls(t *testing.T) {
 	api := h.MockManagementAPI()
 	dup := map[string]any{"timestamp": "1", "message": "same", "replica": nil}
 	logsCalls := 0
-	api.SetRouteFunc("POST", logsLogsPath, func(w http.ResponseWriter, _ *http.Request) {
+	api.SetRouteFunc("GET", logsLogsPath, func(w http.ResponseWriter, _ *http.Request) {
 		logsCalls++
 		var payload map[string]any
 		if logsCalls == 1 {
@@ -308,7 +311,7 @@ func Test_Model_Deployment_Logs_TailDedupesAcrossPolls(t *testing.T) {
 func Test_Model_Deployment_Logs_TailJSONLStreaming(t *testing.T) {
 	h := NewCommandHarness(t)
 	api := h.MockManagementAPI()
-	api.SetRoute("POST", logsLogsPath, 200, logsResponse(
+	api.SetRoute("GET", logsLogsPath, 200, logsResponse(
 		map[string]any{"timestamp": "1", "message": "a", "replica": nil},
 	))
 	api.SetRoute("GET", logsDeployPath, 200, logsDeployment("BUILD_FAILED"))
@@ -325,7 +328,7 @@ func Test_Model_Deployment_Logs_TailJSONLStreaming(t *testing.T) {
 func Test_Model_Deployment_Logs_TailJSONArrayClosesOnExit(t *testing.T) {
 	h := NewCommandHarness(t)
 	api := h.MockManagementAPI()
-	api.SetRoute("POST", logsLogsPath, 200, logsResponse(
+	api.SetRoute("GET", logsLogsPath, 200, logsResponse(
 		map[string]any{"timestamp": "1", "message": "a", "replica": nil},
 	))
 	api.SetRoute("GET", logsDeployPath, 200, logsDeployment("BUILD_FAILED"))

--- a/internal/cmd/command.model_environment_logs.go
+++ b/internal/cmd/command.model_environment_logs.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+)
+
+func init() {
+	Register("model environment logs", commandModelEnvironmentLogs)
+}
+
+func commandModelEnvironmentLogs(ctx *CommandContext, flags *cmd.ModelEnvironmentLogsFlags) error {
+	api, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := ResolveModelRef(ctx, api.API(), flags.ModelRefFlags)
+	if err != nil {
+		return err
+	}
+
+	fetchLogs := func(q logQuery) (*managementapi.GetLogsResponse, error) {
+		return api.API().GetModelsEnvironmentsLogs(ctx, ref.ID, flags.Environment,
+			managementapi.GetV1ModelsModelIdEnvironmentsEnvNameLogsParams{
+				StartEpochMillis: q.StartEpochMillis,
+				EndEpochMillis:   q.EndEpochMillis,
+				MinLevel:         q.MinLevel,
+				Includes:         q.Includes,
+				Excludes:         q.Excludes,
+				SearchPattern:    q.SearchPattern,
+				Replica:          q.Replica,
+				RequestId:        q.RequestId,
+			})
+	}
+	// The tail stop condition tracks the environment's current deployment, so
+	// each status poll resolves the environment and reports its current
+	// deployment's status.
+	fetchStatus := func() (*managementapi.Deployment, error) {
+		env, err := api.API().GetModelsEnvironmentsEnvName(ctx, ref.ID, flags.Environment)
+		if err != nil {
+			return nil, err
+		}
+		return &env.CurrentDeployment, nil
+	}
+	return runLogsCommand(ctx, &flags.LogFlags, fetchLogs, fetchStatus)
+}

--- a/internal/cmd/command.model_environment_logs_test.go
+++ b/internal/cmd/command.model_environment_logs_test.go
@@ -1,0 +1,177 @@
+package cmd_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/internal/cmd"
+)
+
+const (
+	envLogsPath     = "/v1/models/m/environments/production/logs"
+	envDescribePath = "/v1/models/m/environments/production"
+)
+
+// envLogsEnvironment is a minimal environment describe payload whose current
+// deployment carries the given status, used to drive the tail stop condition.
+func envLogsEnvironment(status string) map[string]any {
+	return map[string]any{
+		"name":       "production",
+		"model_id":   "m",
+		"created_at": "2026-05-14T12:00:00Z",
+		"current_deployment": map[string]any{
+			"id":         "dep-1",
+			"model_id":   "m",
+			"name":       "v1",
+			"status":     status,
+			"created_at": "2026-05-14T12:00:00Z",
+		},
+	}
+}
+
+func Test_Model_Environment_Logs_TailWithStartRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "environment", "logs",
+		"--model-id", "m", "--environment", "production",
+		"--tail", "--start", "2026-05-14")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "--tail cannot be combined")
+}
+
+func Test_Model_Environment_Logs_SinceWithStartRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "environment", "logs",
+		"--model-id", "m", "--environment", "production",
+		"--since", "30m", "--start", "2026-05-14")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "--since cannot be combined")
+}
+
+func Test_Model_Environment_Logs_WindowOver7DaysRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "environment", "logs",
+		"--model-id", "m", "--environment", "production",
+		"--start", "2026-05-01", "--end", "2026-05-10")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "at most 7 days")
+}
+
+func Test_Model_Environment_Logs_FiltersSent(t *testing.T) {
+	h := NewCommandHarness(t)
+	var gotQuery url.Values
+	captureLogsQuery(h.MockManagementAPI(), envLogsPath, &gotQuery)
+	err := h.Execute("model", "environment", "logs",
+		"--model-id", "m", "--environment", "production",
+		"--min-level", "info",
+		"--includes", "warn", "--includes", "fail",
+		"--excludes", "healthz",
+		"--search-pattern", ".*timeout",
+		"--replica", "g00r0",
+		"--request-id", "req-123")
+	h.Require.NoError(err)
+	h.Require.Equal("INFO", gotQuery.Get("min_level"))
+	h.Require.Equal([]string{"warn", "fail"}, gotQuery["includes"])
+	h.Require.Equal([]string{"healthz"}, gotQuery["excludes"])
+	h.Require.Equal(".*timeout", gotQuery.Get("search_pattern"))
+	h.Require.Equal("g00r0", gotQuery.Get("replica"))
+	h.Require.Equal("req-123", gotQuery.Get("request_id"))
+}
+
+func Test_Model_Environment_Logs_SinceBoundsSent(t *testing.T) {
+	h := NewCommandHarness(t)
+	var gotQuery url.Values
+	captureLogsQuery(h.MockManagementAPI(), envLogsPath, &gotQuery)
+	fixed := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	h.Context = cmd.WithNow(h.Context, func() time.Time { return fixed })
+	err := h.Execute("model", "environment", "logs",
+		"--model-id", "m", "--environment", "production", "--since", "30m")
+	h.Require.NoError(err)
+	h.Require.Equal(int(fixed.UnixMilli()), mustAtoi(t, gotQuery.Get("end_epoch_millis")))
+	h.Require.Equal(int(fixed.Add(-30*time.Minute).UnixMilli()), mustAtoi(t, gotQuery.Get("start_epoch_millis")))
+}
+
+func Test_Model_Environment_Logs_OneShotText(t *testing.T) {
+	h := NewCommandHarness(t)
+	logAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	h.MockManagementAPI().SetRoute("GET", envLogsPath, 200, logsResponse(
+		map[string]any{"timestamp": strconv.FormatInt(logAt.UnixNano(), 10), "message": "hello", "replica": "r-1"},
+	))
+	err := h.Execute("model", "environment", "logs",
+		"--model-id", "m", "--environment", "production")
+	h.Require.NoError(err)
+	h.Require.Contains(h.Stdout.String(), "(r-1) hello")
+}
+
+func Test_Model_Environment_Logs_OneShotJSONL(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", envLogsPath, 200, logsResponse(
+		map[string]any{"timestamp": "1", "message": "a", "replica": nil},
+		map[string]any{"timestamp": "2", "message": "b", "replica": nil},
+	))
+	err := h.Execute("model", "environment", "logs",
+		"--model-id", "m", "--environment", "production", "--output", "jsonl")
+	h.Require.NoError(err)
+	lines := strings.Split(strings.TrimRight(h.Stdout.String(), "\n"), "\n")
+	h.Require.Len(lines, 2)
+	for _, l := range lines {
+		var v map[string]any
+		h.Require.NoError(json.Unmarshal([]byte(l), &v))
+	}
+}
+
+func Test_Model_Environment_Logs_TailTerminatesOnCurrentDeploymentStatus(t *testing.T) {
+	h := NewCommandHarness(t)
+	api := h.MockManagementAPI()
+	api.SetRoute("GET", envLogsPath, 200, logsResponse(
+		map[string]any{"timestamp": "1", "message": "build started", "replica": nil},
+	))
+	// Tail stop condition resolves the environment's current deployment.
+	api.SetRoute("GET", envDescribePath, 200, envLogsEnvironment("BUILD_FAILED"))
+	h.Context = cmd.WithSleep(h.Context, func(_ context.Context, _ time.Duration) error { return nil })
+	err := h.Execute("model", "environment", "logs",
+		"--model-id", "m", "--environment", "production", "--tail")
+	h.Require.NoError(err)
+	h.Require.Contains(h.Stdout.String(), "build started")
+	h.Require.Contains(h.Stderr.String(), "Tailing stopped: deployment status BUILD_FAILED")
+}
+
+func Test_Model_Environment_Logs_TailDedupesAcrossPolls(t *testing.T) {
+	h := NewCommandHarness(t)
+	api := h.MockManagementAPI()
+	dup := map[string]any{"timestamp": "1", "message": "same", "replica": nil}
+	logsCalls := 0
+	api.SetRouteFunc("GET", envLogsPath, func(w http.ResponseWriter, _ *http.Request) {
+		logsCalls++
+		var payload map[string]any
+		if logsCalls == 1 {
+			payload = logsResponse(dup)
+		} else {
+			payload = logsResponse(dup, map[string]any{"timestamp": "2", "message": "next", "replica": nil})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	})
+	envCalls := 0
+	api.SetRouteFunc("GET", envDescribePath, func(w http.ResponseWriter, _ *http.Request) {
+		envCalls++
+		status := "ACTIVE"
+		if envCalls > 1 {
+			status = "BUILD_FAILED"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(envLogsEnvironment(status))
+	})
+
+	h.Context = cmd.WithSleep(h.Context, func(_ context.Context, _ time.Duration) error { return nil })
+	err := h.Execute("model", "environment", "logs",
+		"--model-id", "m", "--environment", "production", "--tail")
+	h.Require.NoError(err)
+	h.Require.Equal(1, strings.Count(h.Stdout.String(), "same"))
+	h.Require.Contains(h.Stdout.String(), "next")
+}

--- a/internal/cmd/command.model_push_test.go
+++ b/internal/cmd/command.model_push_test.go
@@ -541,7 +541,7 @@ func Test_Model_Push_WaitFailure(t *testing.T) {
 func Test_Model_Push_TailFailure(t *testing.T) {
 	h := newModelPushHarness(t)
 	stubModelPushTimeAndSleep(h)
-	h.API.SetRoute("POST", "/v1/models/model-123/deployments/deploy-456/logs", 200, map[string]any{
+	h.API.SetRoute("GET", "/v1/models/model-123/deployments/deploy-456/logs", 200, map[string]any{
 		"logs": []any{
 			map[string]any{"timestamp": "1", "message": "build started", "replica": nil},
 		},
@@ -566,7 +566,7 @@ func Test_Model_Push_TailFailure(t *testing.T) {
 func Test_Model_Push_TailWaitSuccess(t *testing.T) {
 	h := newModelPushHarness(t)
 	stubModelPushTimeAndSleep(h)
-	h.API.SetRoute("POST", "/v1/models/model-123/deployments/deploy-456/logs", 200, map[string]any{
+	h.API.SetRoute("GET", "/v1/models/model-123/deployments/deploy-456/logs", 200, map[string]any{
 		"logs": []any{
 			map[string]any{"timestamp": "1", "message": "almost ready", "replica": nil},
 		},
@@ -591,7 +591,7 @@ func Test_Model_Push_TailWarmup404(t *testing.T) {
 	stubModelPushTimeAndSleep(h)
 
 	logsCall := 0
-	h.API.SetRouteFunc("POST", "/v1/models/model-123/deployments/deploy-456/logs", func(w http.ResponseWriter, _ *http.Request) {
+	h.API.SetRouteFunc("GET", "/v1/models/model-123/deployments/deploy-456/logs", func(w http.ResponseWriter, _ *http.Request) {
 		logsCall++
 		w.Header().Set("Content-Type", "application/json")
 		if logsCall <= 2 {

--- a/internal/e2e-tests/model_test.go
+++ b/internal/e2e-tests/model_test.go
@@ -277,9 +277,24 @@ type logLine struct {
 // returned (not fatal) so callers can retry while logs propagate.
 func (l *lifecycle) collectLogs(t *testing.T, extraArgs ...string) ([]logLine, error) {
 	t.Helper()
-	args := append([]string{"model", "deployment", "logs",
+	return l.collectLogsFrom(t, append([]string{"model", "deployment", "logs",
 		"--model-id", l.modelID, "--deployment-id", l.initialDeploymentID,
-		"--since", "1h", "--output", "jsonl"}, extraArgs...)
+		"--since", "1h", "--output", "jsonl"}, extraArgs...)...)
+}
+
+// collectEnvLogs is collectLogs over the production environment path. The model
+// is pushed to production, so its current deployment is initialDeploymentID.
+func (l *lifecycle) collectEnvLogs(t *testing.T, extraArgs ...string) ([]logLine, error) {
+	t.Helper()
+	return l.collectLogsFrom(t, append([]string{"model", "environment", "logs",
+		"--model-id", l.modelID, "--environment", "production",
+		"--since", "1h", "--output", "jsonl"}, extraArgs...)...)
+}
+
+// collectLogsFrom runs a `... logs --output jsonl` command and parses each line.
+// CLI errors are returned (not fatal) so callers can retry while logs propagate.
+func (l *lifecycle) collectLogsFrom(t *testing.T, args ...string) ([]logLine, error) {
+	t.Helper()
 	out, _, err := cli(t, args...)
 	if err != nil {
 		return nil, err
@@ -356,6 +371,22 @@ func (l *lifecycle) Logs(t *testing.T) {
 		require.True(t, contains(lines, e2eLogInfoWord))
 		require.True(t, contains(lines, e2eLogErrorWord))
 		require.False(t, contains(lines, e2eLogWarningWord))
+	})
+
+	// The environment logs path spans the versions active on the environment;
+	// production's current deployment is this model, so the same markers show
+	// up and filters apply identically.
+	t.Run("Environment", func(t *testing.T) {
+		lines, err := l.collectEnvLogs(t)
+		require.NoError(t, err)
+		require.True(t, contains(lines, e2eLogInfoWord), "info line missing")
+		require.True(t, contains(lines, e2eLogWarningWord), "warning line missing")
+		require.True(t, contains(lines, e2eLogErrorWord), "error line missing")
+
+		filtered, err := l.collectEnvLogs(t, "--min-level", "error")
+		require.NoError(t, err)
+		require.False(t, contains(filtered, e2eLogInfoWord), "info should be filtered out")
+		require.True(t, contains(filtered, e2eLogErrorWord))
 	})
 }
 


### PR DESCRIPTION
## :rocket: What

- Adds `baseten model environment logs` - full parity with `model deployment logs` (`--tail`, `--start/--end/--since`, `--min-level`, `--includes/--excludes`, `--search-pattern`, `--replica`, `--request-id`, text/json/jsonl).
- Switches `model deployment logs` (and `model push --tail`) from the deprecated POST logs endpoint to the GET endpoint.

## :computer: How

- Extracted shared `LogFlags` embedded by both flag structs.
- Single `runLogsCommand` + transport-neutral `tailLogs` loop; each command supplies only `FetchLogs`/`FetchStatus` closures. `TailDeploymentLogs` is now a thin adapter.

## :microscope: Testing

- New unit tests for env logs; deployment-logs tests converted to GET query-param assertions; push-tail test routes updated to GET.
- New `Logs/Environment` e2e sub-test; ran the scoped logs e2e against staging.