### PR TITLE
Add environment SSH hostname form and richer push summary

### DIFF
--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -109,7 +109,8 @@ func commandModelPush(ctx *CommandContext, flags *cmd.ModelPushFlags) error {
 	if err != nil {
 		return err
 	}
-	if err := writeModelPushResult(ctx, created, prepareReq.Deployment.EnvironmentName); err != nil {
+	if err := writeModelPushResult(ctx, created, prepareReq.Deployment.EnvironmentName,
+		sshEnabledInConfig(prepareReq.Deployment.Config)); err != nil {
 		return err
 	}
 	// The watch loop runs until interrupted, so its exit is never a deployment
@@ -572,7 +573,7 @@ func modelPushURLs(ctx *CommandContext, created *managementapi.CreatedModelDeplo
 	return predictURL, logsURL, nil
 }
 
-func writeModelPushResult(ctx *CommandContext, created *managementapi.CreatedModelDeployment, environment *string) error {
+func writeModelPushResult(ctx *CommandContext, created *managementapi.CreatedModelDeployment, environment *string, sshEnabled bool) error {
 	predictURL, logsURL, err := modelPushURLs(ctx, created)
 	if err != nil {
 		return err
@@ -581,7 +582,7 @@ func writeModelPushResult(ctx *CommandContext, created *managementapi.CreatedMod
 	// Narrative goes first so a user piping JSON to a file or jq sees the
 	// human summary on stderr before the JSON object lands on stdout.
 	if ctx.JSON {
-		writeModelPushSummary(ctx.Logf, created, predictURL, logsURL, environment)
+		writeModelPushSummary(ctx.Logf, created, predictURL, logsURL, environment, sshEnabled)
 		ctx.OutputJSON(cmd.ModelPushResult{
 			Model:      created.Model,
 			Deployment: created.Deployment,
@@ -590,17 +591,53 @@ func writeModelPushResult(ctx *CommandContext, created *managementapi.CreatedMod
 		})
 		return nil
 	}
-	writeModelPushSummary(ctx.Outputf, created, predictURL, logsURL, environment)
+	writeModelPushSummary(ctx.Outputf, created, predictURL, logsURL, environment, sshEnabled)
 	return nil
 }
 
-func writeModelPushSummary(printf func(string, ...any), created *managementapi.CreatedModelDeployment, predictURL, logsURL string, environment *string) {
-	logsCmd := fmt.Sprintf("baseten model deployment logs --model-id %s --deployment-id %s",
-		created.Model.Id, created.Deployment.Id)
-	predictCmd := fmt.Sprintf("baseten model predict --model-id %s", created.Model.Id)
-	// When --wait/--tail observed a terminal-failure status, the upload
-	// itself succeeded but the deployment did not; say so rather than
-	// claiming success.
+// sshEnabledInConfig reports whether the pushed Truss config turns on remote
+// SSH (runtime.remote_ssh.enabled: true), so the push summary only advertises
+// SSH when the workload actually accepts it. config is the parsed config.yaml
+// map, whose nested maps yaml.v3 decodes as map[string]any.
+func sshEnabledInConfig(config map[string]any) bool {
+	runtime, ok := config["runtime"].(map[string]any)
+	if !ok {
+		return false
+	}
+	remoteSSH, ok := runtime["remote_ssh"].(map[string]any)
+	if !ok {
+		return false
+	}
+	enabled, _ := remoteSSH["enabled"].(bool)
+	return enabled
+}
+
+// writeModelPushSummary prints the post-push narrative: a facts card followed by
+// grouped, code-styled hints for logs, invocation, and (when the config enables
+// it) SSH. environment is the --environment target, if any; env-scoped hints are
+// tagged "(once deployed)" since the new deployment only becomes the
+// environment's live one after it finishes deploying.
+func writeModelPushSummary(
+	printf func(string, ...any),
+	created *managementapi.CreatedModelDeployment,
+	predictURL string,
+	logsURL string,
+	environment *string,
+	sshEnabled bool,
+) {
+	modelID, deploymentID := created.Model.Id, created.Deployment.Id
+
+	// Show the environment when the push targeted one, otherwise when the
+	// response associates the deployment with one.
+	envName := ""
+	if environment != nil {
+		envName = *environment
+	} else if created.Deployment.Environment != nil {
+		envName = *created.Deployment.Environment
+	}
+
+	// When --wait/--tail observed a terminal-failure status, the upload itself
+	// succeeded but the deployment did not; say so rather than claiming success.
 	switch created.Deployment.Status {
 	case managementapi.DeploymentStatus_ACTIVE,
 		managementapi.DeploymentStatus_BUILDING,
@@ -612,12 +649,85 @@ func writeModelPushSummary(printf func(string, ...any), created *managementapi.C
 		printf("⚠️  Model %s was pushed but the deployment did not become active (status: %s)\n",
 			created.Model.Name, created.Deployment.Status)
 	}
-	if environment != nil {
-		printf("Your Truss has been deployed into the %q environment. After it successfully deploys, it will become the next %q deployment of your model.\n",
-			*environment, *environment)
+
+	// Facts card: fixed labels left-padded to the widest shown label.
+	rows := [][2]string{
+		{"Model:", fmt.Sprintf("%s (%s)", created.Model.Name, modelID)},
+		{"Deployment:", deploymentID},
 	}
-	printf("🪵  View logs for your deployment at %s or %s\n", inlineCodeStyle.Render(logsURL), inlineCodeStyle.Render(logsCmd))
-	printf("🚀  Invoke your model at %s or %s\n", inlineCodeStyle.Render(predictURL), inlineCodeStyle.Render(predictCmd))
+	if envName != "" {
+		rows = append(rows, [2]string{"Environment:", envName})
+	}
+	labelWidth := 0
+	for _, r := range rows {
+		if len(r[0]) > labelWidth {
+			labelWidth = len(r[0])
+		}
+	}
+	printf("\n")
+	for _, r := range rows {
+		printf("  %-*s %s\n", labelWidth, r[0], r[1])
+	}
+
+	if environment != nil {
+		printf("\nYour Truss has been deployed into the %q environment. After it successfully deploys, "+
+			"it will become the next %q deployment of your model.\n", *environment, *environment)
+	}
+
+	// Each group is an emoji header followed by aligned rows: the code-styled
+	// values line up in a column two spaces past the group's longest label.
+	// Env-scoped rows are tagged "(once deployed)" since the new deployment only
+	// becomes the environment's live one after it finishes deploying.
+	type hint struct {
+		label string
+		value string
+		note  string
+	}
+	group := func(emoji, header string, hints []hint) {
+		printf("\n%s %s\n", emoji, header)
+		width := 0
+		for _, h := range hints {
+			if len(h.label) > width {
+				width = len(h.label)
+			}
+		}
+		width += 2
+		for _, h := range hints {
+			printf("   %-*s%s", width, h.label, inlineCodeStyle.Render(h.value))
+			if h.note != "" {
+				printf("  %s", h.note)
+			}
+			printf("\n")
+		}
+	}
+
+	logs := []hint{
+		{label: "deployment:", value: fmt.Sprintf(
+			"baseten model deployment logs --model-id %s --deployment-id %s", modelID, deploymentID)},
+	}
+	if envName != "" {
+		logs = append(logs, hint{label: "environment:", note: "(once deployed)", value: fmt.Sprintf(
+			"baseten model environment logs --model-id %s --environment %s", modelID, envName)})
+	}
+	logs = append(logs, hint{label: "app:", value: logsURL})
+	group("🪵", "View logs:", logs)
+
+	group("🚀", "Invoke your model:", []hint{
+		{label: "URL:", value: predictURL},
+		{label: "CLI:", value: fmt.Sprintf("baseten model predict --model-id %s", modelID)},
+	})
+
+	// SSH last, and only when the pushed config enabled it.
+	if sshEnabled {
+		ssh := []hint{
+			{label: "deployment:", value: fmt.Sprintf("ssh model-%s-%s.ssh.baseten.co", modelID, deploymentID)},
+		}
+		if envName != "" {
+			ssh = append(ssh, hint{label: "environment:", note: "(once deployed)", value: fmt.Sprintf(
+				"ssh %s.model-%s.ssh.baseten.co", envName, modelID)})
+		}
+		group("🔑", "SSH in:", ssh)
+	}
 }
 
 func formatBytes(n int64) string {

--- a/internal/cmd/command.ssh.go
+++ b/internal/cmd/command.ssh.go
@@ -55,7 +55,10 @@ func commandSSHSetup(ctx *CommandContext, flags *cmd.SSHSetupFlags) error {
 	if profile != "" {
 		ctx.Logf("Connections use profile %q by default.\n", profile)
 	}
-	ctx.LogLine("Connect with: ssh model-<model-id>-<deployment-id>.ssh.baseten.co")
+	ctx.LogLine("Connect with:")
+	ctx.Logf("   deployment:    %s\n", inlineCodeStyle.Render("ssh model-<model-id>-<deployment-id>.ssh.baseten.co"))
+	ctx.Logf("   environment:   %s\n", inlineCodeStyle.Render("ssh <environment>.model-<model-id>.ssh.baseten.co"))
+	ctx.Logf("   training job:  %s\n", inlineCodeStyle.Render("ssh training-job-<job-id>-<node>.ssh.baseten.co"))
 	return nil
 }
 

--- a/internal/cmd/command.ssh_test.go
+++ b/internal/cmd/command.ssh_test.go
@@ -125,6 +125,27 @@ func Test_SSH_Sign_ModelWithReplica(t *testing.T) {
 	h.Require.Contains(call.Body, `"replica_id":"r1"`)
 }
 
+func Test_SSH_Sign_ModelEnvironment(t *testing.T) {
+	h := NewCommandHarness(t)
+	sshEnv(t)
+	_, _, err := ssh.EnsureKeypair()
+	h.Require.NoError(err)
+
+	m := h.MockManagementAPI()
+	// The env form resolves the environment's current deployment, then signs
+	// against that deployment id.
+	m.SetRoute("GET", "/v1/models/m1/environments/staging", 200,
+		map[string]any{"current_deployment": map[string]any{"id": "d1"}})
+	m.SetRoute("POST", "/v1/models/m1/deployments/d1/ssh/sign", 200,
+		signResponse("tok", "127.0.0.1:9"))
+
+	h.Require.NoError(h.Execute("ssh", "sign", "staging.model-m1.ssh.baseten.co"))
+	h.Require.NotNil(m.FindCall("GET", "/v1/models/m1/environments/staging"))
+	sign := m.FindCall("POST", "/v1/models/m1/deployments/d1/ssh/sign")
+	h.Require.NotNil(sign)
+	h.Require.NotContains(sign.Body, `"replica_id"`)
+}
+
 func Test_SSH_Sign_Training(t *testing.T) {
 	h := NewCommandHarness(t)
 	sshEnv(t)

--- a/internal/e2e-tests/model_test.go
+++ b/internal/e2e-tests/model_test.go
@@ -566,12 +566,9 @@ func (l *lifecycle) SSH(t *testing.T) {
 
 	mustCLI(t, "ssh", "setup")
 
-	host := fmt.Sprintf("model-%s-%s.ssh.baseten.co", l.modelID, l.initialDeploymentID)
-
-	// The workload's sshd can lag behind the deployment going ACTIVE, so retry
-	// the connection until it succeeds or the deadline passes.
-	var modelPy string
-	require.Eventually(t, func() bool {
+	// runSSH connects with the system ssh client (which invokes the built binary
+	// for the sign/proxy steps) and cats the remote model.py.
+	runSSH := func(host string) (string, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 		defer cancel()
 		var stdout, stderr bytes.Buffer
@@ -580,14 +577,36 @@ func (l *lifecycle) SSH(t *testing.T) {
 			host, "cat", "/app/model/model.py")
 		c.Stdout, c.Stderr = &stdout, &stderr
 		if err := c.Run(); err != nil {
-			t.Logf("ssh connect attempt failed: %v\nstderr: %s", err, stderr.String())
+			return "", fmt.Errorf("%w\nstderr: %s", err, stderr.String())
+		}
+		return stdout.String(), nil
+	}
+
+	// Deployment form. The workload's sshd can lag behind the deployment going
+	// ACTIVE, so retry the first connection until it succeeds or the deadline
+	// passes.
+	deploymentHost := fmt.Sprintf("model-%s-%s.ssh.baseten.co", l.modelID, l.initialDeploymentID)
+	var modelPy string
+	require.Eventually(t, func() bool {
+		out, err := runSSH(deploymentHost)
+		if err != nil {
+			t.Logf("ssh connect attempt to %s failed: %v", deploymentHost, err)
 			return false
 		}
-		modelPy = stdout.String()
+		modelPy = out
 		return true
-	}, 3*time.Minute, 10*time.Second, "ssh connect to %s never succeeded", host)
-
+	}, 3*time.Minute, 10*time.Second, "ssh connect to %s never succeeded", deploymentHost)
 	require.Equal(t, trussModelPy, modelPy, "remote /app/model/model.py should match the pushed source")
+
+	// Environment form: <env>.model-<id> resolves the environment's current
+	// deployment (production points at initialDeploymentID) client-side in sign.
+	// The workload is already warm from the connection above, so connect directly
+	// without the retry loop.
+	environmentHost := fmt.Sprintf("production.model-%s.ssh.baseten.co", l.modelID)
+	envModelPy, err := runSSH(environmentHost)
+	require.NoError(t, err, "ssh connect to environment host %s", environmentHost)
+	require.Equal(t, trussModelPy, envModelPy,
+		"remote /app/model/model.py via the environment host should match the pushed source")
 }
 
 func (l *lifecycle) Redeploy(t *testing.T) {

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -157,6 +157,10 @@ func buildBlock(keyPath, profile string) string {
 	lines := []string{markerStart}
 	lines = append(lines, match("training-job-*.ssh.baseten.co", "baseten")...)
 	lines = append(lines, match("model-*.ssh.baseten.co", "app")...)
+	// Env form <env>.model-<id>.ssh.baseten.co: the environment name is a
+	// leading label, so it needs its own pattern (disjoint from model-*, which
+	// only matches hostnames that start with model-).
+	lines = append(lines, match("*.model-*.ssh.baseten.co", "app")...)
 	lines = append(lines, markerEnd, "")
 	return strings.Join(lines, "\n")
 }

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -27,6 +27,7 @@ func TestWriteConfig_FreshAppendBakesProfile(t *testing.T) {
 	require.Contains(t, content, markerEnd)
 	require.Contains(t, content, "Match host training-job-*.ssh.baseten.co")
 	require.Contains(t, content, "Match host model-*.ssh.baseten.co")
+	require.Contains(t, content, "Match host *.model-*.ssh.baseten.co")
 	require.Contains(t, content, "baseten ssh sign --default-profile=prod")
 	require.Contains(t, content, "baseten ssh proxy --default-profile=prod")
 	require.Contains(t, content, "IdentityFile /keys/id_ed25519")

--- a/internal/ssh/connect.go
+++ b/internal/ssh/connect.go
@@ -47,7 +47,17 @@ func Sign(ctx context.Context, mgmt *client.ManagementClient, hostname string) (
 	var resp *managementapi.SignSSHCertificateResponse
 	switch h.kind {
 	case workloadModel:
-		resp, err = mgmt.API().PostModelsDeploymentsSshSign(ctx, h.id, h.deploymentID, body)
+		// Env form (<env>.model-<id>) carries no deployment id; resolve the
+		// environment's current deployment now so every connect targets
+		// whatever is live in that environment.
+		deploymentID := h.deploymentID
+		if h.env != "" {
+			deploymentID, err = resolveEnvDeployment(ctx, mgmt, h.id, h.env)
+			if err != nil {
+				return nil, err
+			}
+		}
+		resp, err = mgmt.API().PostModelsDeploymentsSshSign(ctx, h.id, deploymentID, body)
 	case workloadTraining:
 		projectID, perr := resolveTrainingProject(ctx, mgmt, h.id)
 		if perr != nil {
@@ -68,6 +78,19 @@ func Sign(ctx context.Context, mgmt *client.ManagementClient, hostname string) (
 		return nil, err
 	}
 	return resp, nil
+}
+
+// resolveEnvDeployment resolves a model environment to its current deployment
+// id, used by the env hostname form to target whatever deployment is live.
+func resolveEnvDeployment(ctx context.Context, mgmt *client.ManagementClient, modelID, env string) (string, error) {
+	resp, err := mgmt.API().GetModelsEnvironmentsEnvName(ctx, modelID, env)
+	if err != nil {
+		return "", fmt.Errorf("looking up environment %q for model %s: %w", env, modelID, err)
+	}
+	if resp.CurrentDeployment.Id == "" {
+		return "", fmt.Errorf("environment %q for model %s has no current deployment", env, modelID)
+	}
+	return resp.CurrentDeployment.Id, nil
 }
 
 // resolveTrainingProject looks up the project id owning a training job.
@@ -167,40 +190,46 @@ const (
 type hostname struct {
 	kind         workloadKind
 	id           string // model id or training job id
-	deploymentID string // models only
+	deploymentID string // models, deployment form only
+	env          string // models, env form only
 	replica      string // models: optional replica; training: node (required)
 }
 
-// parseHostname parses the first DNS label of an SSH hostname. The domain that
-// follows is env-specific and irrelevant here, since the REST target comes from
-// the resolved profile. Supported label forms:
+// parseHostname parses an SSH hostname into a workload target. The proxy domain
+// that follows the leading label(s) is env-specific and irrelevant here, since
+// the REST target comes from the resolved profile. Supported forms:
 //
 //	training-job-<jobID>-<node>
 //	model-<modelID>-<deploymentID>[-<replica>]
+//	<env>.model-<modelID>
+//
+// The env form puts the environment name in a leading label; its model id has
+// no deployment id, so sign resolves the environment's current deployment.
 func parseHostname(h string) (hostname, error) {
-	label := h
-	if i := strings.IndexByte(h, '.'); i != -1 {
-		label = h[:i]
-	}
+	labels := strings.Split(h, ".")
+	first := labels[0]
 	var hn hostname
 	var err error
 	switch {
-	case strings.HasPrefix(label, "training-job-"):
-		hn, err = parseTrainingHostname(h, label[len("training-job-"):])
-	case strings.HasPrefix(label, "model-"):
-		hn, err = parseModelHostname(h, label[len("model-"):])
+	case len(labels) >= 2 && strings.HasPrefix(labels[1], "model-"):
+		hn, err = parseModelEnvHostname(h, first, labels[1][len("model-"):])
+	case strings.HasPrefix(first, "training-job-"):
+		hn, err = parseTrainingHostname(h, first[len("training-job-"):])
+	case strings.HasPrefix(first, "model-"):
+		hn, err = parseModelHostname(h, first[len("model-"):])
 	default:
 		return hostname{}, fmt.Errorf(
-			"invalid ssh hostname %q: expected training-job-<job>-<node> or model-<model>-<deployment>[-<replica>]", h)
+			"invalid ssh hostname %q: expected training-job-<job>-<node>, "+
+				"model-<model>-<deployment>[-<replica>], or <env>.model-<model>", h)
 	}
 	if err != nil {
 		return hostname{}, err
 	}
 	// Defense in depth: these components are interpolated into the on-disk JWT
 	// cache path, so reject any that contain a path separator. (Dot-containing
-	// traversal like ".." is already stripped, since label ends at the first
-	// dot, but guard explicitly against separators that survive.)
-	for _, part := range []string{hn.id, hn.deploymentID, hn.replica} {
+	// traversal like ".." is already stripped, since labels split on dots, but
+	// guard explicitly against separators that survive.)
+	for _, part := range []string{hn.id, hn.deploymentID, hn.env, hn.replica} {
 		if strings.ContainsAny(part, `/\`) {
 			return hostname{}, fmt.Errorf(
 				"invalid ssh hostname %q: workload identifiers must not contain path separators", h)
@@ -224,6 +253,19 @@ func parseModelHostname(h, rest string) (hostname, error) {
 		hn.replica = parts[2]
 	}
 	return hn, nil
+}
+
+// parseModelEnvHostname parses the env form <env>.model-<id>. env is the
+// leading label; rest is the second label with "model-" stripped and holds
+// just the model id (no deployment id). Model ids contain no dashes.
+func parseModelEnvHostname(h, env, rest string) (hostname, error) {
+	if env == "" || rest == "" {
+		return hostname{}, fmt.Errorf("invalid ssh hostname %q: cannot parse environment and model ID", h)
+	}
+	if strings.Contains(rest, "-") {
+		return hostname{}, fmt.Errorf("invalid ssh hostname %q: env form takes a bare model ID with no deployment", h)
+	}
+	return hostname{kind: workloadModel, id: rest, env: env}, nil
 }
 
 // parseTrainingHostname parses the part after "training-job-". The node is the

--- a/internal/ssh/connect_test.go
+++ b/internal/ssh/connect_test.go
@@ -39,6 +39,21 @@ func TestParseHostname(t *testing.T) {
 			want: hostname{kind: workloadModel, id: "abc", deploymentID: "def"},
 		},
 		{
+			name: "model environment",
+			host: "staging.model-abc.ssh.baseten.co",
+			want: hostname{kind: workloadModel, id: "abc", env: "staging"},
+		},
+		{
+			name: "model environment with hyphen",
+			host: "my-env.model-abc.ssh.baseten.co",
+			want: hostname{kind: workloadModel, id: "abc", env: "my-env"},
+		},
+		{
+			name: "model environment without domain",
+			host: "staging.model-abc",
+			want: hostname{kind: workloadModel, id: "abc", env: "staging"},
+		},
+		{
 			name: "training job",
 			host: "training-job-job123-0.ssh.baseten.co",
 			want: hostname{kind: workloadTraining, id: "job123", replica: "0"},
@@ -57,6 +72,9 @@ func TestParseHostname(t *testing.T) {
 		{name: "training empty job id", host: "training-job--0", wantErr: true},
 		{name: "model component with forward slash", host: "model-a-b/c", wantErr: true},
 		{name: "model component with backslash", host: `model-a-b\c`, wantErr: true},
+		{name: "env form with deployment id", host: "staging.model-abc-def.ssh.baseten.co", wantErr: true},
+		{name: "env form empty model id", host: "staging.model-.ssh.baseten.co", wantErr: true},
+		{name: "env form empty env", host: ".model-abc.ssh.baseten.co", wantErr: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -112,6 +112,12 @@ func jwtCachePath(d string, h hostname) string {
 	if h.kind == workloadTraining {
 		parts[0] = "training"
 	}
+	// The env form carries no deployment id, so key on the environment instead
+	// (with an "env" tag so an env never collides with a deployment id). sign
+	// and proxy both parse the same hostname, so the keys stay consistent.
+	if h.env != "" {
+		parts = append(parts, "env", h.env)
+	}
 	if h.deploymentID != "" {
 		parts = append(parts, h.deploymentID)
 	}

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -73,6 +73,17 @@ func TestJWTCacheRoundTrip(t *testing.T) {
 	require.Equal(t, "proxy:443", c.ProxyAddress)
 }
 
+func TestJWTCachePath_EnvFormDistinctFromDeployment(t *testing.T) {
+	d := t.TempDir()
+	env := hostname{kind: workloadModel, id: "abc", env: "staging"}
+	dep := hostname{kind: workloadModel, id: "abc", deploymentID: "staging"}
+
+	// The env tag keeps an environment named like a deployment id from
+	// colliding with the deployment cache entry.
+	require.Contains(t, jwtCachePath(d, env), "model-abc-env-staging")
+	require.NotEqual(t, jwtCachePath(d, dep), jwtCachePath(d, env))
+}
+
 func TestLoadJWT_MissingReturnsFalse(t *testing.T) {
 	d := t.TempDir()
 	h := hostname{kind: workloadModel, id: "abc", deploymentID: "def"}


### PR DESCRIPTION
## :rocket: What

Added environment SSH hostname support, which alters the push summary so went ahead and cleaned up the push summary for it and other parts

- Add an environment SSH hostname form: `ssh <env>.model-<id>.ssh.baseten.co`, which resolves the environment's current deployment. Bare `model-<id>` with no deployment id is not supported.
- Rewrite the `model push` success summary: a facts card plus grouped, code-styled hints for logs, invocation, and SSH.
- When the deployment is associated with an environment, add environment-scoped log/SSH hints tagged `(once deployed)`.
- `ssh setup` now prints all three connect forms (deployment, environment, training job).

## :computer: How

- `sign` resolves the env form via `GetModelsEnvironmentsEnvName` → current deployment, then reuses the existing deployment sign path. The JWT cache key is tagged with the env so it never collides with a deployment id.
- New `Match host *.model-*.ssh.baseten.co` config block for the leading-label env form (disjoint from `model-*`).
- The push summary reads `remote_ssh.enabled` from the parsed `config.yaml` map; the environment name comes from the `--environment` target, falling back to the deployment's environment on the response.

## :microscope: Testing

- Unit tests: hostname parse table (env form + rejections), env-vs-deployment cache-key distinctness, mock env-form sign, config Match block.
- e2e (`TestE2EModelLifecycle/SSH`, staging): pushes to the `production` environment with SSH enabled, then connects and `cat`s the remote `model.py` over both the deployment host and the environment host.

Example push output, pushed to an environment:

```
✨ Model my-model was successfully pushed ✨

  Model:       my-model (abcd123)
  Deployment:  wxyz789
  Environment: production

Your Truss has been deployed into the "production" environment. After it successfully deploys, it will become the next "production" deployment of your model.

🪵 View logs:
   deployment:   baseten model deployment logs --model-id abcd123 --deployment-id wxyz789
   environment:  baseten model environment logs --model-id abcd123 --environment production  (once deployed)
   app:          https://app.baseten.co/models/abcd123/deployments/wxyz789/logs

🚀 Invoke your model:
   URL:          https://model-abcd123.api.baseten.co/environments/production/predict
   CLI:          baseten model predict --model-id abcd123

🔑 SSH in:
   deployment:   ssh model-abcd123-wxyz789.ssh.baseten.co
   environment:  ssh production.model-abcd123.ssh.baseten.co  (once deployed)
```

Example push output, not associated with an environment (SSH disabled):

```
✨ Model my-model was successfully pushed ✨

  Model:       my-model (abcd123)
  Deployment:  wxyz789

🪵 View logs:
   deployment:  baseten model deployment logs --model-id abcd123 --deployment-id wxyz789
   app:         https://app.baseten.co/models/abcd123/deployments/wxyz789/logs

🚀 Invoke your model:
   URL:         https://model-abcd123.api.baseten.co/deployment/wxyz789/predict
   CLI:         baseten model predict --model-id abcd123
```