### PR TITLE
Add name/email flags and server-side filters to CLI commands

### DIFF
--- a/cmd/command.model.go
+++ b/cmd/command.model.go
@@ -303,9 +303,10 @@ type ModelPredictFlags struct {
 	CommandFlags
 	ModelRefFlags
 
-	Environment  string `flag:"environment" desc:"Environment to target (e.g. production, development). Defaults to production. Mutually exclusive with --deployment-id and --regional."`
-	DeploymentID string `flag:"deployment-id" desc:"Specific deployment to target. Mutually exclusive with --environment and --regional."`
-	Regional     string `flag:"regional" desc:"Regional environment name; routes via the regional hostname. Mutually exclusive with --environment and --deployment-id."`
+	Environment    string `flag:"environment" desc:"Environment to target (e.g. production, development). Defaults to production. Mutually exclusive with --deployment-id, --deployment-name, and --regional."`
+	DeploymentID   string `flag:"deployment-id" desc:"Specific deployment to target. Mutually exclusive with --environment, --deployment-name, and --regional."`
+	DeploymentName string `flag:"deployment-name" desc:"Name of the deployment to target. Mutually exclusive with --environment, --deployment-id, and --regional."`
+	Regional       string `flag:"regional" desc:"Regional environment name; routes via the regional hostname. Mutually exclusive with --environment, --deployment-id, and --deployment-name."`
 
 	Data string `flag:"data" desc:"Inline JSON request body." oneof:"predict-input"`
 	File string `flag:"file" desc:"Path to a JSON file containing the request body. Use '-' for stdin." oneof:"predict-input"`

--- a/cmd/command.model_deployment.go
+++ b/cmd/command.model_deployment.go
@@ -234,7 +234,7 @@ var commandModelDeployment = Command{
 				"with --start/--end or --since (max 7 days), which only apply to " +
 				"summary and series.",
 			Flags: ModelDeploymentMetricsFlags{},
-			Output: &CommandOutput[managementapi.GetDeploymentMetricsResponse]{
+			Output: &CommandOutput[managementapi.GetModelMetricsResponse]{
 				TextDescription: "For current/summary, a table with columns METRIC, one column per " +
 					"label dimension (e.g. QUANTILE, STAT), and VALUE; summary COUNTER values show " +
 					"\"total (rate/s)\". For series, a sparkline per metric label set with its " +
@@ -269,7 +269,8 @@ var commandModelDeployment = Command{
 // commands that act on a specific deployment.
 type ModelDeploymentIDFlags struct {
 	ModelRefFlags
-	DeploymentID string `flag:"deployment-id" desc:"ID of the deployment." required:"true"`
+	DeploymentID   string `flag:"deployment-id" desc:"ID of the deployment." oneof:"deployment-ref"`
+	DeploymentName string `flag:"deployment-name" desc:"Name of the deployment." oneof:"deployment-ref"`
 }
 
 // ModelDeploymentListFlags configures `baseten model deployment list`.

--- a/cmd/command.org.go
+++ b/cmd/command.org.go
@@ -323,7 +323,8 @@ type OrgTeamListFlags struct {
 type OrgTeamDescribeFlags struct {
 	CommandFlags
 
-	TeamID string `flag:"team-id" desc:"Team ID to describe." required:"true"`
+	TeamID   string `flag:"team-id" desc:"Team ID to describe." oneof:"team-ref"`
+	TeamName string `flag:"team-name" desc:"Team name to describe." oneof:"team-ref"`
 }
 
 type OrgUserListFlags struct {
@@ -333,7 +334,8 @@ type OrgUserListFlags struct {
 type OrgUserDescribeFlags struct {
 	CommandFlags
 
-	UserID string `flag:"user-id" desc:"User ID to describe. Pass 'me' for the authenticated user." required:"true"`
+	UserID    string `flag:"user-id" desc:"User ID to describe. Pass 'me' for the authenticated user." oneof:"user-ref"`
+	UserEmail string `flag:"user-email" desc:"Email of the user to describe." oneof:"user-ref"`
 }
 
 type OrgAPIKeyListFlags struct {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.1.1-0.20260701165513-0c85d1a410d1
+	github.com/basetenlabs/baseten-go v0.1.1-0.20260707212718-21773e22923e
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.1.1-0.20260707212718-21773e22923e
+	github.com/basetenlabs/baseten-go v0.1.1-0.20260709151359-c4d6f07b6fab
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.1.1-0.20260701165513-0c85d1a410d1 h1:GI3CkX1rpfih1h/790c+w1Fx4J5sGTouYSSJ7H5SkOQ=
-github.com/basetenlabs/baseten-go v0.1.1-0.20260701165513-0c85d1a410d1/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.1.1-0.20260707212718-21773e22923e h1:tmMgLnlnCO+QI0Qzm8J6ccV1s1d8TBv7b16SnOGhu5U=
+github.com/basetenlabs/baseten-go v0.1.1-0.20260707212718-21773e22923e/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.1.1-0.20260707212718-21773e22923e h1:tmMgLnlnCO+QI0Qzm8J6ccV1s1d8TBv7b16SnOGhu5U=
-github.com/basetenlabs/baseten-go v0.1.1-0.20260707212718-21773e22923e/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.1.1-0.20260709151359-c4d6f07b6fab h1:3Pmeq1uFwhdreZa99Z3EJ/MJY7Ry1zGOpv1PoQTaHAo=
+github.com/basetenlabs/baseten-go v0.1.1-0.20260709151359-c4d6f07b6fab/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/internal/cmd/command.model.go
+++ b/internal/cmd/command.model.go
@@ -54,27 +54,33 @@ func ResolveModelRef(
 }
 
 // findModelIDByName returns the ID of the unique model with the given name,
-// scoped to teamID when non-empty. Returns "" with nil error when no model
+// scoped to teamID when non-empty. The server filters by exact name, so this
+// matches at most one model per team; the org-wide route may still return the
+// same name from multiple teams. Returns "" with nil error when no model
 // matches. Returns an error when multiple models match (only possible when
 // teamID is empty, since (org, team, name) is unique server-side).
 func findModelIDByName(
 	ctx context.Context, api *managementapi.Client, name, teamID string,
 ) (string, error) {
-	models, err := listModels(ctx, api, teamID)
-	if err != nil {
-		return "", err
-	}
-	var matches []managementapi.Model
-	for _, m := range models {
-		if m.Name == name {
-			matches = append(matches, m)
+	var models []managementapi.Model
+	if teamID == "" {
+		resp, err := api.GetModels(ctx, managementapi.GetV1ModelsParams{Name: &name})
+		if err != nil {
+			return "", fmt.Errorf("list models: %w", err)
 		}
+		models = resp.Models
+	} else {
+		resp, err := api.GetTeamsModels(ctx, teamID, managementapi.GetV1TeamsTeamIdModelsParams{Name: &name})
+		if err != nil {
+			return "", fmt.Errorf("list models for team %s: %w", teamID, err)
+		}
+		models = resp.Models
 	}
-	switch len(matches) {
+	switch len(models) {
 	case 0:
 		return "", nil
 	case 1:
-		return matches[0].Id, nil
+		return models[0].Id, nil
 	default:
 		return "", fmt.Errorf("multiple models named %q across teams; pass --team to disambiguate", name)
 	}
@@ -86,13 +92,13 @@ func listModels(
 	ctx context.Context, api *managementapi.Client, teamID string,
 ) ([]managementapi.Model, error) {
 	if teamID == "" {
-		resp, err := api.GetModels(ctx)
+		resp, err := api.GetModels(ctx, managementapi.GetV1ModelsParams{})
 		if err != nil {
 			return nil, fmt.Errorf("list models: %w", err)
 		}
 		return resp.Models, nil
 	}
-	resp, err := api.GetTeamsModels(ctx, teamID)
+	resp, err := api.GetTeamsModels(ctx, teamID, managementapi.GetV1TeamsTeamIdModelsParams{})
 	if err != nil {
 		return nil, fmt.Errorf("list models for team %s: %w", teamID, err)
 	}

--- a/internal/cmd/command.model_deployment.go
+++ b/internal/cmd/command.model_deployment.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"archive/tar"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,6 +27,53 @@ func init() {
 	Register("model deployment promote", commandModelDeploymentPromote)
 }
 
+// DeploymentRef is the result of resolving [cmd.ModelDeploymentIDFlags]: a
+// resolved model ID paired with a resolved deployment ID.
+type DeploymentRef struct {
+	ModelID      string
+	DeploymentID string
+}
+
+// ResolveDeploymentRef resolves the model, then the deployment within it. When
+// --deployment-id is set it is used directly; when --deployment-name is set the
+// deployment is looked up by exact name within the model. Absent or ambiguous
+// name matches return an error.
+func ResolveDeploymentRef(
+	ctx context.Context, api *managementapi.Client, flags cmd.ModelDeploymentIDFlags,
+) (DeploymentRef, error) {
+	modelRef, err := ResolveModelRef(ctx, api, flags.ModelRefFlags)
+	if err != nil {
+		return DeploymentRef{}, err
+	}
+	if flags.DeploymentID != "" {
+		return DeploymentRef{ModelID: modelRef.ID, DeploymentID: flags.DeploymentID}, nil
+	}
+	deploymentID, err := findDeploymentIDByName(ctx, api, modelRef.ID, flags.DeploymentName)
+	if err != nil {
+		return DeploymentRef{}, err
+	}
+	return DeploymentRef{ModelID: modelRef.ID, DeploymentID: deploymentID}, nil
+}
+
+// findDeploymentIDByName returns the ID of the deployment with the given exact
+// name within a model. The server filters by exact name, so at most one
+// deployment matches; absent or (defensively) ambiguous matches return an error.
+func findDeploymentIDByName(
+	ctx context.Context, api *managementapi.Client, modelID, name string,
+) (string, error) {
+	resp, err := api.GetModelsDeployments(ctx, modelID,
+		managementapi.GetV1ModelsModelIdDeploymentsParams{Name: &name})
+	if err != nil {
+		return "", fmt.Errorf("list deployments for model %s: %w", modelID, err)
+	}
+	if len(resp.Deployments) == 0 {
+		return "", fmt.Errorf("no deployment named %q in model %s", name, modelID)
+	} else if len(resp.Deployments) > 1 {
+		return "", fmt.Errorf("multiple deployments named %q in model %s", name, modelID)
+	}
+	return resp.Deployments[0].Id, nil
+}
+
 func commandModelDeploymentList(ctx *CommandContext, flags *cmd.ModelDeploymentListFlags) error {
 	cl, err := ctx.NewManagementClient()
 	if err != nil {
@@ -35,7 +83,8 @@ func commandModelDeploymentList(ctx *CommandContext, flags *cmd.ModelDeploymentL
 	if err != nil {
 		return err
 	}
-	resp, err := cl.API().GetModelsDeployments(ctx, ref.ID)
+	resp, err := cl.API().GetModelsDeployments(ctx, ref.ID,
+		managementapi.GetV1ModelsModelIdDeploymentsParams{})
 	if err != nil {
 		return fmt.Errorf("list deployments for model %s: %w", ref.ID, err)
 	}
@@ -80,13 +129,13 @@ func commandModelDeploymentDescribe(ctx *CommandContext, flags *cmd.ModelDeploym
 	if err != nil {
 		return err
 	}
-	ref, err := ResolveModelRef(ctx, cl.API(), flags.ModelRefFlags)
+	ref, err := ResolveDeploymentRef(ctx, cl.API(), flags.ModelDeploymentIDFlags)
 	if err != nil {
 		return err
 	}
-	dep, err := cl.API().GetModelsDeploymentsDeploymentId(ctx, ref.ID, flags.DeploymentID)
+	dep, err := cl.API().GetModelsDeploymentsDeploymentId(ctx, ref.ModelID, ref.DeploymentID)
 	if err != nil {
-		return fmt.Errorf("describe deployment %s: %w", flags.DeploymentID, err)
+		return fmt.Errorf("describe deployment %s: %w", ref.DeploymentID, err)
 	}
 
 	if ctx.JSON {
@@ -113,14 +162,14 @@ func commandModelDeploymentConfig(ctx *CommandContext, flags *cmd.ModelDeploymen
 	if err != nil {
 		return err
 	}
-	ref, err := ResolveModelRef(ctx, cl.API(), flags.ModelRefFlags)
+	ref, err := ResolveDeploymentRef(ctx, cl.API(), flags.ModelDeploymentIDFlags)
 	if err != nil {
 		return err
 	}
-	resp, err := cl.API().GetModelsDeploymentsConfig(ctx, ref.ID, flags.DeploymentID,
+	resp, err := cl.API().GetModelsDeploymentsConfig(ctx, ref.ModelID, ref.DeploymentID,
 		managementapi.GetV1ModelsModelIdDeploymentsDeploymentIdConfigParams{})
 	if err != nil {
-		return fmt.Errorf("fetch deployment config for %s: %w", flags.DeploymentID, err)
+		return fmt.Errorf("fetch deployment config for %s: %w", ref.DeploymentID, err)
 	}
 
 	if ctx.JSON {
@@ -147,20 +196,20 @@ func commandModelDeploymentActivate(ctx *CommandContext, flags *cmd.ModelDeploym
 	if err != nil {
 		return err
 	}
-	ref, err := ResolveModelRef(ctx, cl.API(), flags.ModelRefFlags)
+	ref, err := ResolveDeploymentRef(ctx, cl.API(), flags.ModelDeploymentIDFlags)
 	if err != nil {
 		return err
 	}
-	resp, err := cl.API().PostModelsDeploymentsActivate(ctx, ref.ID, flags.DeploymentID)
+	resp, err := cl.API().PostModelsDeploymentsActivate(ctx, ref.ModelID, ref.DeploymentID)
 	if err != nil {
-		return fmt.Errorf("activate deployment %s: %w", flags.DeploymentID, err)
+		return fmt.Errorf("activate deployment %s: %w", ref.DeploymentID, err)
 	}
 
 	if ctx.JSON {
 		ctx.OutputJSON(resp)
 		return nil
 	}
-	ctx.Logf("Activated deployment %s\n", flags.DeploymentID)
+	ctx.Logf("Activated deployment %s\n", ref.DeploymentID)
 	return nil
 }
 
@@ -169,27 +218,27 @@ func commandModelDeploymentDeactivate(ctx *CommandContext, flags *cmd.ModelDeplo
 	if err != nil {
 		return err
 	}
-	ref, err := ResolveModelRef(ctx, cl.API(), flags.ModelRefFlags)
+	ref, err := ResolveDeploymentRef(ctx, cl.API(), flags.ModelDeploymentIDFlags)
 	if err != nil {
 		return err
 	}
 
 	if !flags.Yes {
-		if err := ctx.ConfirmYesNo(fmt.Sprintf("Deactivate deployment %s?", flags.DeploymentID)); err != nil {
+		if err := ctx.ConfirmYesNo(fmt.Sprintf("Deactivate deployment %s?", ref.DeploymentID)); err != nil {
 			return err
 		}
 	}
 
-	resp, err := cl.API().PostModelsDeploymentsDeactivate(ctx, ref.ID, flags.DeploymentID)
+	resp, err := cl.API().PostModelsDeploymentsDeactivate(ctx, ref.ModelID, ref.DeploymentID)
 	if err != nil {
-		return fmt.Errorf("deactivate deployment %s: %w", flags.DeploymentID, err)
+		return fmt.Errorf("deactivate deployment %s: %w", ref.DeploymentID, err)
 	}
 
 	if ctx.JSON {
 		ctx.OutputJSON(resp)
 		return nil
 	}
-	ctx.Logf("Deactivated deployment %s\n", flags.DeploymentID)
+	ctx.Logf("Deactivated deployment %s\n", ref.DeploymentID)
 	return nil
 }
 
@@ -198,27 +247,27 @@ func commandModelDeploymentDelete(ctx *CommandContext, flags *cmd.ModelDeploymen
 	if err != nil {
 		return err
 	}
-	ref, err := ResolveModelRef(ctx, cl.API(), flags.ModelRefFlags)
+	ref, err := ResolveDeploymentRef(ctx, cl.API(), flags.ModelDeploymentIDFlags)
 	if err != nil {
 		return err
 	}
 
 	if !flags.Yes {
-		if err := ctx.ConfirmYesNo(fmt.Sprintf("Delete deployment %s? This cannot be undone.", flags.DeploymentID)); err != nil {
+		if err := ctx.ConfirmYesNo(fmt.Sprintf("Delete deployment %s? This cannot be undone.", ref.DeploymentID)); err != nil {
 			return err
 		}
 	}
 
-	tombstone, err := cl.API().DeleteModelsDeployments(ctx, ref.ID, flags.DeploymentID)
+	tombstone, err := cl.API().DeleteModelsDeployments(ctx, ref.ModelID, ref.DeploymentID)
 	if err != nil {
-		return fmt.Errorf("delete deployment %s: %w", flags.DeploymentID, err)
+		return fmt.Errorf("delete deployment %s: %w", ref.DeploymentID, err)
 	}
 
 	if ctx.JSON {
 		ctx.OutputJSON(tombstone)
 		return nil
 	}
-	ctx.Logf("Deleted deployment %s\n", flags.DeploymentID)
+	ctx.Logf("Deleted deployment %s\n", ref.DeploymentID)
 	return nil
 }
 
@@ -247,15 +296,15 @@ func commandModelDeploymentDownload(ctx *CommandContext, flags *cmd.ModelDeploym
 	if err != nil {
 		return err
 	}
-	ref, err := ResolveModelRef(ctx, cl.API(), flags.ModelRefFlags)
+	ref, err := ResolveDeploymentRef(ctx, cl.API(), flags.ModelDeploymentIDFlags)
 	if err != nil {
 		return err
 	}
 
 	ctx.Logf("Fetching download URL...\n")
-	resp, err := cl.API().GetModelsDeploymentsDownload(ctx, ref.ID, flags.DeploymentID)
+	resp, err := cl.API().GetModelsDeploymentsDownload(ctx, ref.ModelID, ref.DeploymentID)
 	if err != nil {
-		return fmt.Errorf("fetch download URL for deployment %s: %w", flags.DeploymentID, err)
+		return fmt.Errorf("fetch download URL for deployment %s: %w", ref.DeploymentID, err)
 	}
 
 	ctx.Logf("Downloading truss...\n")
@@ -347,31 +396,31 @@ func commandModelDeploymentPromote(ctx *CommandContext, flags *cmd.ModelDeployme
 	if err != nil {
 		return err
 	}
-	ref, err := ResolveModelRef(ctx, cl.API(), flags.ModelRefFlags)
+	ref, err := ResolveDeploymentRef(ctx, cl.API(), flags.ModelDeploymentIDFlags)
 	if err != nil {
 		return err
 	}
 
 	if !flags.Yes {
-		if err := ctx.ConfirmYesNo(fmt.Sprintf("Promote deployment %s to environment %q?", flags.DeploymentID, flags.Environment)); err != nil {
+		if err := ctx.ConfirmYesNo(fmt.Sprintf("Promote deployment %s to environment %q?", ref.DeploymentID, flags.Environment)); err != nil {
 			return err
 		}
 	}
 
 	preserve := !flags.OverrideEnvInstanceType
-	dep, err := cl.API().PostModelsEnvironmentsPromote(ctx, ref.ID, flags.Environment,
+	dep, err := cl.API().PostModelsEnvironmentsPromote(ctx, ref.ModelID, flags.Environment,
 		managementapi.PromoteToEnvironmentRequest{
-			DeploymentId:            flags.DeploymentID,
+			DeploymentId:            ref.DeploymentID,
 			PreserveEnvInstanceType: &preserve,
 		})
 	if err != nil {
-		return fmt.Errorf("promote deployment %s to environment %s: %w", flags.DeploymentID, flags.Environment, err)
+		return fmt.Errorf("promote deployment %s to environment %s: %w", ref.DeploymentID, flags.Environment, err)
 	}
 
 	if ctx.JSON {
 		ctx.OutputJSON(dep)
 		return nil
 	}
-	ctx.Logf("Promoted deployment %s to environment %s\n", flags.DeploymentID, flags.Environment)
+	ctx.Logf("Promoted deployment %s to environment %s\n", ref.DeploymentID, flags.Environment)
 	return nil
 }

--- a/internal/cmd/command.model_deployment_logs.go
+++ b/internal/cmd/command.model_deployment_logs.go
@@ -36,16 +36,16 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 	if err != nil {
 		return err
 	}
-	ref, err := ResolveModelRef(ctx, api.API(), flags.ModelRefFlags)
+	ref, err := ResolveDeploymentRef(ctx, api.API(), flags.ModelDeploymentIDFlags)
 	if err != nil {
 		return err
 	}
 
 	fetchLogs := func(q logQuery) (*managementapi.GetLogsResponse, error) {
-		return api.API().GetModelsDeploymentsLogs(ctx, ref.ID, flags.DeploymentID, deploymentLogParams(q))
+		return api.API().GetModelsDeploymentsLogs(ctx, ref.ModelID, ref.DeploymentID, deploymentLogParams(q))
 	}
 	fetchStatus := func() (*managementapi.Deployment, error) {
-		return api.API().GetModelsDeploymentsDeploymentId(ctx, ref.ID, flags.DeploymentID)
+		return api.API().GetModelsDeploymentsDeploymentId(ctx, ref.ModelID, ref.DeploymentID)
 	}
 	return runLogsCommand(ctx, &flags.LogFlags, fetchLogs, fetchStatus)
 }

--- a/internal/cmd/command.model_deployment_metrics.go
+++ b/internal/cmd/command.model_deployment_metrics.go
@@ -17,7 +17,7 @@ func init() {
 }
 
 func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeploymentMetricsFlags) error {
-	mode := managementapi.DeploymentMetricMode(strings.ToUpper(flags.Mode))
+	mode := managementapi.ModelMetricMode(strings.ToUpper(flags.Mode))
 
 	hasStart := !flags.Start.IsZero()
 	hasEnd := !flags.End.IsZero()
@@ -25,7 +25,7 @@ func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeployme
 	// positive-duration check below instead of being silently dropped.
 	hasSince := ctx.Command.Flags().Changed("since")
 
-	if mode == managementapi.DeploymentMetricMode_CURRENT && (hasStart || hasEnd || hasSince) {
+	if mode == managementapi.ModelMetricMode_CURRENT && (hasStart || hasEnd || hasSince) {
 		return cmd.NewErrUsagef("--start, --end, and --since are only valid with --mode summary or series")
 	}
 	if hasSince && (hasStart || hasEnd) {
@@ -36,7 +36,7 @@ func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeployme
 	if err != nil {
 		return err
 	}
-	ref, err := ResolveModelRef(ctx, api.API(), flags.ModelRefFlags)
+	ref, err := ResolveDeploymentRef(ctx, api.API(), flags.ModelDeploymentIDFlags)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeployme
 		params.Metrics = &flags.Metric
 	}
 
-	resp, err := api.API().GetModelsDeploymentsMetrics(ctx, ref.ID, flags.DeploymentID, params)
+	resp, err := api.API().GetModelsDeploymentsMetrics(ctx, ref.ModelID, ref.DeploymentID, params)
 	if err != nil {
 		return err
 	}
@@ -95,12 +95,12 @@ func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeployme
 	// current is a point-in-time snapshot with no window. For the windowed modes,
 	// report the resolved window (the server backfills a missing bound and it may
 	// be historical) on stderr so it stays out of the table on stdout.
-	if resp.Mode != managementapi.DeploymentMetricMode_CURRENT {
+	if resp.Mode != managementapi.ModelMetricMode_CURRENT {
 		ctx.LogLine(deploymentMetricsWindowLine(resp))
 	}
 
 	switch resp.Mode {
-	case managementapi.DeploymentMetricMode_SERIES:
+	case managementapi.ModelMetricMode_SERIES:
 		if flags.NoChart {
 			headers, rows, rightAligned := deploymentMetricsSeriesTable(resp)
 			ctx.OutputTable(TableOutput{Headers: headers, Rows: rows, RightAlignedColumns: rightAligned})
@@ -110,7 +110,7 @@ func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeployme
 			ctx.OutputLine(line)
 		}
 		return nil
-	case managementapi.DeploymentMetricMode_CURRENT, managementapi.DeploymentMetricMode_SUMMARY:
+	case managementapi.ModelMetricMode_CURRENT, managementapi.ModelMetricMode_SUMMARY:
 		headers, rows, rightAligned := deploymentMetricsSnapshotRows(resp)
 		ctx.OutputTable(TableOutput{Headers: headers, Rows: rows, RightAlignedColumns: rightAligned})
 		return nil
@@ -122,7 +122,7 @@ func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeployme
 // deploymentMetricsWindowLine summarizes the returned window for summary/series
 // modes: resolved start/end in local time plus duration, and the step interval
 // when the server reports one (SERIES only).
-func deploymentMetricsWindowLine(resp *managementapi.GetDeploymentMetricsResponse) string {
+func deploymentMetricsWindowLine(resp *managementapi.GetModelMetricsResponse) string {
 	start := time.UnixMilli(int64(resp.StartEpochMillis)).Local()
 	end := time.UnixMilli(int64(resp.EndEpochMillis)).Local()
 	line := fmt.Sprintf("Window: %s – %s local (%s)",
@@ -164,7 +164,7 @@ func deploymentMetricsHumanizeDuration(d time.Duration) string {
 // (metric, label set), with a column per label key seen across descriptors and
 // a trailing VALUE column. In summary mode, COUNTER values render as
 // "total (rate/s)" where the rate is the window total divided by its duration.
-func deploymentMetricsSnapshotRows(resp *managementapi.GetDeploymentMetricsResponse) (headers []string, rows [][]string, rightAligned []int) {
+func deploymentMetricsSnapshotRows(resp *managementapi.GetModelMetricsResponse) (headers []string, rows [][]string, rightAligned []int) {
 	labelKeys := deploymentMetricsLabelKeys(resp.MetricDescriptors)
 	headers = append(headers, "METRIC")
 	for _, k := range labelKeys {
@@ -175,7 +175,7 @@ func deploymentMetricsSnapshotRows(resp *managementapi.GetDeploymentMetricsRespo
 	rightAligned = []int{valueCol}
 
 	windowSeconds := float64(resp.EndEpochMillis-resp.StartEpochMillis) / 1000
-	var values *managementapi.DeploymentMetricValueSet
+	var values *managementapi.ModelMetricValueSet
 	if len(resp.MetricValues) > 0 {
 		values = &resp.MetricValues[0]
 	}
@@ -188,8 +188,8 @@ func deploymentMetricsSnapshotRows(resp *managementapi.GetDeploymentMetricsRespo
 				row[1+ki] = labelSet[k]
 			}
 			v := deploymentMetricsValueAt(values, di, li)
-			if resp.Mode == managementapi.DeploymentMetricMode_SUMMARY &&
-				d.Kind == managementapi.DeploymentMetricKind_COUNTER {
+			if resp.Mode == managementapi.ModelMetricMode_SUMMARY &&
+				d.Kind == managementapi.ModelMetricKind_COUNTER {
 				row[valueCol] = deploymentMetricsFormatCounter(v, d.UnitHint, windowSeconds)
 			} else {
 				row[valueCol] = deploymentMetricsFormatValue(v, d.UnitHint)
@@ -204,7 +204,7 @@ func deploymentMetricsSnapshotRows(resp *managementapi.GetDeploymentMetricsRespo
 // metric, then one sparkline per label set with its min-max range and the
 // trailing ("end") value. The window may be historical, so the last point is
 // labeled "end", not "now".
-func deploymentMetricsChartLines(resp *managementapi.GetDeploymentMetricsResponse) []string {
+func deploymentMetricsChartLines(resp *managementapi.GetModelMetricsResponse) []string {
 	var lines []string
 	for di, d := range resp.MetricDescriptors {
 		lines = append(lines, fmt.Sprintf("%s  [%s · %s]", d.Name, d.Kind, strings.ToLower(string(d.UnitHint))))
@@ -248,7 +248,7 @@ func deploymentMetricsChartLines(resp *managementapi.GetDeploymentMetricsRespons
 // deploymentMetricsSeriesTable is the --no-chart fallback for series mode: one
 // row per (metric, label set) with a value column per time step, headed by the
 // step's local start time.
-func deploymentMetricsSeriesTable(resp *managementapi.GetDeploymentMetricsResponse) (headers []string, rows [][]string, rightAligned []int) {
+func deploymentMetricsSeriesTable(resp *managementapi.GetModelMetricsResponse) (headers []string, rows [][]string, rightAligned []int) {
 	labelKeys := deploymentMetricsLabelKeys(resp.MetricDescriptors)
 	headers = append(headers, "METRIC")
 	for _, k := range labelKeys {
@@ -281,7 +281,7 @@ func deploymentMetricsSeriesTable(resp *managementapi.GetDeploymentMetricsRespon
 
 // deploymentMetricsLabelKeys returns the union of label keys across descriptors
 // in first-seen order, so the table has a stable column per label dimension.
-func deploymentMetricsLabelKeys(descriptors []managementapi.DeploymentMetricDescriptor) []string {
+func deploymentMetricsLabelKeys(descriptors []managementapi.ModelMetricDescriptor) []string {
 	var keys []string
 	seen := map[string]bool{}
 	for _, d := range descriptors {
@@ -329,7 +329,7 @@ func deploymentMetricsLabelShort(labelSet map[string]string) string {
 
 // deploymentMetricsValueAt reads the value for descriptor di / label set li from
 // a single value set, guarding the index-mapped slices. nil means no data.
-func deploymentMetricsValueAt(values *managementapi.DeploymentMetricValueSet, di, li int) *float32 {
+func deploymentMetricsValueAt(values *managementapi.ModelMetricValueSet, di, li int) *float32 {
 	if values == nil || di >= len(values.Values) || li >= len(values.Values[di]) {
 		return nil
 	}
@@ -338,7 +338,7 @@ func deploymentMetricsValueAt(values *managementapi.DeploymentMetricValueSet, di
 
 // deploymentMetricsSeriesValues collects descriptor di / label set li across all
 // time steps, preserving nil gaps.
-func deploymentMetricsSeriesValues(steps []managementapi.DeploymentMetricValueSet, di, li int) []*float32 {
+func deploymentMetricsSeriesValues(steps []managementapi.ModelMetricValueSet, di, li int) []*float32 {
 	series := make([]*float32, len(steps))
 	for si := range steps {
 		series[si] = deploymentMetricsValueAt(&steps[si], di, li)
@@ -446,7 +446,7 @@ func deploymentMetricsSparkline(series []*float32) string {
 
 // deploymentMetricsFormatValue formats a single value with its unit suffix; nil
 // renders as "-".
-func deploymentMetricsFormatValue(v *float32, unit managementapi.DeploymentMetricUnitHint) string {
+func deploymentMetricsFormatValue(v *float32, unit managementapi.ModelMetricUnitHint) string {
 	if v == nil {
 		return "-"
 	}
@@ -455,7 +455,7 @@ func deploymentMetricsFormatValue(v *float32, unit managementapi.DeploymentMetri
 
 // deploymentMetricsFormatCounter formats a COUNTER summary value as the window
 // total plus its per-second rate, e.g. "1.2k (340.5/s)".
-func deploymentMetricsFormatCounter(total *float32, unit managementapi.DeploymentMetricUnitHint, windowSeconds float64) string {
+func deploymentMetricsFormatCounter(total *float32, unit managementapi.ModelMetricUnitHint, windowSeconds float64) string {
 	if total == nil {
 		return "-"
 	}
@@ -469,17 +469,17 @@ func deploymentMetricsFormatCounter(total *float32, unit managementapi.Deploymen
 
 // deploymentMetricsUnitSuffix is the short value suffix for a unit hint. COUNT
 // and RATIO are dimensionless and carry no suffix; unknown hints are omitted.
-func deploymentMetricsUnitSuffix(unit managementapi.DeploymentMetricUnitHint) string {
+func deploymentMetricsUnitSuffix(unit managementapi.ModelMetricUnitHint) string {
 	switch unit {
-	case managementapi.DeploymentMetricUnitHint_SECONDS:
+	case managementapi.ModelMetricUnitHint_SECONDS:
 		return "s"
-	case managementapi.DeploymentMetricUnitHint_PER_SECOND:
+	case managementapi.ModelMetricUnitHint_PER_SECOND:
 		return "/s"
-	case managementapi.DeploymentMetricUnitHint_BYTES:
+	case managementapi.ModelMetricUnitHint_BYTES:
 		return "B"
-	case managementapi.DeploymentMetricUnitHint_MEBIBYTES:
+	case managementapi.ModelMetricUnitHint_MEBIBYTES:
 		return "MiB"
-	case managementapi.DeploymentMetricUnitHint_COUNT, managementapi.DeploymentMetricUnitHint_RATIO:
+	case managementapi.ModelMetricUnitHint_COUNT, managementapi.ModelMetricUnitHint_RATIO:
 		return ""
 	default:
 		return ""

--- a/internal/cmd/command.model_deployment_metrics_test.go
+++ b/internal/cmd/command.model_deployment_metrics_test.go
@@ -15,7 +15,7 @@ import (
 
 const metricsPath = "/v1/models/m/deployments/d/metrics"
 
-// metricsResponse builds a GetDeploymentMetricsResponse body.
+// metricsResponse builds a GetModelMetricsResponse body.
 func metricsResponse(mode string, startMs, endMs int, descriptors []any, valueSets []any) map[string]any {
 	return map[string]any{
 		"mode":               mode,

--- a/internal/cmd/command.model_deployment_replica.go
+++ b/internal/cmd/command.model_deployment_replica.go
@@ -15,18 +15,18 @@ func commandModelDeploymentReplicaTerminate(ctx *CommandContext, flags *cmd.Mode
 	if err != nil {
 		return err
 	}
-	ref, err := ResolveModelRef(ctx, cl.API(), flags.ModelRefFlags)
+	ref, err := ResolveDeploymentRef(ctx, cl.API(), flags.ModelDeploymentIDFlags)
 	if err != nil {
 		return err
 	}
 
 	if !flags.Yes {
-		if err := ctx.ConfirmYesNo(fmt.Sprintf("Terminate replica %s of deployment %s?", flags.ReplicaID, flags.DeploymentID)); err != nil {
+		if err := ctx.ConfirmYesNo(fmt.Sprintf("Terminate replica %s of deployment %s?", flags.ReplicaID, ref.DeploymentID)); err != nil {
 			return err
 		}
 	}
 
-	resp, err := cl.API().DeleteModelsDeploymentsReplicas(ctx, ref.ID, flags.DeploymentID, flags.ReplicaID)
+	resp, err := cl.API().DeleteModelsDeploymentsReplicas(ctx, ref.ModelID, ref.DeploymentID, flags.ReplicaID)
 	if err != nil {
 		return fmt.Errorf("terminate replica %s: %w", flags.ReplicaID, err)
 	}
@@ -35,6 +35,6 @@ func commandModelDeploymentReplicaTerminate(ctx *CommandContext, flags *cmd.Mode
 		ctx.OutputJSON(resp)
 		return nil
 	}
-	ctx.Logf("Terminated replica %s of deployment %s\n", flags.ReplicaID, flags.DeploymentID)
+	ctx.Logf("Terminated replica %s of deployment %s\n", flags.ReplicaID, ref.DeploymentID)
 	return nil
 }

--- a/internal/cmd/command.model_deployment_test.go
+++ b/internal/cmd/command.model_deployment_test.go
@@ -90,6 +90,40 @@ func Test_Model_Deployment_Describe_MissingDeploymentID(t *testing.T) {
 	h.Require.Error(err)
 }
 
+func Test_Model_Deployment_Describe_ByName(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/models/m-1/deployments", 200,
+		map[string]any{"deployments": []any{depFixture("d-1", "first", "production", "ACTIVE")}})
+	m.SetRoute("GET", "/v1/models/m-1/deployments/d-1", 200,
+		depFixture("d-1", "first", "production", "ACTIVE"))
+
+	h.Require.NoError(h.Execute("model", "deployment", "describe",
+		"--model-id", "m-1", "--deployment-name", "first"))
+	h.Require.Contains(h.Stdout.String(), "d-1")
+	call := m.FindCall("GET", "/v1/models/m-1/deployments")
+	h.Require.NotNil(call)
+	h.Require.Equal("first", call.Query().Get("name"))
+	h.Require.NotNil(m.FindCall("GET", "/v1/models/m-1/deployments/d-1"))
+}
+
+func Test_Model_Deployment_Describe_ByName_NotFound(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/models/m-1/deployments", 200,
+		map[string]any{"deployments": []any{}})
+
+	err := h.Execute("model", "deployment", "describe",
+		"--model-id", "m-1", "--deployment-name", "ghost")
+	h.Require.ErrorContains(err, `no deployment named "ghost"`)
+}
+
+func Test_Model_Deployment_Describe_IDAndName_Rejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "deployment", "describe",
+		"--model-id", "m-1", "--deployment-id", "d-1", "--deployment-name", "first")
+	h.Require.Error(err)
+}
+
 func Test_Model_Deployment_Config_TextRaw(t *testing.T) {
 	h := NewCommandHarness(t)
 	h.MockManagementAPI().SetRoute("GET", "/v1/models/m-1/deployments/d-1/config", 200,

--- a/internal/cmd/command.model_predict.go
+++ b/internal/cmd/command.model_predict.go
@@ -37,11 +37,14 @@ func commandModelPredict(ctx *CommandContext, flags *cmd.ModelPredictFlags) erro
 	if flags.DeploymentID != "" {
 		targets++
 	}
+	if flags.DeploymentName != "" {
+		targets++
+	}
 	if flags.Regional != "" {
 		targets++
 	}
 	if targets > 1 {
-		return cmd.NewErrUsagef("--environment, --deployment-id, and --regional are mutually exclusive")
+		return cmd.NewErrUsagef("--environment, --deployment-id, --deployment-name, and --regional are mutually exclusive")
 	}
 
 	mgmtCl, err := ctx.NewManagementClient()
@@ -51,6 +54,15 @@ func commandModelPredict(ctx *CommandContext, flags *cmd.ModelPredictFlags) erro
 	ref, err := ResolveModelRef(ctx, mgmtCl.API(), flags.ModelRefFlags)
 	if err != nil {
 		return err
+	}
+
+	// Resolve --deployment-name to an ID so the rest of the command routes via
+	// the deployment path, exactly as --deployment-id does.
+	if flags.DeploymentName != "" {
+		flags.DeploymentID, err = findDeploymentIDByName(ctx, mgmtCl.API(), ref.ID, flags.DeploymentName)
+		if err != nil {
+			return err
+		}
 	}
 
 	icFlags := cmd.InferenceClientFlags{ModelID: ref.ID}

--- a/internal/cmd/command.model_predict_test.go
+++ b/internal/cmd/command.model_predict_test.go
@@ -53,6 +53,27 @@ func Test_Model_Predict_DeploymentID(t *testing.T) {
 	h.Require.NotNil(m.FindCall("POST", "/deployment/d-1/predict"))
 }
 
+func Test_Model_Predict_DeploymentName(t *testing.T) {
+	h, m := newPredictHarness(t)
+	m.SetRoute("GET", "/v1/models/m-1/deployments", 200,
+		map[string]any{"deployments": []any{depFixture("d-1", "first", "production", "ACTIVE")}})
+	m.SetRoute("POST", "/deployment/d-1/predict", 200, map[string]any{"r": 1})
+
+	err := h.Execute("model", "predict", "--model-id", "m-1", "--deployment-name", "first", "--data", `{}`)
+	h.Require.NoError(err)
+	call := m.FindCall("GET", "/v1/models/m-1/deployments")
+	h.Require.NotNil(call)
+	h.Require.Equal("first", call.Query().Get("name"))
+	h.Require.NotNil(m.FindCall("POST", "/deployment/d-1/predict"))
+}
+
+func Test_Model_Predict_DeploymentNameExclusive(t *testing.T) {
+	h, _ := newPredictHarness(t)
+	err := h.Execute("model", "predict", "--model-id", "m-1",
+		"--deployment-name", "first", "--deployment-id", "d-1", "--data", `{}`)
+	h.Require.ErrorContains(err, "mutually exclusive")
+}
+
 func Test_Model_Predict_Regional(t *testing.T) {
 	h, m := newPredictHarness(t)
 	m.SetRoute("POST", "/predict", 200, map[string]any{"r": 1})

--- a/internal/cmd/command.model_test.go
+++ b/internal/cmd/command.model_test.go
@@ -123,6 +123,10 @@ func Test_Model_Describe_ByName(t *testing.T) {
 
 	h.Require.NoError(h.Execute("model", "describe", "--model-name", "alpha"))
 	h.Require.NotNil(m.FindCall("GET", "/v1/models/m-1"))
+	// The name filter is applied server-side via the ?name= query param.
+	listCall := m.FindCall("GET", "/v1/models")
+	h.Require.NotNil(listCall)
+	h.Require.Equal("alpha", listCall.Query().Get("name"))
 }
 
 func Test_Model_Describe_ByNameAmbiguous(t *testing.T) {

--- a/internal/cmd/command.org_team.go
+++ b/internal/cmd/command.org_team.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-go/client/managementapi"
 )
 
 func init() {
@@ -17,7 +18,7 @@ func commandOrgTeamList(ctx *CommandContext, flags *cmd.OrgTeamListFlags) error 
 	if err != nil {
 		return err
 	}
-	teams, err := cl.API().GetTeams(ctx)
+	teams, err := cl.API().GetTeams(ctx, managementapi.GetV1TeamsParams{})
 	if err != nil {
 		return fmt.Errorf("listing teams: %w", err)
 	}
@@ -51,9 +52,23 @@ func commandOrgTeamDescribe(ctx *CommandContext, flags *cmd.OrgTeamDescribeFlags
 		return err
 	}
 
-	team, err := cl.API().GetTeamsTeamId(ctx, flags.TeamID)
-	if err != nil {
-		return fmt.Errorf("describe team %s: %w", flags.TeamID, err)
+	var team *managementapi.Team
+	if flags.TeamName != "" {
+		resp, err := cl.API().GetTeams(ctx, managementapi.GetV1TeamsParams{Name: &flags.TeamName})
+		if err != nil {
+			return fmt.Errorf("describe team %q: %w", flags.TeamName, err)
+		}
+		if len(resp.Teams) == 0 {
+			return fmt.Errorf("no team named %q", flags.TeamName)
+		} else if len(resp.Teams) > 1 {
+			return fmt.Errorf("multiple teams named %q; pass --team-id instead", flags.TeamName)
+		}
+		team = &resp.Teams[0]
+	} else {
+		team, err = cl.API().GetTeamsTeamId(ctx, flags.TeamID)
+		if err != nil {
+			return fmt.Errorf("describe team %s: %w", flags.TeamID, err)
+		}
 	}
 
 	if ctx.JSON {

--- a/internal/cmd/command.org_team_test.go
+++ b/internal/cmd/command.org_team_test.go
@@ -63,6 +63,36 @@ func Test_Org_Team_Describe_ByID(t *testing.T) {
 	h.Require.Contains(out, "Default:")
 }
 
+func Test_Org_Team_Describe_ByName(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/teams", 200, map[string]any{
+		"teams": []any{teamFixture("t1", "Engineering", true)},
+	})
+
+	h.Require.NoError(h.Execute("org", "team", "describe", "--team-name", "Engineering"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "t1")
+	h.Require.Contains(out, "Engineering")
+	call := m.FindCall("GET", "/v1/teams")
+	h.Require.NotNil(call)
+	h.Require.Equal("Engineering", call.Query().Get("name"))
+}
+
+func Test_Org_Team_Describe_ByName_NotFound(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/teams", 200, map[string]any{"teams": []any{}})
+
+	err := h.Execute("org", "team", "describe", "--team-name", "ghost")
+	h.Require.ErrorContains(err, `no team named "ghost"`)
+}
+
+func Test_Org_Team_Describe_IDAndName_Rejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("org", "team", "describe", "--team-id", "t1", "--team-name", "Engineering")
+	h.Require.Error(err)
+}
+
 func Test_Org_Team_Describe_JSON(t *testing.T) {
 	h := NewCommandHarness(t)
 	m := h.MockManagementAPI()

--- a/internal/cmd/command.org_user.go
+++ b/internal/cmd/command.org_user.go
@@ -59,15 +59,29 @@ func commandOrgUserDescribe(ctx *CommandContext, flags *cmd.OrgUserDescribeFlags
 		return err
 	}
 
-	// "me" routes to the dedicated authenticated-user endpoint.
 	var user *managementapi.UserInfo
-	if flags.UserID == "me" {
+	if flags.UserEmail != "" {
+		resp, err := cl.API().GetUsers(ctx, managementapi.GetV1UsersParams{Email: &flags.UserEmail})
+		if err != nil {
+			return fmt.Errorf("describe user %q: %w", flags.UserEmail, err)
+		}
+		if len(resp.Items) == 0 {
+			return fmt.Errorf("no user with email %q", flags.UserEmail)
+		} else if len(resp.Items) > 1 {
+			return fmt.Errorf("multiple users with email %q", flags.UserEmail)
+		}
+		user = &resp.Items[0]
+	} else if flags.UserID == "me" {
+		// "me" routes to the dedicated authenticated-user endpoint.
 		user, err = cl.API().GetUsersMe(ctx)
+		if err != nil {
+			return fmt.Errorf("describe user %s: %w", flags.UserID, err)
+		}
 	} else {
 		user, err = cl.API().GetUsersUserId(ctx, flags.UserID)
-	}
-	if err != nil {
-		return fmt.Errorf("describe user %s: %w", flags.UserID, err)
+		if err != nil {
+			return fmt.Errorf("describe user %s: %w", flags.UserID, err)
+		}
 	}
 
 	if ctx.JSON {

--- a/internal/cmd/command.org_user_test.go
+++ b/internal/cmd/command.org_user_test.go
@@ -101,6 +101,36 @@ func Test_Org_User_Describe_ByID(t *testing.T) {
 	h.Require.Contains(h.Stdout.String(), "grace@acme.io")
 }
 
+func Test_Org_User_Describe_ByEmail(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/users", 200, map[string]any{
+		"items":      []any{userFixture("u9", "grace@acme.io", "Grace Hopper")},
+		"pagination": map[string]any{"has_more": false},
+	})
+
+	h.Require.NoError(h.Execute("org", "user", "describe", "--user-email", "grace@acme.io"))
+	h.Require.Contains(h.Stdout.String(), "grace@acme.io")
+	call := m.FindCall("GET", "/v1/users")
+	h.Require.NotNil(call)
+	h.Require.Equal("grace@acme.io", call.Query().Get("email"))
+}
+
+func Test_Org_User_Describe_ByEmail_NotFound(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/users", 200,
+		map[string]any{"items": []any{}, "pagination": map[string]any{"has_more": false}})
+
+	err := h.Execute("org", "user", "describe", "--user-email", "ghost@acme.io")
+	h.Require.ErrorContains(err, `no user with email "ghost@acme.io"`)
+}
+
+func Test_Org_User_Describe_IDAndEmail_Rejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("org", "user", "describe", "--user-id", "u1", "--user-email", "ada@acme.io")
+	h.Require.Error(err)
+}
+
 func Test_Org_User_Describe_JSON(t *testing.T) {
 	h := NewCommandHarness(t)
 	h.MockManagementAPI().SetRoute("GET", "/v1/users/me", 200,

--- a/internal/cmd/team.go
+++ b/internal/cmd/team.go
@@ -17,7 +17,7 @@ func ResolveTeam(ctx context.Context, api *managementapi.Client, input string) (
 	if input == "" {
 		return "", nil
 	}
-	resp, err := api.GetTeams(ctx)
+	resp, err := api.GetTeams(ctx, managementapi.GetV1TeamsParams{})
 	if err != nil {
 		return "", fmt.Errorf("list teams: %w", err)
 	}

--- a/internal/e2e-tests/helpers_test.go
+++ b/internal/e2e-tests/helpers_test.go
@@ -91,6 +91,7 @@ type pushedDeployment struct {
 	} `json:"model"`
 	Deployment struct {
 		ID     string `json:"id"`
+		Name   string `json:"name"`
 		Status string `json:"status"`
 	} `json:"deployment"`
 }

--- a/internal/e2e-tests/management_test.go
+++ b/internal/e2e-tests/management_test.go
@@ -157,6 +157,7 @@ func (m *management) User(t *testing.T) {
 	meOut := mustCLI(t, "org", "user", "describe", "--user-id", "me", "--output", "json")
 	var me struct {
 		UserID string `json:"user_id"`
+		Email  string `json:"email"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(meOut), &me))
 	require.NotEmpty(t, me.UserID, "describe me missing user_id")
@@ -184,6 +185,15 @@ func (m *management) User(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal([]byte(byIDOut), &byID))
 	require.Equal(t, me.UserID, byID.UserID)
+
+	// Describing by email (server-side ?email= filter) resolves the same user.
+	require.NotEmpty(t, me.Email, "describe me missing email")
+	byEmailOut := mustCLI(t, "org", "user", "describe", "--user-email", me.Email, "--output", "json")
+	var byEmail struct {
+		UserID string `json:"user_id"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(byEmailOut), &byEmail))
+	require.Equal(t, me.UserID, byEmail.UserID)
 }
 
 // Team lists teams and describes the default team by ID.
@@ -192,6 +202,7 @@ func (m *management) Team(t *testing.T) {
 	var list struct {
 		Teams []struct {
 			ID      string `json:"id"`
+			Name    string `json:"name"`
 			Default bool   `json:"default"`
 		} `json:"teams"`
 	}
@@ -199,19 +210,28 @@ func (m *management) Team(t *testing.T) {
 	require.NotEmpty(t, list.Teams, "team list is empty")
 
 	// Every org has a default team; describe it by ID.
-	teamID := list.Teams[0].ID
+	team := list.Teams[0]
 	for _, tm := range list.Teams {
 		if tm.Default {
-			teamID = tm.ID
+			team = tm
 			break
 		}
 	}
-	descOut := mustCLI(t, "org", "team", "describe", "--team-id", teamID, "--output", "json")
+	descOut := mustCLI(t, "org", "team", "describe", "--team-id", team.ID, "--output", "json")
 	var desc struct {
 		ID string `json:"id"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(descOut), &desc))
-	require.Equal(t, teamID, desc.ID)
+	require.Equal(t, team.ID, desc.ID)
+
+	// Describing by name (server-side ?name= filter) resolves the same team.
+	require.NotEmpty(t, team.Name, "team missing name")
+	byNameOut := mustCLI(t, "org", "team", "describe", "--team-name", team.Name, "--output", "json")
+	var byName struct {
+		ID string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(byNameOut), &byName))
+	require.Equal(t, team.ID, byName.ID)
 }
 
 // Whoami resolves the authenticated user.

--- a/internal/e2e-tests/model_test.go
+++ b/internal/e2e-tests/model_test.go
@@ -46,6 +46,9 @@ type lifecycle struct {
 	modelDir            string
 	modelID             string
 	initialDeploymentID string
+	// deploymentName is the initial deployment's server-assigned name, captured
+	// in the Deployment phase and reused by the name-based lookups.
+	deploymentName string
 }
 
 // newLifecycle runs the env-gate, materializes the truss source, performs the
@@ -94,6 +97,7 @@ func newLifecycle(t *testing.T) *lifecycle {
 	require.Equal(t, l.modelName, initial.Model.Name)
 	l.modelID = initial.Model.ID
 	l.initialDeploymentID = initial.Deployment.ID
+	l.deploymentName = initial.Deployment.Name
 	return l
 }
 
@@ -223,6 +227,19 @@ func (l *lifecycle) Deployment(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(out), &resp))
 		require.Equal(t, l.initialDeploymentID, resp.ID)
 		require.Equal(t, l.modelID, resp.ModelID)
+	})
+
+	t.Run("DescribeByName", func(t *testing.T) {
+		// Resolving both the model and the deployment by name (server-side
+		// ?name= filters) yields the same deployment as the IDs.
+		require.NotEmpty(t, l.deploymentName, "deployment missing name")
+		out := mustCLI(t, "model", "deployment", "describe",
+			"--model-name", l.modelName, "--deployment-name", l.deploymentName, "--output", "json")
+		var resp struct {
+			ID string `json:"id"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.Equal(t, l.initialDeploymentID, resp.ID)
 	})
 
 	t.Run("Config_Text", func(t *testing.T) {
@@ -465,6 +482,18 @@ func (l *lifecycle) Environment(t *testing.T) {
 func (l *lifecycle) ModelPredict(t *testing.T) {
 	t.Run("Default", func(t *testing.T) {
 		out := mustCLI(t, "model", "predict", "--model-id", l.modelID, "--data", `{"x":1}`, "--output", "json")
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.Equal(t, map[string]any{"got request": map[string]any{"x": float64(1)}}, resp)
+	})
+
+	t.Run("ByDeploymentName", func(t *testing.T) {
+		// Targets the deployment by resolving both the model and the deployment
+		// by name (server-side ?name= filters).
+		require.NotEmpty(t, l.deploymentName, "deployment missing name")
+		out := mustCLI(t, "model", "predict",
+			"--model-name", l.modelName, "--deployment-name", l.deploymentName,
+			"--data", `{"x":1}`, "--output", "json")
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal([]byte(out), &resp))
 		require.Equal(t, map[string]any{"got request": map[string]any{"x": float64(1)}}, resp)


### PR DESCRIPTION
## 🚀 What

- Add `--user-email` (`org user describe`), `--team-name` (`org team describe`), and `--deployment-name` (all `model deployment` commands + `model predict`) as alternatives to their `-id` flags.
- Resolve `model`/`deployment` name lookups server-side via the new `?name=`/`?email=` filters instead of listing-and-looping client-side.
- Bump `baseten-go` to pick up the filter params and the `ModelMetric*` spec rename.

Will wait on https://github.com/basetenlabs/baseten-go/pull/13

## 💻 How

- New/paired flags are tagged `oneof:"…-ref"` so Cobra enforces exactly-one (mutually exclusive + one-required); dropped the old `required` tags.
- Shared `ResolveDeploymentRef` (resolve model, then filter deployments by name) backs every deployment command; `model predict` reuses `findDeploymentIDByName`.
- All name/email resolvers error on both 0 and >1 matches.

## 🔬 Testing

- Unit tests for each new flag: success, not-found, and mutual-exclusion, plus `?name=`/`?email=` query assertions.
- E2E lifecycle now cross-checks name-based lookups against the ID-based results (user by email, team by name, deployment describe + predict by model-name + deployment-name), with `deploymentName` captured at setup to avoid inter-test dependencies.