### PR TITLE
Clear external_package_dirs from pushed config so server build validation passes

### DIFF
--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -187,25 +187,37 @@ func readModelConfigYAML(dir string, deployment *managementapi.DeploymentArchive
 		return fmt.Errorf("read %s: %w", path, err)
 	}
 
-	configMap := map[string]any{}
-	if err := yaml.Unmarshal(raw, &configMap); err != nil {
+	deployment.Config = map[string]any{}
+	if err := yaml.Unmarshal(raw, &deployment.Config); err != nil {
 		return fmt.Errorf("parse %s: %w", path, err)
 	}
-	if configMap == nil {
-		configMap = map[string]any{}
-	}
-	deployment.Config = configMap
+	// RawConfig is persisted verbatim and only surfaced back for display/download;
+	// the server never parses it into the build, so it keeps the original bytes
+	// (comments and all), including external_package_dirs.
 	rawStr := string(raw)
 	deployment.RawConfig = &rawStr
 
-	if raw, ok := configMap["external_package_dirs"].([]any); ok {
-		for _, v := range raw {
+	if extDirs, ok := deployment.Config["external_package_dirs"].([]any); ok {
+		for _, v := range extDirs {
 			if s, ok := v.(string); ok {
 				buildOpts.ExternalPackageDirs = append(buildOpts.ExternalPackageDirs, s)
 			}
 		}
+		// The external package contents are inlined into the archive under
+		// bundled_packages_dir (mirroring the Python CLI's gather step), so the
+		// field must be dropped from the config the server builds from: its truss
+		// validation errors on external_package_dirs whose relative paths don't
+		// exist in the extracted archive. ConfigYAMLOverride replaces the archived
+		// config.yaml (the file the build actually reads); RawConfig above keeps
+		// the original bytes since the server never builds from it.
+		delete(deployment.Config, "external_package_dirs")
+		cleared, err := yaml.Marshal(deployment.Config)
+		if err != nil {
+			return fmt.Errorf("re-marshal %s after clearing external_package_dirs: %w", path, err)
+		}
+		buildOpts.ConfigYAMLOverride = cleared
 	}
-	if bundled, ok := configMap["bundled_packages_dir"].(string); ok && bundled != "" {
+	if bundled, ok := deployment.Config["bundled_packages_dir"].(string); ok && bundled != "" {
 		buildOpts.BundledPackagesDir = bundled
 	} else {
 		buildOpts.BundledPackagesDir = modelPushDefaultBundledPkgDir

--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -187,9 +187,11 @@ func readModelConfigYAML(dir string, deployment *managementapi.DeploymentArchive
 		return fmt.Errorf("read %s: %w", path, err)
 	}
 
-	deployment.Config = map[string]any{}
 	if err := yaml.Unmarshal(raw, &deployment.Config); err != nil {
 		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	if deployment.Config == nil {
+		deployment.Config = map[string]any{}
 	}
 	// RawConfig is persisted verbatim and only surfaced back for display/download;
 	// the server never parses it into the build, so it keeps the original bytes

--- a/internal/cmd/command.model_push_test.go
+++ b/internal/cmd/command.model_push_test.go
@@ -290,7 +290,9 @@ func Test_Model_Push_TeamByName(t *testing.T) {
 
 // Verifies the asymmetry: --override-name and --no-build-cache mutate the API
 // `config` payload but NOT the archived config.yaml bytes. Also verifies
-// external_package_dirs are bundled under the configured directory.
+// external_package_dirs are bundled under the configured directory and
+// stripped from the config the server builds from, while raw_config keeps
+// the original on-disk bytes verbatim.
 func Test_Model_Push_OverridesAndExternalPackages(t *testing.T) {
 	h := newModelPushHarness(t)
 	dir := h.WriteModelDir("model_name: original\nexternal_package_dirs:\n  - extras\n")
@@ -311,12 +313,16 @@ func Test_Model_Push_OverridesAndExternalPackages(t *testing.T) {
 	h.Require.Equal("renamed", cfg["model_name"])
 	build := cfg["build"].(map[string]any)
 	h.Require.Equal(true, build["no_cache"])
+	// external_package_dirs is stripped from the parsed config: the server's
+	// truss validation would reject the now-nonexistent relative paths.
+	h.Require.NotContains(cfg, "external_package_dirs")
 	// raw_config is the on-disk bytes, NOT the mutated map.
 	h.Require.Equal("model_name: original\nexternal_package_dirs:\n  - extras\n", dep["raw_config"])
 
 	entries := h.UntarUploaded()
-	// Archived config.yaml is verbatim — no override leak.
-	h.Require.Equal("model_name: original\nexternal_package_dirs:\n  - extras\n", entries["config.yaml"])
+	// Archived config.yaml (what the build reads) has external_package_dirs
+	// stripped; the override-name rename only lands on the API-level config.
+	h.Require.Equal("model_name: original\n", entries["config.yaml"])
 	// External package dir contents bundled under the default "packages/".
 	h.Require.Equal("X = 1\n", entries["packages/util.py"])
 }

--- a/internal/e2e-tests/helpers_test.go
+++ b/internal/e2e-tests/helpers_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 // Minimal Truss source files baked into the test binary.
+// trussConfigTmpl is the lifecycle model's config. external_package_dirs points
+// at a sibling dir (see writeTruss) so the push exercises gather: its contents
+// are inlined into the archive's packages/ and the field is stripped from the
+// config the server builds from.
 const trussConfigTmpl = `model_name: %s
 python_version: py313
 resources:
@@ -27,7 +31,14 @@ resources:
 runtime:
   remote_ssh:
     enabled: true
+external_package_dirs:
+  - ../extpkg
 `
+
+// e2eExternalConst is exported by the external package module and echoed back
+// by the model's predict, proving the inlined packages/ dir is importable.
+const e2eExternalConst = "baseten-e2e-external-ok"
+const e2eExternalModule = "EXTERNAL_CONST = \"" + e2eExternalConst + "\"\n"
 
 // Marker tokens emitted by the test model's load() and asserted by the Logs
 // phase. The shared marker scopes queries to our lines; the per-level words
@@ -50,6 +61,9 @@ import time
 
 from fastapi.responses import StreamingResponse
 
+# Imported from the external package dir, inlined into packages/ on push.
+from e2e_ext import EXTERNAL_CONST
+
 _logger = logging.getLogger(__name__)
 
 class Model:
@@ -68,6 +82,8 @@ class Model:
             _logger.info("baseten-e2e-pagination line %02d" % i)
 
     def predict(self, request):
+        if request.get("style") == "external":
+            return {"external_const": EXTERNAL_CONST}
         if request.get("style") == "streaming":
             chunks = request.get("chunks", ["alpha", "beta", "gamma"])
             def gen():
@@ -157,14 +173,22 @@ func mustCLIStdin(t *testing.T, stdin string, args ...string) string {
 	return out
 }
 
-// writeTruss materializes the baked-in Truss source into a temp dir with
-// the given model name baked into config.yaml.
+// writeTruss materializes the baked-in Truss source and returns the truss dir.
+// The truss lives in a "truss" subdir alongside an "extpkg" sibling so
+// config.yaml's `external_package_dirs: [../extpkg]` resolves; the sibling
+// holds the module imported by model.py.
 func writeTruss(t *testing.T, modelName string) string {
 	t.Helper()
-	dir := t.TempDir()
+	parent := t.TempDir()
+
+	extDir := filepath.Join(parent, "extpkg")
+	require.NoError(t, os.MkdirAll(extDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(extDir, "e2e_ext.py"), []byte(e2eExternalModule), 0o644))
+
+	dir := filepath.Join(parent, "truss")
 	cfg := fmt.Sprintf(trussConfigTmpl, modelName)
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfg), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "model"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfg), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "model", "model.py"), []byte(trussModelPy), 0o644))
 	return dir
 }

--- a/internal/e2e-tests/model_test.go
+++ b/internal/e2e-tests/model_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // TestE2EModelLifecycle pushes a fresh model, drives the management and
@@ -248,12 +249,21 @@ func (l *lifecycle) Deployment(t *testing.T) {
 		mustCLI(t, "model", "deployment", "download",
 			"--model-id", l.modelID, "--deployment-id", l.initialDeploymentID, "--out-dir", outDir)
 
+		// The downloaded archive is the gathered truss: external_package_dirs is
+		// stripped and the external module is inlined under packages/. The config
+		// is re-marshalled server-side, so assert on structure, not exact bytes.
 		gotCfg, err := os.ReadFile(filepath.Join(outDir, "config.yaml"))
 		require.NoError(t, err)
-		require.Equal(t, fmt.Sprintf(trussConfigTmpl, l.modelName), string(gotCfg))
+		var cfgMap map[string]any
+		require.NoError(t, yaml.Unmarshal(gotCfg, &cfgMap))
+		require.Equal(t, l.modelName, cfgMap["model_name"])
+		require.NotContains(t, cfgMap, "external_package_dirs")
 		gotModel, err := os.ReadFile(filepath.Join(outDir, "model", "model.py"))
 		require.NoError(t, err)
 		require.Equal(t, trussModelPy, string(gotModel))
+		gotExt, err := os.ReadFile(filepath.Join(outDir, "packages", "e2e_ext.py"))
+		require.NoError(t, err)
+		require.Equal(t, e2eExternalModule, string(gotExt))
 	})
 
 	t.Run("Download_OutFile", func(t *testing.T) {
@@ -468,6 +478,13 @@ func (l *lifecycle) ModelPredict(t *testing.T) {
 		var resp map[string]any
 		require.NoError(t, json.Unmarshal([]byte(out), &resp))
 		require.Equal(t, map[string]any{"got request": map[string]any{"x": float64(1)}}, resp)
+	})
+
+	t.Run("ExternalPackage", func(t *testing.T) {
+		out := mustCLI(t, "model", "predict", "--model-id", l.modelID, "--data", `{"style":"external"}`, "--output", "json")
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.Equal(t, map[string]any{"external_const": e2eExternalConst}, resp)
 	})
 
 	t.Run("Streaming_Text", func(t *testing.T) {

--- a/internal/e2e-tests/model_watch_test.go
+++ b/internal/e2e-tests/model_watch_test.go
@@ -19,6 +19,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const watchConfigTmpl = `model_name: %s
+python_version: py313
+resources:
+  cpu: 50m
+  memory: 50Mi
+  use_gpu: false
+runtime:
+  remote_ssh:
+    enabled: true
+`
+
 // watchModelPyTmpl is a model whose predict response carries a version token
 // and the serving process PID. The watch test rewrites the token on disk and
 // asserts the running development deployment serves the new value, proving the
@@ -123,7 +134,7 @@ func newWatchTest(t *testing.T) *watchTest {
 		modelName: fmt.Sprintf("cli-e2e-watch-%s", randomSuffix(t)),
 		dir:       t.TempDir(),
 	}
-	cfg := fmt.Sprintf(trussConfigTmpl, w.modelName)
+	cfg := fmt.Sprintf(watchConfigTmpl, w.modelName)
 	require.NoError(t, os.WriteFile(filepath.Join(w.dir, "config.yaml"), []byte(cfg), 0o644))
 	require.NoError(t, os.MkdirAll(filepath.Join(w.dir, "model"), 0o755))
 	w.writeModelPy("v1")


### PR DESCRIPTION
## :rocket: What
- Fix `model push` failing server-side build validation for scattered trusses (those with `external_package_dirs`), while `truss push` succeeds.

## :computer: How
- In `readModelConfigYAML`, when `external_package_dirs` is set: strip it from the parsed config and set `ConfigYAMLOverride` so the archived `config.yaml` the server builds from is self-contained (contents are already inlined under `packages/`), mirroring the Python CLI's gather step.
- Keep `raw_config` as the verbatim on-disk bytes, since the backend only persists/displays it and never builds from it.

## :microscope: Testing
- Updated the push unit test: archived `config.yaml` stripped, parsed config stripped, `raw_config` verbatim.
- Made the lifecycle e2e model scattered (external pkg + import + predict const), decoupled the watch test onto its own config template, and added `Download_OutDir` structural checks + an `ExternalPackage` predict assertion.