### PR TITLE
Make output URLs clickable in supporting terminals

### DIFF
--- a/internal/cmd/command.auth.go
+++ b/internal/cmd/command.auth.go
@@ -206,7 +206,7 @@ func commandAuthStatus(ctx *CommandContext, flags *cmd.AuthStatusFlags) error {
 		if ctx.JSON {
 			ctx.OutputJSON(cmd.AuthStatusResult{RemoteURL: remoteURL, AuthType: string(auth.AuthTypeAPIKey)})
 		} else {
-			ctx.Outputf("Using API key from BASETEN_API_KEY\n  Remote: %s\n", remoteURL)
+			ctx.Outputf("Using API key from BASETEN_API_KEY\n  Remote: %s\n", hyperlink(ctx.Stdout, remoteURL))
 		}
 		return nil
 	}
@@ -227,7 +227,7 @@ func commandAuthStatus(ctx *CommandContext, flags *cmd.AuthStatusFlags) error {
 			AuthType:  string(profile.AuthType),
 		})
 	} else {
-		ctx.Outputf("%s\n  Remote: %s\n  Auth type: %s\n", profileName, profile.RemoteURL, profile.AuthType)
+		ctx.Outputf("%s\n  Remote: %s\n  Auth type: %s\n", profileName, hyperlink(ctx.Stdout, profile.RemoteURL), profile.AuthType)
 	}
 	return nil
 }

--- a/internal/cmd/command.model_api.go
+++ b/internal/cmd/command.model_api.go
@@ -98,7 +98,7 @@ func commandModelAPIDescribe(ctx *CommandContext, flags *cmd.ModelAPIDescribeFla
 	ctx.Outputf("Context Length:  %d\n", m.ContextLength)
 	ctx.Outputf("Input Cost:      $%s / 1M tokens\n", modelAPICurrencyString(m.CostPerMillionInputTokens))
 	ctx.Outputf("Output Cost:     $%s / 1M tokens\n", modelAPICurrencyString(m.CostPerMillionOutputTokens))
-	ctx.Outputf("Invoke URL:      %s\n", m.InvokeUrl)
+	ctx.Outputf("Invoke URL:      %s\n", hyperlink(ctx.Stdout, m.InvokeUrl))
 	if len(m.RateLimits) > 0 {
 		ctx.Outputf("Rate Limits:     %s\n", modelAPIRateLimitsString(m.RateLimits))
 	}

--- a/internal/cmd/command.model_deployment.go
+++ b/internal/cmd/command.model_deployment.go
@@ -93,6 +93,10 @@ func commandModelDeploymentDescribe(ctx *CommandContext, flags *cmd.ModelDeploym
 		ctx.OutputJSON(dep)
 		return nil
 	}
+	remote, err := ctx.authInfo.Remote()
+	if err != nil {
+		return err
+	}
 	ctx.Outputf("ID:           %s\n", dep.Id)
 	ctx.Outputf("Name:         %s\n", dep.Name)
 	ctx.Outputf("Model:        %s\n", dep.ModelId)
@@ -104,6 +108,8 @@ func commandModelDeploymentDescribe(ctx *CommandContext, flags *cmd.ModelDeploym
 		ctx.Outputf("Instance:     %s\n", *dep.InstanceTypeName)
 	}
 	ctx.Outputf("Replicas:     %d\n", dep.ActiveReplicaCount)
+	ctx.Outputf("Invoke URL:   %s\n", hyperlink(ctx.Stdout, remote.PredictURL(dep.ModelId, dep.Id, dep.IsDevelopment)))
+	ctx.Outputf("Logs URL:     %s\n", hyperlink(ctx.Stdout, remote.LogsURL(dep.ModelId, dep.Id)))
 	ctx.Outputf("Created:      %s\n", dep.CreatedAt.UTC().Format(time.RFC3339))
 	return nil
 }

--- a/internal/cmd/command.model_environment.go
+++ b/internal/cmd/command.model_environment.go
@@ -69,6 +69,10 @@ func commandModelEnvironmentDescribe(ctx *CommandContext, flags *cmd.ModelEnviro
 		ctx.OutputJSON(env)
 		return nil
 	}
+	remote, err := ctx.authInfo.Remote()
+	if err != nil {
+		return err
+	}
 	ctx.Outputf("Name:                %s\n", env.Name)
 	ctx.Outputf("Model:               %s\n", env.ModelId)
 	ctx.Outputf("Current Deployment:  %s\n", env.CurrentDeployment.Id)
@@ -76,6 +80,8 @@ func commandModelEnvironmentDescribe(ctx *CommandContext, flags *cmd.ModelEnviro
 	if env.CandidateDeployment != nil {
 		ctx.Outputf("Candidate Deployment: %s\n", env.CandidateDeployment.Id)
 	}
+	ctx.Outputf("Invoke URL:          %s\n", hyperlink(ctx.Stdout, remote.EnvironmentPredictURL(env.ModelId, env.Name)))
+	ctx.Outputf("Logs URL:            %s\n", hyperlink(ctx.Stdout, remote.LogsURL(env.ModelId, env.CurrentDeployment.Id)))
 	ctx.Outputf("Created:             %s\n", env.CreatedAt.UTC().Format(time.RFC3339))
 	return nil
 }

--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -582,7 +582,7 @@ func writeModelPushResult(ctx *CommandContext, created *managementapi.CreatedMod
 	// Narrative goes first so a user piping JSON to a file or jq sees the
 	// human summary on stderr before the JSON object lands on stdout.
 	if ctx.JSON {
-		writeModelPushSummary(ctx.Logf, created, predictURL, logsURL, environment, sshEnabled)
+		writeModelPushSummary(ctx.Logf, ctx.Stderr, created, predictURL, logsURL, environment, sshEnabled)
 		ctx.OutputJSON(cmd.ModelPushResult{
 			Model:      created.Model,
 			Deployment: created.Deployment,
@@ -591,7 +591,7 @@ func writeModelPushResult(ctx *CommandContext, created *managementapi.CreatedMod
 		})
 		return nil
 	}
-	writeModelPushSummary(ctx.Outputf, created, predictURL, logsURL, environment, sshEnabled)
+	writeModelPushSummary(ctx.Outputf, ctx.Stdout, created, predictURL, logsURL, environment, sshEnabled)
 	return nil
 }
 
@@ -619,6 +619,7 @@ func sshEnabledInConfig(config map[string]any) bool {
 // environment's live one after it finishes deploying.
 func writeModelPushSummary(
 	printf func(string, ...any),
+	w io.Writer,
 	created *managementapi.CreatedModelDeployment,
 	predictURL string,
 	logsURL string,
@@ -682,6 +683,9 @@ func writeModelPushSummary(
 		label string
 		value string
 		note  string
+		// rendered marks value as already styled (e.g. a hyperlink), so it is
+		// printed as-is rather than wrapped in inlineCodeStyle.
+		rendered bool
 	}
 	group := func(emoji, header string, hints []hint) {
 		printf("\n%s %s\n", emoji, header)
@@ -693,7 +697,11 @@ func writeModelPushSummary(
 		}
 		width += 2
 		for _, h := range hints {
-			printf("   %-*s%s", width, h.label, inlineCodeStyle.Render(h.value))
+			value := h.value
+			if !h.rendered {
+				value = inlineCodeStyle.Render(value)
+			}
+			printf("   %-*s%s", width, h.label, value)
 			if h.note != "" {
 				printf("  %s", h.note)
 			}
@@ -709,11 +717,11 @@ func writeModelPushSummary(
 		logs = append(logs, hint{label: "environment:", note: "(once deployed)", value: fmt.Sprintf(
 			"baseten model environment logs --model-id %s --environment %s", modelID, envName)})
 	}
-	logs = append(logs, hint{label: "app:", value: logsURL})
+	logs = append(logs, hint{label: "app:", value: hyperlink(w, logsURL), rendered: true})
 	group("🪵", "View logs:", logs)
 
 	group("🚀", "Invoke your model:", []hint{
-		{label: "URL:", value: predictURL},
+		{label: "URL:", value: hyperlink(w, predictURL), rendered: true},
 		{label: "CLI:", value: fmt.Sprintf("baseten model predict --model-id %s", modelID)},
 	})
 

--- a/internal/cmd/remote.go
+++ b/internal/cmd/remote.go
@@ -139,6 +139,12 @@ func (r *Remote) PredictURL(modelID, deploymentID string, isDraft bool) string {
 	return base + "/deployment/" + deploymentID + "/predict"
 }
 
+// EnvironmentPredictURL returns the user-facing predict URL for a model
+// environment, whose stable name selects the live deployment via the path.
+func (r *Remote) EnvironmentPredictURL(modelID, environment string) string {
+	return r.scheme + "://model-" + modelID + "." + r.managementAPIHost + "/environments/" + environment + "/predict"
+}
+
 // LogsURL returns the user-facing logs URL printed in push output.
 func (r *Remote) LogsURL(modelID, deploymentID string) string {
 	return r.scheme + "://app." + r.baseHost + "/models/" + modelID + "/logs/" + deploymentID

--- a/internal/cmd/style.go
+++ b/internal/cmd/style.go
@@ -1,8 +1,41 @@
 package cmd
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"io"
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/term"
+)
 
 // inlineCodeStyle renders a string like inline code in a markdown renderer:
 // subtle foreground color, no bold. lipgloss / termenv handle NO_COLOR and
 // non-TTY downgrade automatically.
 var inlineCodeStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "63", Dark: "117"})
+
+// linkStyle renders a hyperlink's visible text: the inline-code color plus an
+// underline so links read as links. lipgloss handles NO_COLOR and non-TTY
+// downgrade automatically.
+var linkStyle = inlineCodeStyle.Underline(true)
+
+// hyperlink renders url as an OSC 8 terminal hyperlink whose visible text is
+// the url itself, so terminals that support it make the URL clickable and
+// others simply show it. When w is not a terminal (piped or redirected), it
+// returns url unchanged so scripts and greps see exactly the URL.
+func hyperlink(w io.Writer, url string) string {
+	if !isTerminalWriter(w) {
+		return url
+	}
+	return ansi.SetHyperlink(url) + linkStyle.Render(url) + ansi.ResetHyperlink()
+}
+
+// isTerminalWriter reports whether w is a terminal, so escape sequences are
+// only emitted when a terminal will interpret them.
+func isTerminalWriter(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(f.Fd())
+}


### PR DESCRIPTION
## :rocket: What

- Output URLs are now clickable (OSC 8 hyperlinks) and underlined in terminals that support it: push summary invoke/logs URLs, `model api describe` invoke URL, `auth status` remote URL
- `model deployment describe` and `model environment describe` now show clickable **Invoke URL** and **Logs URL** lines

## :computer: How

- New `hyperlink(w, url)` helper in `style.go` wraps the URL via `x/ansi` `SetHyperlink`/`ResetHyperlink`, styled underline via lipgloss
- Gated on `term.IsTerminal`: piped, redirected, and `--json` output emit the bare URL, no escape bytes
- Added `Remote.EnvironmentPredictURL` for the environment-scoped `/environments/<env>/predict` URL

## :microscope: Testing

- `go vet` and `gofmt` clean; deployment/environment/push/auth/remote unit tests pass
- Verified a redirected/piped stream receives the plain URL with no escape sequences