### PR TITLE
Add model environment metrics command

### DIFF
--- a/cmd/command.model.go
+++ b/cmd/command.model.go
@@ -232,6 +232,21 @@ type LogFlags struct {
 	RequestID     string   `flag:"request-id" desc:"Only return logs tagged with this inference request ID."`
 }
 
+// MetricsFlags is the shared metric-query flag set for `baseten model deployment
+// metrics` and `baseten model environment metrics`. Both commands accept the
+// same mode, window, and metric-selection flags; only the metric source differs.
+type MetricsFlags struct {
+	Mode string `flag:"mode" desc:"Aggregation mode. 'current' returns an instantaneous snapshot at now; 'summary' aggregates the whole window into one value per metric; 'series' returns evenly-spaced points across the window. --start/--end/--since are only meaningful for summary and series." enum:"current,summary,series" default:"current"`
+
+	Start time.Time     `flag:"start" desc:"Start of the metrics time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the start to one hour before the end. Window must be at most 7 days."`
+	End   time.Time     `flag:"end" desc:"End of the metrics time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the end to now. Window must be at most 7 days."`
+	Since time.Duration `flag:"since" desc:"Shortcut for a window from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
+
+	Metric []string `flag:"metric" desc:"Name of a metric to return; see https://docs.baseten.co/observability/export-metrics/supported-metrics for the available names. May be repeated. When omitted, a default set is returned."`
+
+	NoChart bool `flag:"no-chart" desc:"For --mode series, emit a per-step table instead of sparklines."`
+}
+
 // ModelPushFlags configures `baseten model push`.
 type ModelPushFlags struct {
 	CommandFlags

--- a/cmd/command.model_deployment.go
+++ b/cmd/command.model_deployment.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"time"
-
 	"github.com/basetenlabs/baseten-go/client/managementapi"
 )
 
@@ -353,14 +351,5 @@ type ModelDeploymentLogsFlags struct {
 type ModelDeploymentMetricsFlags struct {
 	CommandFlags
 	ModelDeploymentIDFlags
-
-	Mode string `flag:"mode" desc:"Aggregation mode. 'current' returns an instantaneous snapshot at now; 'summary' aggregates the whole window into one value per metric; 'series' returns evenly-spaced points across the window. --start/--end/--since are only meaningful for summary and series." enum:"current,summary,series" default:"current"`
-
-	Start time.Time     `flag:"start" desc:"Start of the metrics time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the start to one hour before the end. Window must be at most 7 days."`
-	End   time.Time     `flag:"end" desc:"End of the metrics time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the end to now. Window must be at most 7 days."`
-	Since time.Duration `flag:"since" desc:"Shortcut for a window from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
-
-	Metric []string `flag:"metric" desc:"Name of a metric to return; see https://docs.baseten.co/observability/export-metrics/supported-metrics for the available names. May be repeated. When omitted, a default set is returned."`
-
-	NoChart bool `flag:"no-chart" desc:"For --mode series, emit a per-step table instead of sparklines."`
+	MetricsFlags
 }

--- a/cmd/command.model_environment.go
+++ b/cmd/command.model_environment.go
@@ -117,6 +117,44 @@ var commandModelEnvironment = Command{
 				},
 			},
 		},
+		{
+			Name:    "metrics",
+			Summary: "Fetch metrics for an environment",
+			Description: "Fetch metrics aggregated across every deployment that was active on the " +
+				"environment over the time range.\n\n" +
+				"--mode selects what you get back: a current snapshot, a windowed " +
+				"summary, or a series; see its flag help for details. Scope the window " +
+				"with --start/--end or --since (max 7 days), which only apply to " +
+				"summary and series. In series mode the window is split at each promotion " +
+				"so every point reflects the deployment(s) serving the environment at that time.",
+			Flags: ModelEnvironmentMetricsFlags{},
+			Output: &CommandOutput[managementapi.GetModelMetricsResponse]{
+				TextDescription: "For current/summary, a table with columns METRIC, one column per " +
+					"label dimension (e.g. QUANTILE, STAT), and VALUE; summary COUNTER values show " +
+					"\"total (rate/s)\". For series, a sparkline per metric label set with its " +
+					"min-max range and end value, or a per-step table under --no-chart.",
+				JSONDescription: "The metrics response: metric_descriptors, index-mapped metric_values, " +
+					"the resolved mode, and the returned window.",
+				Examples: []CommandExample{
+					{
+						Description: "Show a current snapshot of the default metrics for the production environment.",
+						Command:     "baseten model environment metrics --model-id <model-id> --environment production",
+					},
+					{
+						Description: "Summarize request volume and latency over the last hour.",
+						Command:     "baseten model environment metrics --model-id <model-id> --environment production --mode summary --since 1h --metric baseten_inference_requests_total --metric baseten_end_to_end_response_time_seconds",
+					},
+					{
+						Description: "Plot a series over the last 6 hours.",
+						Command:     "baseten model environment metrics --model-id <model-id> --environment production --mode series --since 6h",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the metric names returned.",
+					Command:     "baseten model environment metrics --model-id <model-id> --environment production --jq '.metric_descriptors[].name'",
+				},
+			},
+		},
 	},
 }
 
@@ -158,4 +196,11 @@ type ModelEnvironmentLogsFlags struct {
 	CommandFlags
 	ModelEnvironmentFlags
 	LogFlags
+}
+
+// ModelEnvironmentMetricsFlags configures `baseten model environment metrics`.
+type ModelEnvironmentMetricsFlags struct {
+	CommandFlags
+	ModelEnvironmentFlags
+	MetricsFlags
 }

--- a/internal/cmd/command.model_deployment_metrics.go
+++ b/internal/cmd/command.model_deployment_metrics.go
@@ -17,6 +17,44 @@ func init() {
 }
 
 func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeploymentMetricsFlags) error {
+	api, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := ResolveDeploymentRef(ctx, api.API(), flags.ModelDeploymentIDFlags)
+	if err != nil {
+		return err
+	}
+	fetch := func(q metricsQuery) (*managementapi.GetModelMetricsResponse, error) {
+		return api.API().GetModelsDeploymentsMetrics(ctx, ref.ModelID, ref.DeploymentID,
+			managementapi.GetV1ModelsModelIdDeploymentsDeploymentIdMetricsParams{
+				Mode:             &q.Mode,
+				StartEpochMillis: q.StartEpochMillis,
+				EndEpochMillis:   q.EndEpochMillis,
+				Metrics:          q.Metrics,
+			})
+	}
+	return runMetricsCommand(ctx, &flags.MetricsFlags, fetch)
+}
+
+// metricsQuery is the transport-neutral set of metric-query parameters shared by
+// the deployment and environment metrics endpoints. Each command maps it onto
+// its own generated query-params type.
+type metricsQuery struct {
+	Mode             managementapi.ModelMetricMode
+	StartEpochMillis *int
+	EndEpochMillis   *int
+	Metrics          *[]string
+}
+
+// metricsFetcher fetches metrics for the given query.
+type metricsFetcher func(q metricsQuery) (*managementapi.GetModelMetricsResponse, error)
+
+// runMetricsCommand implements the shared metrics command flow for both
+// deployment and environment metrics. It validates the flags, resolves the mode
+// and time window into a metricsQuery, fetches via the supplied fetcher, and
+// renders the response.
+func runMetricsCommand(ctx *CommandContext, flags *cmd.MetricsFlags, fetch metricsFetcher) error {
 	mode := managementapi.ModelMetricMode(strings.ToUpper(flags.Mode))
 
 	hasStart := !flags.Start.IsZero()
@@ -32,16 +70,7 @@ func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeployme
 		return cmd.NewErrUsagef("--since cannot be combined with --start or --end")
 	}
 
-	api, err := ctx.NewManagementClient()
-	if err != nil {
-		return err
-	}
-	ref, err := ResolveDeploymentRef(ctx, api.API(), flags.ModelDeploymentIDFlags)
-	if err != nil {
-		return err
-	}
-
-	params := managementapi.GetV1ModelsModelIdDeploymentsDeploymentIdMetricsParams{Mode: &mode}
+	q := metricsQuery{Mode: mode}
 	if hasSince {
 		if flags.Since <= 0 {
 			return cmd.NewErrUsagef("--since must be a positive duration")
@@ -52,17 +81,17 @@ func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeployme
 		now := ctx.Now()
 		s := int(now.Add(-flags.Since).UnixMilli())
 		e := int(now.UnixMilli())
-		params.StartEpochMillis, params.EndEpochMillis = &s, &e
+		q.StartEpochMillis, q.EndEpochMillis = &s, &e
 	} else if hasStart || hasEnd {
 		// Send only the bounds given and leave the other nil so the server
 		// backfills it. Validate the window client-side only when both are given.
 		if hasStart {
 			s := int(flags.Start.UnixMilli())
-			params.StartEpochMillis = &s
+			q.StartEpochMillis = &s
 		}
 		if hasEnd {
 			e := int(flags.End.UnixMilli())
-			params.EndEpochMillis = &e
+			q.EndEpochMillis = &e
 		}
 		if hasStart && hasEnd {
 			if !flags.Start.Before(flags.End) {
@@ -74,10 +103,10 @@ func commandModelDeploymentMetrics(ctx *CommandContext, flags *cmd.ModelDeployme
 		}
 	}
 	if len(flags.Metric) > 0 {
-		params.Metrics = &flags.Metric
+		q.Metrics = &flags.Metric
 	}
 
-	resp, err := api.API().GetModelsDeploymentsMetrics(ctx, ref.ModelID, ref.DeploymentID, params)
+	resp, err := fetch(q)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/command.model_environment_metrics.go
+++ b/internal/cmd/command.model_environment_metrics.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+)
+
+func init() {
+	Register("model environment metrics", commandModelEnvironmentMetrics)
+}
+
+func commandModelEnvironmentMetrics(ctx *CommandContext, flags *cmd.ModelEnvironmentMetricsFlags) error {
+	api, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := ResolveModelRef(ctx, api.API(), flags.ModelRefFlags)
+	if err != nil {
+		return err
+	}
+	fetch := func(q metricsQuery) (*managementapi.GetModelMetricsResponse, error) {
+		return api.API().GetModelsEnvironmentsMetrics(ctx, ref.ID, flags.Environment,
+			managementapi.GetV1ModelsModelIdEnvironmentsEnvNameMetricsParams{
+				Mode:             &q.Mode,
+				StartEpochMillis: q.StartEpochMillis,
+				EndEpochMillis:   q.EndEpochMillis,
+				Metrics:          q.Metrics,
+			})
+	}
+	return runMetricsCommand(ctx, &flags.MetricsFlags, fetch)
+}

--- a/internal/cmd/command.model_environment_metrics_test.go
+++ b/internal/cmd/command.model_environment_metrics_test.go
@@ -1,0 +1,85 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/internal/cmd"
+)
+
+const envMetricsPath = "/v1/models/m/environments/production/metrics"
+
+func Test_Model_Environment_Metrics_CurrentWithSinceRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("model", "environment", "metrics",
+		"--model-id", "m", "--environment", "production", "--since", "1h")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "only valid with --mode summary or series")
+}
+
+func Test_Model_Environment_Metrics_ModeAndMetricsSent(t *testing.T) {
+	h := NewCommandHarness(t)
+	api := h.MockManagementAPI()
+	var gotQuery url.Values
+	api.SetRouteFunc("GET", envMetricsPath, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(metricsResponse("SUMMARY", 0, 3600000, []any{}, []any{}))
+	})
+	fixed := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	h.Context = cmd.WithNow(h.Context, func() time.Time { return fixed })
+	err := h.Execute("model", "environment", "metrics",
+		"--model-id", "m", "--environment", "production", "--mode", "summary", "--since", "1h",
+		"--metric", "baseten_inference_requests_total", "--metric", "baseten_replicas_active")
+	h.Require.NoError(err)
+	// Mode is uppercased before sending.
+	h.Require.Equal("SUMMARY", gotQuery.Get("mode"))
+	h.Require.Equal(int(fixed.Add(-time.Hour).UnixMilli()), mustAtoi(t, gotQuery.Get("start_epoch_millis")))
+	h.Require.Equal(int(fixed.UnixMilli()), mustAtoi(t, gotQuery.Get("end_epoch_millis")))
+	call := api.FindCall("GET", envMetricsPath)
+	h.Require.NotNil(call)
+	raw := gotQuery.Encode()
+	h.Require.Contains(raw, "baseten_inference_requests_total")
+	h.Require.Contains(raw, "baseten_replicas_active")
+}
+
+func Test_Model_Environment_Metrics_CurrentSnapshotTable(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", envMetricsPath, 200, metricsResponse("CURRENT", 0, 0,
+		[]any{
+			metricsDescriptor("baseten_replicas_active", "GAUGE", "COUNT", map[string]string{}),
+			metricsDescriptor("baseten_end_to_end_response_time_seconds", "HISTOGRAM", "SECONDS",
+				map[string]string{"quantile": "0.5"}, map[string]string{"quantile": "0.99"}),
+		},
+		[]any{metricsValueSet(0, []any{3}, []any{0.12, 0.55})},
+	))
+	err := h.Execute("model", "environment", "metrics",
+		"--model-id", "m", "--environment", "production")
+	h.Require.NoError(err)
+	out := h.Stdout.String()
+	h.Require.Contains(out, "METRIC")
+	h.Require.Contains(out, "QUANTILE")
+	h.Require.Contains(out, "baseten_replicas_active")
+	h.Require.Contains(out, "0.12s")
+	// current is a point-in-time snapshot: no window line.
+	h.Require.NotContains(h.Stderr.String(), "Window:")
+}
+
+func Test_Model_Environment_Metrics_JSONPassthrough(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", envMetricsPath, 200, metricsResponse("CURRENT", 0, 0,
+		[]any{metricsDescriptor("baseten_replicas_active", "GAUGE", "COUNT", map[string]string{})},
+		[]any{metricsValueSet(0, []any{3})},
+	))
+	err := h.Execute("model", "environment", "metrics",
+		"--model-id", "m", "--environment", "production", "--output", "json")
+	h.Require.NoError(err)
+	out := strings.TrimSpace(h.Stdout.String())
+	h.Require.True(strings.HasPrefix(out, "{"))
+	h.Require.Contains(out, `"metric_descriptors"`)
+	h.Require.Contains(out, "baseten_replicas_active")
+}

--- a/internal/e2e-tests/model_test.go
+++ b/internal/e2e-tests/model_test.go
@@ -565,6 +565,19 @@ func (l *lifecycle) Metrics(t *testing.T) {
 		require.Equal(t, "SERIES", resp.Mode)
 		require.NotEmpty(t, resp.MetricDescriptors)
 	})
+
+	// The environment metrics path aggregates across the deployments active on
+	// the environment; production's current deployment is this model, so the
+	// same registered descriptor appears. Shape only, never a value.
+	t.Run("Environment", func(t *testing.T) {
+		out := mustCLI(t, "model", "environment", "metrics",
+			"--model-id", l.modelID, "--environment", "production", "--output", "json")
+		var resp metricsResp
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.Equal(t, "CURRENT", resp.Mode)
+		require.True(t, hasDescriptor(resp, "baseten_replicas_active"),
+			"baseten_replicas_active missing from current snapshot")
+	})
 }
 
 // SSH exercises the full `baseten ssh` flow against the live deployment: it


### PR DESCRIPTION
## :rocket: What

- Adds `baseten model environment metrics`, fronting the environment metrics REST endpoint
- Full parity with `model deployment metrics` (same `--mode`/`--start`/`--end`/`--since`/`--metric`/`--no-chart` flags and output modes)
- Metrics are aggregated across every deployment active on the environment; series mode splits the window at each promotion

## :computer: How

- Extracted the shared metric-query flags into `MetricsFlags` (mirrors `LogFlags`)
- Split the metrics command into a thin per-source wrapper plus a shared `runMetricsCommand`, with a transport-neutral `metricsQuery`/`metricsFetcher` (mirrors the logs refactor)
- New env command resolves via `ResolveModelRef` and calls `GetModelsEnvironmentsMetrics`

## :microscope: Testing

- New env-metrics unit tests (route/params, rendering, JSON, validation wiring); shared runner's full matrix stays covered by the deployment tests
- Added an `Environment` sub-step to the `Metrics` e2e