### PR TITLE
Skip S3 upload on model push when prepare returns no S3 key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.1.1-0.20260709151359-c4d6f07b6fab
+	github.com/basetenlabs/baseten-go v0.1.1-0.20260720143708-a98e2103a143
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -86,5 +86,3 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 )
-
-replace github.com/basetenlabs/baseten-go => ../baseten-go

--- a/go.mod
+++ b/go.mod
@@ -86,3 +86,5 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 )
+
+replace github.com/basetenlabs/baseten-go => ../baseten-go

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/basetenlabs/baseten-go v0.1.1-0.20260720143708-a98e2103a143 h1:tApns1tFcWfBl3/jXFj6yNtcPzZLwQHpeD+SNOKRuhs=
+github.com/basetenlabs/baseten-go v0.1.1-0.20260720143708-a98e2103a143/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,6 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.1.1-0.20260709151359-c4d6f07b6fab h1:3Pmeq1uFwhdreZa99Z3EJ/MJY7Ry1zGOpv1PoQTaHAo=
-github.com/basetenlabs/baseten-go v0.1.1-0.20260709151359-c4d6f07b6fab/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -88,12 +88,18 @@ func commandModelPush(ctx *CommandContext, flags *cmd.ModelPushFlags) error {
 		return nil
 	}
 
-	if err := uploadModelPushArchive(ctx, buildOpts, prepareResp); err != nil {
-		return err
+	// Model formats that are not built from an uploaded archive (for example,
+	// BIS-LLM) get no upload target back from prepare: prepare returns a null
+	// S3 key. In that case skip the S3 upload and go straight to the commit,
+	// which the server builds from the config alone.
+	if prepareResp.S3Key != nil {
+		if err := uploadModelPushArchive(ctx, buildOpts, prepareResp); err != nil {
+			return err
+		}
 	}
 
 	modelName := resolvedModelPushName(prepareReq)
-	created, err := commitModelPush(ctx, api.API(), existingModelID, teamID, modelName, *prepareResp.S3Key, prepareReq.Deployment, flags.DisableArchiveDownload)
+	created, err := commitModelPush(ctx, api.API(), existingModelID, teamID, modelName, prepareResp.S3Key, prepareReq.Deployment, flags.DisableArchiveDownload)
 	if err != nil {
 		return err
 	}
@@ -411,7 +417,8 @@ func (c *readCounter) Read(p []byte) (int, error) {
 func commitModelPush(
 	ctx context.Context,
 	api *managementapi.Client,
-	existingModelID, teamID, modelName, s3Key string,
+	existingModelID, teamID, modelName string,
+	s3Key *string,
 	deployment managementapi.DeploymentArchivePayload,
 	disableArchiveDownload bool,
 ) (*managementapi.CreatedModelDeployment, error) {


### PR DESCRIPTION
## :rocket: What

- Support pushing archive-less model formats (e.g. BIS-LLM), where prepare returns no S3 upload target.

NOTE: This is in draft pending a backend deployment and baseten-go update.

## :computer: How

- Skip the S3 archive upload when `prepare_model_upload` returns a null `s3_key`; still issue the create/deploy POST.
- `commitModelPush` now takes `s3_key` as `*string`, omitted from the request when nil (matches regenerated baseten-go source types).

## :microscope: Testing

- Confirmed BIS LLM model works