### PR TITLE
Add model image build and prepare commands

### DIFF
--- a/cmd/command.model.go
+++ b/cmd/command.model.go
@@ -187,6 +187,7 @@ var commandModel = Command{
 		},
 		commandModelDeployment,
 		commandModelEnvironment,
+		commandModelImage,
 	},
 }
 

--- a/cmd/command.model_image.go
+++ b/cmd/command.model_image.go
@@ -1,0 +1,124 @@
+package cmd
+
+// commandModelImage groups the `baseten model image` subcommands, which build a
+// local Docker image (or just its build context) from a model directory. Both
+// subcommands shell out to the truss CLI via `uv` to generate the build context
+// and, for `build`, to `docker` to build the image. They require no
+// authentication and make no Baseten API calls.
+var commandModelImage = Command{
+	Name:    "image",
+	Summary: "Build local Docker images from a model directory",
+	Description: "Build a local Docker image, or just its Docker build context, from a " +
+		"model directory.\n\n" +
+		"These commands run entirely locally: they shell out to the truss CLI (via " +
+		"'uv') to generate the build context and to 'docker' to build the image. They " +
+		"need no authentication and make no Baseten API calls. 'uv' must be on PATH; " +
+		"'build' also requires 'docker'.",
+	Children: []Command{
+		{
+			Name:      "build",
+			ArgsUsage: "[-- DOCKER_BUILD_ARGS...]",
+			Summary:   "Build a local Docker image from a model directory",
+			Description: "Generate the Docker build context for a model directory and build it " +
+				"into a local Docker image.\n\n" +
+				"The current directory is used by default; pass --dir to point at a model " +
+				"directory elsewhere. The build context is written to a temporary directory " +
+				"that is removed afterward unless --build-dir is given.\n\n" +
+				"Any arguments after '--' are passed through verbatim to 'docker build'. If " +
+				"you supply your own --iidfile there, it is honored and used to report the " +
+				"image ID; otherwise one is injected internally.",
+			MaxArgs: -1,
+			Flags:   ModelImageBuildFlags{},
+			Output: &CommandOutput[ModelImageBuildResult]{
+				TextDescription: "Build progress from truss and docker is streamed to stderr. On " +
+					"success a one-line summary is printed to stderr; no stdout output.",
+				JSONDescription: "Under --output json, stdout is the {image_id, tag} result. " +
+					"image_id is empty when it cannot be resolved (e.g. a custom buildx builder " +
+					"that does not write the iidfile).",
+				Examples: []CommandExample{
+					{
+						Description: "Build the current directory into a local Docker image.",
+						Command:     "baseten model image build",
+					},
+					{
+						Description: "Build another directory with a custom tag.",
+						Command:     "baseten model image build --dir ./my-model --tag my-model:dev",
+					},
+					{
+						Description: "Pass extra flags through to docker build.",
+						Command:     "baseten model image build -- --no-cache --build-arg FOO=bar",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the built image ID.",
+					Command:     "baseten model image build --jq '.image_id'",
+				},
+			},
+		},
+		{
+			Name:      "prepare",
+			ArgsUsage: "--build-dir DIR",
+			Summary:   "Write a Docker build context from a model directory",
+			Description: "Generate the Docker build context (Dockerfile and supporting files) for " +
+				"a model directory into --build-dir, without building an image.\n\n" +
+				"The current directory is used by default; pass --dir to point at a model " +
+				"directory elsewhere. The resulting directory is self-contained and can be " +
+				"built with 'docker build <build-dir>'.",
+			Flags: ModelImagePrepareFlags{},
+			Output: &CommandOutput[ModelImagePrepareResult]{
+				TextDescription: "Progress from truss is streamed to stderr. On success a one-line " +
+					"summary is printed to stderr; no stdout output.",
+				JSONDescription: "Under --output json, stdout is the {build_dir, dockerfile} result " +
+					"with absolute paths.",
+				Examples: []CommandExample{
+					{
+						Description: "Write the current directory's build context to ./ctx.",
+						Command:     "baseten model image prepare --build-dir ./ctx",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the generated Dockerfile path.",
+					Command:     "baseten model image prepare --build-dir ./ctx --jq '.dockerfile'",
+				},
+			},
+		},
+	},
+}
+
+// ModelImageBuildResult is the JSON output of `baseten model image build`.
+type ModelImageBuildResult struct {
+	ImageID string `json:"image_id"`
+	Tag     string `json:"tag"`
+}
+
+// ModelImagePrepareResult is the JSON output of `baseten model image prepare`.
+type ModelImagePrepareResult struct {
+	BuildDir   string `json:"build_dir"`
+	Dockerfile string `json:"dockerfile"`
+}
+
+// ModelImageCommonFlags are the flags shared by both `baseten model image`
+// subcommands.
+type ModelImageCommonFlags struct {
+	CommandFlags
+
+	Dir string `flag:"dir" desc:"Model directory. Defaults to the current directory." default:"."`
+
+	TrussVersion string `flag:"truss-version" desc:"Truss version to run via uv, e.g. '0.9.0' or 'latest'." default:"latest"`
+}
+
+// ModelImageBuildFlags configures `baseten model image build`.
+type ModelImageBuildFlags struct {
+	ModelImageCommonFlags
+
+	BuildDir string `flag:"build-dir" desc:"Directory to write the Docker build context into. Defaults to a temporary directory that is removed after the build."`
+
+	Tag string `flag:"tag" desc:"Image tag for 'docker build -t'. Defaults to '<model_name>:latest' from config.yaml."`
+}
+
+// ModelImagePrepareFlags configures `baseten model image prepare`.
+type ModelImagePrepareFlags struct {
+	ModelImageCommonFlags
+
+	BuildDir string `flag:"build-dir" desc:"Directory to write the Docker build context into. Created if absent and kept after the command completes." required:"true"`
+}

--- a/cmd/command.model_image.go
+++ b/cmd/command.model_image.go
@@ -31,7 +31,7 @@ var commandModelImage = Command{
 			Flags:   ModelImageBuildFlags{},
 			Output: &CommandOutput[ModelImageBuildResult]{
 				TextDescription: "Build progress from truss and docker is streamed to stderr. On " +
-					"success a one-line summary is printed to stderr; no stdout output.",
+					"success a one-line summary is printed to stdout.",
 				JSONDescription: "Under --output json, stdout is the {image_id, tag} result. " +
 					"image_id is empty when it cannot be resolved (e.g. a custom buildx builder " +
 					"that does not write the iidfile).",
@@ -67,7 +67,7 @@ var commandModelImage = Command{
 			Flags: ModelImagePrepareFlags{},
 			Output: &CommandOutput[ModelImagePrepareResult]{
 				TextDescription: "Progress from truss is streamed to stderr. On success a one-line " +
-					"summary is printed to stderr; no stdout output.",
+					"summary is printed to stdout.",
 				JSONDescription: "Under --output json, stdout is the {build_dir, dockerfile} result " +
 					"with absolute paths.",
 				Examples: []CommandExample{

--- a/cmd/command.model_image.go
+++ b/cmd/command.model_image.go
@@ -101,24 +101,21 @@ type ModelImagePrepareResult struct {
 // subcommands.
 type ModelImageCommonFlags struct {
 	CommandFlags
-
-	Dir string `flag:"dir" desc:"Model directory. Defaults to the current directory." default:"."`
-
-	TrussVersion string `flag:"truss-version" desc:"Truss version to run via uv, e.g. '0.9.0' or 'latest'." default:"latest"`
+	Dir          string `flag:"dir" desc:"Model directory." default:"."`
+	TrussVersion string `flag:"truss-version" desc:"Truss version to run via uv." default:"latest"`
+	RootUser     bool   `flag:"root-user" desc:"Run the image's container as root instead of the default non-root user."`
+	CacheMountID string `flag:"cache-mount-id" desc:"Enable a persistent apt/pip/uv build cache keyed by this id."`
 }
 
 // ModelImageBuildFlags configures `baseten model image build`.
 type ModelImageBuildFlags struct {
 	ModelImageCommonFlags
-
-	BuildDir string `flag:"build-dir" desc:"Directory to write the Docker build context into. Defaults to a temporary directory that is removed after the build."`
-
-	Tag string `flag:"tag" desc:"Image tag for 'docker build -t'. Defaults to '<model_name>:latest' from config.yaml."`
+	BuildDir string `flag:"build-dir" desc:"Directory for the Docker build context. Defaults to a temp dir removed after the build."`
+	Tag      string `flag:"tag" desc:"Image tag. Defaults to '<model_name>:latest' from config.yaml."`
 }
 
 // ModelImagePrepareFlags configures `baseten model image prepare`.
 type ModelImagePrepareFlags struct {
 	ModelImageCommonFlags
-
-	BuildDir string `flag:"build-dir" desc:"Directory to write the Docker build context into. Created if absent and kept after the command completes." required:"true"`
+	BuildDir string `flag:"build-dir" desc:"Directory for the Docker build context. Created if absent and kept." required:"true"`
 }

--- a/internal/cmd/command.model_image.go
+++ b/internal/cmd/command.model_image.go
@@ -1,0 +1,236 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/basetenlabs/baseten-cli/cmd"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	modelImageConfigFileName = "config.yaml"
+	modelImageDockerfileName = "Dockerfile"
+	modelImageDefaultTag     = "baseten-model:latest"
+)
+
+func init() {
+	Register("model image build", commandModelImageBuild)
+	Register("model image prepare", commandModelImagePrepare)
+}
+
+func commandModelImageBuild(ctx *CommandContext, flags *cmd.ModelImageBuildFlags) error {
+	if err := modelImageRequireUV(ctx); err != nil {
+		return err
+	}
+	if _, err := ctx.Execer().LookPath("docker"); err != nil {
+		return cmd.NewErrUsagef("docker not found on PATH, required to build the image")
+	}
+
+	// Everything after `--` is forwarded verbatim to `docker build`; no
+	// positional arguments are allowed before it.
+	passthrough, err := modelImageDockerPassthroughArgs(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Resolve the build context dir: an explicit --build-dir is kept, otherwise
+	// a temp dir is used and removed afterward.
+	buildDir := flags.BuildDir
+	if buildDir == "" {
+		tmp, err := os.MkdirTemp("", "baseten-image-*")
+		if err != nil {
+			return fmt.Errorf("create temp build dir: %w", err)
+		}
+		defer func() { _ = os.RemoveAll(tmp) }()
+		buildDir = tmp
+	} else if err := os.MkdirAll(buildDir, 0o755); err != nil {
+		return fmt.Errorf("create build dir: %w", err)
+	}
+
+	if err := modelImageBuildContext(ctx, flags.TrussVersion, buildDir, flags.Dir); err != nil {
+		return err
+	}
+
+	tag := flags.Tag
+	if tag == "" {
+		tag = modelImageDeriveDefaultTag(flags.Dir)
+	}
+
+	// Capture the image ID via --iidfile. If the user supplied their own in the
+	// passthrough, defer to it; otherwise inject a temp file we own.
+	iidPath := modelImageUserIIDFilePath(passthrough)
+	inject := iidPath == ""
+	if inject {
+		f, err := os.CreateTemp("", "baseten-iid-*")
+		if err != nil {
+			return fmt.Errorf("create iidfile: %w", err)
+		}
+		iidPath = f.Name()
+		_ = f.Close()
+		defer func() { _ = os.Remove(iidPath) }()
+	}
+
+	dockerArgs := []string{"build", "-t", tag}
+	if inject {
+		dockerArgs = append(dockerArgs, "--iidfile", iidPath)
+	}
+	dockerArgs = append(dockerArgs, passthrough...)
+	dockerArgs = append(dockerArgs, buildDir)
+
+	build := exec.CommandContext(ctx, "docker", dockerArgs...)
+	build.Stdin = ctx.Stdin
+	// Keep our stdout clean for the result; build progress goes to stderr.
+	build.Stdout = ctx.Stderr
+	build.Stderr = ctx.Stderr
+	if err := modelImageExec(ctx, build); err != nil {
+		return err
+	}
+
+	imageID := ""
+	if b, err := os.ReadFile(iidPath); err == nil {
+		imageID = strings.TrimSpace(string(b))
+	}
+
+	result := cmd.ModelImageBuildResult{ImageID: imageID, Tag: tag}
+	if ctx.JSON {
+		ctx.OutputJSON(result)
+	} else if imageID != "" {
+		ctx.Outputf("Built image %s (%s)\n", tag, imageID)
+	} else {
+		ctx.Outputf("Built image %s\n", tag)
+	}
+	return nil
+}
+
+func commandModelImagePrepare(ctx *CommandContext, flags *cmd.ModelImagePrepareFlags) error {
+	if err := modelImageRequireUV(ctx); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(flags.BuildDir, 0o755); err != nil {
+		return fmt.Errorf("create build dir: %w", err)
+	}
+	if err := modelImageBuildContext(ctx, flags.TrussVersion, flags.BuildDir, flags.Dir); err != nil {
+		return err
+	}
+
+	buildDir, err := filepath.Abs(flags.BuildDir)
+	if err != nil {
+		buildDir = flags.BuildDir
+	}
+	result := cmd.ModelImagePrepareResult{
+		BuildDir:   buildDir,
+		Dockerfile: filepath.Join(buildDir, modelImageDockerfileName),
+	}
+	if ctx.JSON {
+		ctx.OutputJSON(result)
+	} else {
+		ctx.Outputf("Wrote Docker build context to %s\n", result.BuildDir)
+	}
+	return nil
+}
+
+// modelImageRequireUV confirms the `uv` binary, required to run the truss CLI,
+// is on PATH.
+func modelImageRequireUV(ctx *CommandContext) error {
+	if _, err := ctx.Execer().LookPath("uv"); err != nil {
+		return cmd.NewErrUsagef("uv not found on PATH, required to run truss; install from https://docs.astral.sh/uv/")
+	}
+	return nil
+}
+
+// modelImageBuildContext runs `uv tool run truss@<version> image build_context`,
+// which generates the Docker build context for dir into buildDir. Its output is
+// routed to stderr so our stdout stays clean for the result.
+// TRUSS_NO_UPDATE_CHECK suppresses truss's update check and its associated
+// disk/network side effects.
+func modelImageBuildContext(ctx *CommandContext, trussVersion, buildDir, dir string) error {
+	c := exec.CommandContext(ctx, "uv",
+		"tool", "run", "truss@"+trussVersion,
+		"image", "build-context", buildDir, dir,
+	)
+	c.Stdin = ctx.Stdin
+	c.Stdout = ctx.Stderr
+	c.Stderr = ctx.Stderr
+	c.Env = append(os.Environ(), "TRUSS_NO_UPDATE_CHECK=1")
+	return modelImageExec(ctx, c)
+}
+
+// modelImageExec logs the command line to stderr and runs c via the context's
+// Execer, which propagates a non-zero exit as an ErrSubprocess.
+func modelImageExec(ctx *CommandContext, c *exec.Cmd) error {
+	ctx.Logf("+ %s\n", strings.Join(c.Args, " "))
+	return ctx.Execer().Exec(c)
+}
+
+// modelImageDockerPassthroughArgs returns the arguments after `--`, which are
+// forwarded to `docker build`. Any positional argument before `--` is a usage
+// error.
+func modelImageDockerPassthroughArgs(ctx *CommandContext) ([]string, error) {
+	dash := ctx.Command.ArgsLenAtDash()
+	if dash == -1 {
+		if len(ctx.Args) > 0 {
+			return nil, cmd.NewErrUsagef("unexpected arguments %v; pass extra docker build flags after '--'", ctx.Args)
+		}
+		return nil, nil
+	}
+	if dash > 0 {
+		return nil, cmd.NewErrUsagef("unexpected arguments %v; pass extra docker build flags after '--'", ctx.Args[:dash])
+	}
+	return ctx.Args[dash:], nil
+}
+
+// modelImageUserIIDFilePath returns the value of a user-supplied --iidfile in
+// args, or "" if none is present.
+func modelImageUserIIDFilePath(args []string) string {
+	for i, a := range args {
+		if a == "--iidfile" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if v, ok := strings.CutPrefix(a, "--iidfile="); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// modelImageDeriveDefaultTag builds a default image tag from the model_name in
+// the model directory's config.yaml, falling back to modelImageDefaultTag when
+// it is missing or unreadable.
+func modelImageDeriveDefaultTag(dir string) string {
+	raw, err := os.ReadFile(filepath.Join(dir, modelImageConfigFileName))
+	if err != nil {
+		return modelImageDefaultTag
+	}
+	var cfg struct {
+		ModelName string `yaml:"model_name"`
+	}
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return modelImageDefaultTag
+	}
+	if name := modelImageSanitizeDockerTag(cfg.ModelName); name != "" {
+		return name + ":latest"
+	}
+	return modelImageDefaultTag
+}
+
+// modelImageSanitizeDockerTag lowercases name and replaces runs of characters
+// that are invalid in a Docker image name with a single hyphen, trimming
+// leading and trailing separators. Returns "" if nothing usable remains.
+func modelImageSanitizeDockerTag(name string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range strings.ToLower(name) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.' || r == '_' {
+			b.WriteRune(r)
+			prevDash = false
+		} else if !prevDash {
+			b.WriteByte('-')
+			prevDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-._")
+}

--- a/internal/cmd/command.model_image.go
+++ b/internal/cmd/command.model_image.go
@@ -159,10 +159,11 @@ func modelImageBuildContext(ctx *CommandContext, trussVersion, buildDir, dir str
 	return modelImageExec(ctx, c)
 }
 
-// modelImageExec logs the command line to stderr and runs c via the context's
-// Execer, which propagates a non-zero exit as an ErrSubprocess.
+// modelImageExec runs c via the context's Execer, which propagates a non-zero
+// exit as an ErrSubprocess. The command line is logged only in verbose mode
+// since passthrough docker args can carry secrets (e.g. --build-arg, --secret).
 func modelImageExec(ctx *CommandContext, c *exec.Cmd) error {
-	ctx.Logf("+ %s\n", strings.Join(c.Args, " "))
+	ctx.VerboseLogf("+ %s\n", strings.Join(c.Args, " "))
 	return ctx.Execer().Exec(c)
 }
 

--- a/internal/cmd/command.model_image.go
+++ b/internal/cmd/command.model_image.go
@@ -51,7 +51,7 @@ func commandModelImageBuild(ctx *CommandContext, flags *cmd.ModelImageBuildFlags
 		return fmt.Errorf("create build dir: %w", err)
 	}
 
-	if err := modelImageBuildContext(ctx, flags.TrussVersion, buildDir, flags.Dir); err != nil {
+	if err := modelImageBuildContext(ctx, &flags.ModelImageCommonFlags, buildDir); err != nil {
 		return err
 	}
 
@@ -113,7 +113,7 @@ func commandModelImagePrepare(ctx *CommandContext, flags *cmd.ModelImagePrepareF
 	if err := os.MkdirAll(flags.BuildDir, 0o755); err != nil {
 		return fmt.Errorf("create build dir: %w", err)
 	}
-	if err := modelImageBuildContext(ctx, flags.TrussVersion, flags.BuildDir, flags.Dir); err != nil {
+	if err := modelImageBuildContext(ctx, &flags.ModelImageCommonFlags, flags.BuildDir); err != nil {
 		return err
 	}
 
@@ -142,20 +142,29 @@ func modelImageRequireUV(ctx *CommandContext) error {
 	return nil
 }
 
-// modelImageBuildContext runs `uv tool run truss@<version> image build_context`,
-// which generates the Docker build context for dir into buildDir. Its output is
-// routed to stderr so our stdout stays clean for the result.
+// modelImageBuildContext runs `uv tool run truss@<version> image build-context`,
+// which generates the Docker build context for the model dir into buildDir. Its
+// output is routed to stderr so our stdout stays clean for the result.
 // TRUSS_NO_UPDATE_CHECK suppresses truss's update check and its associated
-// disk/network side effects.
-func modelImageBuildContext(ctx *CommandContext, trussVersion, buildDir, dir string) error {
+// disk/network side effects. BT_USE_NON_ROOT_USER defaults the image to a
+// non-root user (matching the backend) and is omitted when --root-user is set.
+func modelImageBuildContext(ctx *CommandContext, flags *cmd.ModelImageCommonFlags, buildDir string) error {
+	env := []string{"TRUSS_NO_UPDATE_CHECK=1"}
+	if !flags.RootUser {
+		env = append(env, "BT_USE_NON_ROOT_USER=true")
+	}
+	if flags.CacheMountID != "" {
+		env = append(env, "TRUSS_CACHE_MOUNT_ID="+flags.CacheMountID)
+	}
+
 	c := exec.CommandContext(ctx, "uv",
-		"tool", "run", "truss@"+trussVersion,
-		"image", "build-context", buildDir, dir,
+		"tool", "run", "truss@"+flags.TrussVersion,
+		"image", "build-context", buildDir, flags.Dir,
 	)
 	c.Stdin = ctx.Stdin
 	c.Stdout = ctx.Stderr
 	c.Stderr = ctx.Stderr
-	c.Env = append(os.Environ(), "TRUSS_NO_UPDATE_CHECK=1")
+	c.Env = append(os.Environ(), env...)
 	return modelImageExec(ctx, c)
 }
 

--- a/internal/cmd/command.model_image_test.go
+++ b/internal/cmd/command.model_image_test.go
@@ -1,0 +1,269 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/basetenlabs/baseten-cli/internal/cmd"
+)
+
+// modelImageFakeExecer implements cmd.Execer for the model image command tests,
+// recording calls and simulating docker's --iidfile write so nothing spawns a
+// real process.
+type modelImageFakeExecer struct {
+	available map[string]bool
+	calls     []*exec.Cmd
+}
+
+func newModelImageFakeExecer(available ...string) *modelImageFakeExecer {
+	m := map[string]bool{}
+	for _, a := range available {
+		m[a] = true
+	}
+	return &modelImageFakeExecer{available: m}
+}
+
+func (f *modelImageFakeExecer) LookPath(name string) (string, error) {
+	if f.available[name] {
+		return "/fake/" + name, nil
+	}
+	return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
+}
+
+func (f *modelImageFakeExecer) Exec(c *exec.Cmd) error {
+	f.calls = append(f.calls, c)
+	if filepath.Base(c.Args[0]) == "docker" {
+		if p := modelImageArgValue(c.Args, "--iidfile"); p != "" {
+			_ = os.WriteFile(p, []byte("sha256:test\n"), 0o644)
+		}
+	}
+	return nil
+}
+
+// call returns the first recorded command whose program is name.
+func (f *modelImageFakeExecer) call(name string) *exec.Cmd {
+	for _, c := range f.calls {
+		if filepath.Base(c.Args[0]) == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// modelImageArgValue returns the value following flag (or the "flag=value" form).
+func modelImageArgValue(args []string, flag string) string {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+		if v, ok := strings.CutPrefix(a, flag+"="); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func modelImageArgCount(args []string, flag string) int {
+	n := 0
+	for _, a := range args {
+		if a == flag {
+			n++
+		}
+	}
+	return n
+}
+
+// modelImageWriteDir creates a temp model directory, optionally with a
+// config.yaml holding the given contents.
+func modelImageWriteDir(t *testing.T, configYAML string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if configYAML != "" {
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(configYAML), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func Test_Model_Image_Build_UVNotOnPath(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.Context = cmd.WithExecer(h.Context, newModelImageFakeExecer())
+	_ = h.Execute("model", "image", "build")
+	h.Require.True(h.Exited())
+	h.Require.Contains(h.Stderr.String(), "uv not found")
+}
+
+func Test_Model_Image_Build_DockerNotOnPath(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.Context = cmd.WithExecer(h.Context, newModelImageFakeExecer("uv"))
+	_ = h.Execute("model", "image", "build")
+	h.Require.True(h.Exited())
+	h.Require.Contains(h.Stderr.String(), "docker not found")
+}
+
+func Test_Model_Image_Build_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	fake := newModelImageFakeExecer("uv", "docker")
+	h.Context = cmd.WithExecer(h.Context, fake)
+	modelDir := modelImageWriteDir(t, "model_name: test-model\n")
+
+	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir, "--output", "json"))
+
+	var result map[string]any
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &result))
+	h.Require.Equal("sha256:test", result["image_id"])
+	h.Require.Equal("test-model:latest", result["tag"])
+
+	uv := fake.call("uv")
+	docker := fake.call("docker")
+	h.Require.NotNil(uv)
+	h.Require.NotNil(docker)
+	// truss writes the context into the same dir docker builds from.
+	buildDir := uv.Args[len(uv.Args)-2] // ...build-context <buildDir> <dir>
+	h.Require.Equal(modelDir, uv.Args[len(uv.Args)-1])
+	h.Require.Contains(uv.Env, "TRUSS_NO_UPDATE_CHECK=1")
+	h.Require.Equal("build", docker.Args[1])
+	h.Require.Equal("test-model:latest", modelImageArgValue(docker.Args, "-t"))
+	h.Require.NotEmpty(modelImageArgValue(docker.Args, "--iidfile"))
+	h.Require.Equal(buildDir, docker.Args[len(docker.Args)-1])
+}
+
+func Test_Model_Image_Build_DefaultTagFromConfig(t *testing.T) {
+	h := NewCommandHarness(t)
+	fake := newModelImageFakeExecer("uv", "docker")
+	h.Context = cmd.WithExecer(h.Context, fake)
+	modelDir := modelImageWriteDir(t, "model_name: My Model\n")
+
+	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir, "--output", "json"))
+
+	var result map[string]any
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &result))
+	h.Require.Equal("my-model:latest", result["tag"])
+}
+
+func Test_Model_Image_Build_DefaultTagFallback(t *testing.T) {
+	h := NewCommandHarness(t)
+	fake := newModelImageFakeExecer("uv", "docker")
+	h.Context = cmd.WithExecer(h.Context, fake)
+	modelDir := modelImageWriteDir(t, "") // no config.yaml
+
+	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir, "--output", "json"))
+
+	var result map[string]any
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &result))
+	h.Require.Equal("baseten-model:latest", result["tag"])
+}
+
+func Test_Model_Image_Build_TagOverride(t *testing.T) {
+	h := NewCommandHarness(t)
+	fake := newModelImageFakeExecer("uv", "docker")
+	h.Context = cmd.WithExecer(h.Context, fake)
+	modelDir := modelImageWriteDir(t, "model_name: test-model\n")
+
+	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir, "--tag", "custom:v1", "--output", "json"))
+
+	var result map[string]any
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &result))
+	h.Require.Equal("custom:v1", result["tag"])
+	h.Require.Equal("custom:v1", modelImageArgValue(fake.call("docker").Args, "-t"))
+}
+
+func Test_Model_Image_Build_TrussVersion(t *testing.T) {
+	h := NewCommandHarness(t)
+	fake := newModelImageFakeExecer("uv", "docker")
+	h.Context = cmd.WithExecer(h.Context, fake)
+	modelDir := modelImageWriteDir(t, "model_name: test-model\n")
+
+	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir, "--truss-version", "0.9.0"))
+
+	h.Require.Equal("truss@0.9.0", fake.call("uv").Args[3])
+}
+
+func Test_Model_Image_Build_Passthrough(t *testing.T) {
+	h := NewCommandHarness(t)
+	fake := newModelImageFakeExecer("uv", "docker")
+	h.Context = cmd.WithExecer(h.Context, fake)
+	modelDir := modelImageWriteDir(t, "model_name: test-model\n")
+
+	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir, "--", "--build-arg", "X=Y", "--no-cache"))
+
+	docker := fake.call("docker")
+	h.Require.Contains(strings.Join(docker.Args, " "), "--build-arg X=Y --no-cache")
+	// Passthrough sits before the build dir; our --iidfile is still injected once.
+	h.Require.Equal(1, modelImageArgCount(docker.Args, "--iidfile"))
+	h.Require.NotEmpty(modelImageArgValue(docker.Args, "--iidfile"))
+}
+
+func Test_Model_Image_Build_UserIIDFile(t *testing.T) {
+	h := NewCommandHarness(t)
+	fake := newModelImageFakeExecer("uv", "docker")
+	h.Context = cmd.WithExecer(h.Context, fake)
+	modelDir := modelImageWriteDir(t, "model_name: test-model\n")
+	userIID := filepath.Join(t.TempDir(), "iid.txt")
+
+	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir, "--output", "json", "--", "--iidfile", userIID))
+
+	docker := fake.call("docker")
+	// We defer to the user's --iidfile rather than injecting a second one.
+	h.Require.Equal(1, modelImageArgCount(docker.Args, "--iidfile"))
+	h.Require.Equal(userIID, modelImageArgValue(docker.Args, "--iidfile"))
+
+	var result map[string]any
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &result))
+	h.Require.Equal("sha256:test", result["image_id"])
+}
+
+func Test_Model_Image_Build_PositionalRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.Context = cmd.WithExecer(h.Context, newModelImageFakeExecer("uv", "docker"))
+	_ = h.Execute("model", "image", "build", "foo")
+	h.Require.True(h.Exited())
+	h.Require.Contains(h.Stderr.String(), "unexpected arguments")
+}
+
+func Test_Model_Image_Build_Text(t *testing.T) {
+	h := NewCommandHarness(t)
+	fake := newModelImageFakeExecer("uv", "docker")
+	h.Context = cmd.WithExecer(h.Context, fake)
+	modelDir := modelImageWriteDir(t, "model_name: test-model\n")
+
+	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir))
+
+	h.Require.Contains(h.Stdout.String(), "Built image test-model:latest (sha256:test)")
+	h.Require.Contains(h.Stderr.String(), "+ uv tool run truss@latest")
+	h.Require.Contains(h.Stderr.String(), "+ docker build")
+}
+
+func Test_Model_Image_Prepare_UVNotOnPath(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.Context = cmd.WithExecer(h.Context, newModelImageFakeExecer())
+	_ = h.Execute("model", "image", "prepare", "--build-dir", t.TempDir())
+	h.Require.True(h.Exited())
+	h.Require.Contains(h.Stderr.String(), "uv not found")
+}
+
+func Test_Model_Image_Prepare_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	fake := newModelImageFakeExecer("uv")
+	h.Context = cmd.WithExecer(h.Context, fake)
+	modelDir := modelImageWriteDir(t, "model_name: test-model\n")
+	buildDir := filepath.Join(t.TempDir(), "ctx")
+
+	h.Require.NoError(h.Execute("model", "image", "prepare", "--dir", modelDir, "--build-dir", buildDir, "--output", "json"))
+
+	var result map[string]any
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &result))
+	absBuild, _ := filepath.Abs(buildDir)
+	h.Require.Equal(absBuild, result["build_dir"])
+	h.Require.Equal(filepath.Join(absBuild, "Dockerfile"), result["dockerfile"])
+
+	uv := fake.call("uv")
+	h.Require.NotNil(uv)
+	h.Require.Equal([]string{"uv", "tool", "run", "truss@latest", "image", "build-context", buildDir, modelDir}, uv.Args)
+	h.Require.Contains(uv.Env, "TRUSS_NO_UPDATE_CHECK=1")
+}

--- a/internal/cmd/command.model_image_test.go
+++ b/internal/cmd/command.model_image_test.go
@@ -184,6 +184,39 @@ func Test_Model_Image_Build_TrussVersion(t *testing.T) {
 	h.Require.Equal("truss@0.9.0", fake.call("uv").Args[3])
 }
 
+func Test_Model_Image_Build_NonRootByDefault(t *testing.T) {
+	h := NewCommandHarness(t)
+	fake := newModelImageFakeExecer("uv", "docker")
+	h.Context = cmd.WithExecer(h.Context, fake)
+	modelDir := modelImageWriteDir(t, "model_name: test-model\n")
+
+	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir))
+
+	h.Require.Contains(fake.call("uv").Env, "BT_USE_NON_ROOT_USER=true")
+}
+
+func Test_Model_Image_Build_RootUser(t *testing.T) {
+	h := NewCommandHarness(t)
+	fake := newModelImageFakeExecer("uv", "docker")
+	h.Context = cmd.WithExecer(h.Context, fake)
+	modelDir := modelImageWriteDir(t, "model_name: test-model\n")
+
+	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir, "--root-user"))
+
+	h.Require.NotContains(fake.call("uv").Env, "BT_USE_NON_ROOT_USER=true")
+}
+
+func Test_Model_Image_Build_CacheMountID(t *testing.T) {
+	h := NewCommandHarness(t)
+	fake := newModelImageFakeExecer("uv", "docker")
+	h.Context = cmd.WithExecer(h.Context, fake)
+	modelDir := modelImageWriteDir(t, "model_name: test-model\n")
+
+	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir, "--cache-mount-id", "myorg"))
+
+	h.Require.Contains(fake.call("uv").Env, "TRUSS_CACHE_MOUNT_ID=myorg")
+}
+
 func Test_Model_Image_Build_Passthrough(t *testing.T) {
 	h := NewCommandHarness(t)
 	fake := newModelImageFakeExecer("uv", "docker")

--- a/internal/cmd/command.model_image_test.go
+++ b/internal/cmd/command.model_image_test.go
@@ -232,9 +232,10 @@ func Test_Model_Image_Build_Text(t *testing.T) {
 	h.Context = cmd.WithExecer(h.Context, fake)
 	modelDir := modelImageWriteDir(t, "model_name: test-model\n")
 
-	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir))
+	h.Require.NoError(h.Execute("model", "image", "build", "--dir", modelDir, "--verbose"))
 
 	h.Require.Contains(h.Stdout.String(), "Built image test-model:latest (sha256:test)")
+	// The command trace is gated behind --verbose.
 	h.Require.Contains(h.Stderr.String(), "+ uv tool run truss@latest")
 	h.Require.Contains(h.Stderr.String(), "+ docker build")
 }

--- a/internal/cmd/command.ssh.go
+++ b/internal/cmd/command.ssh.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"os/exec"
-
 	"github.com/basetenlabs/baseten-cli/cmd"
 	"github.com/basetenlabs/baseten-cli/internal/ssh"
 )
@@ -38,7 +36,7 @@ func commandSSHSetup(ctx *CommandContext, flags *cmd.SSHSetupFlags) error {
 
 	// The generated config invokes `baseten`; warn if it is not on the PATH,
 	// since the SSH connection will run it at connect time.
-	if _, err := exec.LookPath("baseten"); err != nil {
+	if _, err := ctx.Execer().LookPath("baseten"); err != nil {
 		ctx.LogLine("warning: `baseten` was not found on your PATH; SSH connections will fail until it is.")
 	}
 

--- a/internal/cmd/command.truss.go
+++ b/internal/cmd/command.truss.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 
 	"github.com/basetenlabs/baseten-cli/cmd"
@@ -14,21 +12,13 @@ func init() {
 }
 
 func commandTruss(ctx *CommandContext, flags *cmd.TrussFlags) error {
-	trussPath, err := exec.LookPath("truss")
-	if err != nil {
+	if _, err := ctx.Execer().LookPath("truss"); err != nil {
 		return fmt.Errorf("truss not found on PATH, install with: uv tool install truss")
 	}
 
-	trussCmd := exec.CommandContext(ctx, trussPath, ctx.Args...)
-	trussCmd.Stdin = os.Stdin
-	trussCmd.Stdout = os.Stdout
-	trussCmd.Stderr = os.Stderr
-	if err := trussCmd.Run(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return &ErrSubprocess{Err: err, Code: exitErr.ExitCode()}
-		}
-		return err
-	}
-	return nil
+	trussCmd := exec.CommandContext(ctx, "truss", ctx.Args...)
+	trussCmd.Stdin = ctx.Stdin
+	trussCmd.Stdout = ctx.Stdout
+	trussCmd.Stderr = ctx.Stderr
+	return ctx.Execer().Exec(trussCmd)
 }

--- a/internal/cmd/command_context.go
+++ b/internal/cmd/command_context.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"sync"
 	"time"
 
@@ -504,6 +506,50 @@ func (c *CommandContext) newS3APIClient(cfg aws.Config) transfermanager.S3APICli
 		return f(cfg)
 	}
 	return s3.NewFromConfig(cfg)
+}
+
+// Execer looks up and runs external commands. The default uses os/exec; tests
+// inject a fake via WithExecer to avoid spawning real processes.
+type Execer interface {
+	// LookPath reports whether name is an executable on PATH, like exec.LookPath.
+	LookPath(name string) (string, error)
+	// Exec runs cmd (already built via exec.CommandContext, so it carries the
+	// command context and wired stdio/env) and returns an [ErrSubprocess] on a
+	// non-zero exit so the inner exit code propagates.
+	Exec(cmd *exec.Cmd) error
+}
+
+// defaultExecer is the production [Execer] backed by os/exec.
+type defaultExecer struct{}
+
+func (defaultExecer) LookPath(name string) (string, error) { return exec.LookPath(name) }
+
+func (defaultExecer) Exec(cmd *exec.Cmd) error {
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return &ErrSubprocess{Err: err, Code: exitErr.ExitCode()}
+		}
+		return err
+	}
+	return nil
+}
+
+type execerKey struct{}
+
+// WithExecer returns a context that overrides the [Execer] used by
+// CommandContext to look up and run external commands. Intended for tests.
+func WithExecer(ctx context.Context, e Execer) context.Context {
+	return context.WithValue(ctx, execerKey{}, e)
+}
+
+// Execer returns the [Execer] used to run external commands, honoring any
+// override installed via [WithExecer].
+func (c *CommandContext) Execer() Execer {
+	if e, ok := c.Value(execerKey{}).(Execer); ok {
+		return e
+	}
+	return defaultExecer{}
 }
 
 // staticAuthClient is an HTTP client that sets a fixed Authorization header.


### PR DESCRIPTION
## :rocket: What
- Adds `baseten model image prepare`: writes just the Docker build context (Dockerfile + supporting files) for a model dir, by shelling out to truss's `image build-context`.
- Adds `baseten model image build`: produces a local Docker image. It runs `prepare` to generate the context, then invokes `docker build` directly rather than truss's `image build`.
  - Why direct `docker build`: it sidesteps truss's build-side behavior (a label cache keyed on a content hash that can serve a stale image, and a `~/.truss` signature write) and gives full, transparent control over the build (any `docker build` flags via `--` passthrough, an explicit `--tag`). Both commands are local-only: no auth, no Baseten API calls.

## :computer: How
- Shell out to `uv tool run truss@<version> image build-context` to generate the context, then `docker build` for `build`. Flags: `--dir`, `--build-dir`, `--truss-version`, plus `--tag` (defaults to `<model_name>:latest`); everything after `--` is forwarded to `docker build`.
- Set `TRUSS_NO_UPDATE_CHECK=1` on the truss subprocess; capture the image ID via `--iidfile` (deferring to a user-supplied one). See https://github.com/basetenlabs/truss/pull/2561
- Add a mockable `Execer` (`LookPath`/`Exec`) to the command context and route the existing `truss`/`ssh` lookups through it.

## :microscope: Testing
- Unit tests via a fake `Execer`: uv/docker-not-found, JSON and text output, default/override/fallback tags, truss-version, `--` passthrough, user `--iidfile` reuse, positional rejection.
- Manually confirmed a real `build`.