### PR TITLE
Add Nix flake for installing the CLI on macOS and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,35 @@ brew update
 brew upgrade baseten
 ```
 
+### Nix (macOS and Linux)
+
+This repository is a Nix flake. Run the CLI without installing anything:
+
+```bash
+nix run github:basetenlabs/baseten-cli -- --help
+```
+
+or install it into your profile:
+
+```bash
+nix profile install github:basetenlabs/baseten-cli
+```
+
+To install with [Home Manager](https://github.com/nix-community/home-manager),
+add the flake as an input and put the package in `home.packages`:
+
+```nix
+{
+  inputs.baseten-cli.url = "github:basetenlabs/baseten-cli";
+
+  # In your home-manager configuration (with `inputs` passed through):
+  # home.packages = [ inputs.baseten-cli.packages.${pkgs.system}.default ];
+}
+```
+
+The flake also exposes `overlays.default`, which adds the package as
+`pkgs.baseten`.
+
 ### Prebuilt binaries
 
 Download the [latest release](https://github.com/basetenlabs/baseten-cli/releases/latest) for Windows, macOS, or Linux, extract the archive, and place the `baseten` executable on your `PATH`.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785386831,
+        "narHash": "sha256-sPS3CaXH8RAT3FZRuy4VcV47iuYIWMMfa0GbyJKC3o4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "21ea275a7c46aef9d4d6ddc962e6d562e9d94183",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  description = "CLI for Baseten";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        baseten = pkgs.callPackage ./nix/package.nix {
+          version = if self ? shortRev then "unstable-${self.shortRev}" else "dev";
+        };
+      in
+      {
+        packages = {
+          default = baseten;
+          inherit baseten;
+        };
+
+        checks = {
+          build = baseten;
+          # Smoke test: the built binary runs and reports the expected version.
+          version = pkgs.runCommand "baseten-version-check" { } ''
+            got="$(${pkgs.lib.getExe baseten} version)"
+            want=${pkgs.lib.escapeShellArg baseten.version}
+            if [ "$got" != "$want" ]; then
+              echo "baseten version reported '$got', expected '$want'" >&2
+              exit 1
+            fi
+            ${pkgs.lib.getExe baseten} --help > /dev/null
+            touch $out
+          '';
+        };
+      }
+    )
+    // {
+      overlays.default = final: prev: {
+        baseten = final.callPackage ./nix/package.nix { };
+      };
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildGoModule,
+  version ? "dev",
+}:
+buildGoModule {
+  pname = "baseten";
+  inherit version;
+
+  src = lib.cleanSource ../.;
+
+  # Update by setting to lib.fakeHash and copying the hash from the build error.
+  vendorHash = "sha256-ghtyvdt80fy6JCw0J20a70fai9fUQyJW5vS8gQibZWE=";
+
+  subPackages = [ "cmd/baseten" ];
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/basetenlabs/baseten-cli/internal/cmd.Version=${version}"
+  ];
+
+  meta = {
+    description = "CLI for Baseten";
+    homepage = "https://github.com/basetenlabs/baseten-cli";
+    license = lib.licenses.mit;
+    mainProgram = "baseten";
+  };
+}


### PR DESCRIPTION
Adds a Nix flake so the CLI can be installed on macOS and Linux (x86_64 and aarch64) via `nix profile install github:basetenlabs/baseten-cli`, run ad hoc with `nix run`, or pulled into a Home Manager / NixOS configuration.

- `nix/package.nix`: callPackage-able `buildGoModule` derivation (CGO disabled, version injected via the same ldflag goreleaser uses, `mainProgram = "baseten"`).
- `flake.nix`: pinned to nixpkgs 26.05 (Go 1.26.5; unstable has dropped x86_64-darwin support, which 26.05 retains). Outputs `packages.{default,baseten}`, `overlays.default` (adds `pkgs.baseten`), and `checks` with a smoke test asserting `baseten version` reports the build version.
- README: new "Nix (macOS and Linux)" installation section covering `nix run`, `nix profile install`, Home Manager usage, and the overlay.

Tested with `nix build` + `nix flake check` on aarch64-darwin (build and version smoke test pass) and evaluation of the package for all four Linux/macOS systems. When `go.mod`/`go.sum` change, `vendorHash` in `nix/package.nix` needs updating (set to `lib.fakeHash`, rebuild, copy the hash from the error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)