### PR TITLE
Scope ssh jwt cache by credential

### DIFF
--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"os"
@@ -92,6 +94,23 @@ func (s *Session) ProfileName() string { return s.profileName }
 // IsEphemeral reports whether the session uses credentials from BASETEN_API_KEY
 // rather than a stored profile.
 func (s *Session) IsEphemeral() bool { return s.ephemeralAPIKey != "" }
+
+// CacheIdentity returns a stable, filesystem-safe token for the resolved
+// credential, scoping on-disk caches so an entry written under one credential is
+// never read under another. Hashed to keep the profile name (an email by default)
+// and the API key out of file paths.
+func (s *Session) CacheIdentity() string {
+	switch {
+	case s.ephemeralAPIKey != "":
+		sum := sha256.Sum256([]byte(s.ephemeralAPIKey))
+		return "key-" + hex.EncodeToString(sum[:8])
+	case s.profileName != "":
+		sum := sha256.Sum256([]byte(s.profileName))
+		return "profile-" + hex.EncodeToString(sum[:8])
+	default:
+		return "anonymous"
+	}
+}
 
 // OAuthContext returns a context that carries an oauth2 HTTP client which
 // stamps the Baseten User-Agent on every request, layered over base.

--- a/internal/auth/transport_test.go
+++ b/internal/auth/transport_test.go
@@ -190,6 +190,42 @@ func TestTransport_CustomBaseUsed(t *testing.T) {
 	require.True(t, called, "custom Base RoundTripper must be used")
 }
 
+func TestSession_CacheIdentity(t *testing.T) {
+	s := storeWithConfigDir(t)
+	require.NoError(t, s.SetAPIKeyProfile(profileA, remoteURL, apiKeyA, true, nil))
+	require.NoError(t, s.SetAPIKeyProfile(profileB, remoteURL, "api-key-bob", false, nil))
+
+	alice := mustResolve(t, profileA).CacheIdentity()
+	bob := mustResolve(t, profileB).CacheIdentity()
+
+	// Distinct credentials never share an identity, and the raw profile name (an
+	// email) does not appear in it, since it is used as a path segment.
+	require.NotEqual(t, alice, bob)
+	require.NotContains(t, alice, profileA)
+	require.Regexp(t, `^profile-[0-9a-f]{16}$`, alice)
+
+	// Stable across resolutions, so sign and proxy agree.
+	require.Equal(t, alice, mustResolve(t, profileA).CacheIdentity())
+}
+
+func TestSession_CacheIdentityEphemeralKey(t *testing.T) {
+	storeWithConfigDir(t)
+	t.Setenv("BASETEN_API_KEY", "env-key")
+	first := mustResolve(t, "").CacheIdentity()
+	require.Regexp(t, `^key-[0-9a-f]{16}$`, first)
+	require.NotContains(t, first, "env-key")
+
+	// A different key is a different identity: ephemeral sessions carry no
+	// profile name to distinguish them.
+	t.Setenv("BASETEN_API_KEY", "other-key")
+	require.NotEqual(t, first, mustResolve(t, "").CacheIdentity())
+}
+
+func TestSession_CacheIdentityUnauthenticated(t *testing.T) {
+	storeWithConfigDir(t)
+	require.Equal(t, "anonymous", mustResolve(t, "").CacheIdentity())
+}
+
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/internal/cmd/command.ssh.go
+++ b/internal/cmd/command.ssh.go
@@ -66,9 +66,13 @@ func commandSSHSign(ctx *CommandContext, flags *cmd.SSHSignFlags) error {
 	if err != nil {
 		return err
 	}
+	cacheIdentity, err := ctx.sshCacheIdentity()
+	if err != nil {
+		return err
+	}
 	// The signed cert and proxy authorization are written to disk by Sign; we
 	// deliberately do not surface them on stdout.
-	if _, err := ssh.Sign(ctx, cl, ctx.Args[0]); err != nil {
+	if _, err := ssh.Sign(ctx, cl, cacheIdentity, ctx.Args[0]); err != nil {
 		return err
 	}
 	if ctx.JSON {
@@ -79,5 +83,21 @@ func commandSSHSign(ctx *CommandContext, flags *cmd.SSHSignFlags) error {
 
 func commandSSHProxy(ctx *CommandContext, flags *cmd.SSHProxyFlags) error {
 	ctx.SetDefaultProfile(flags.DefaultProfile)
-	return ssh.Proxy(ctx, ctx.Args[0], ctx.Stdin, ctx.Stdout)
+	cacheIdentity, err := ctx.sshCacheIdentity()
+	if err != nil {
+		return err
+	}
+	return ssh.Proxy(ctx, cacheIdentity, ctx.Args[0], ctx.Stdin, ctx.Stdout)
+}
+
+// sshCacheIdentity scopes the JWT cache to the credential this invocation
+// resolves to. sign and proxy run as separate processes under one ssh connection,
+// inheriting the same flags and environment, so both arrive at the same value.
+// Must be called after SetDefaultProfile, which the session resolution reads.
+func (c *CommandContext) sshCacheIdentity() (string, error) {
+	session, err := c.authInfo.Session()
+	if err != nil {
+		return "", err
+	}
+	return session.CacheIdentity(), nil
 }

--- a/internal/cmd/command.ssh_test.go
+++ b/internal/cmd/command.ssh_test.go
@@ -196,6 +196,25 @@ func Test_SSH_Proxy_NoCachedCredential(t *testing.T) {
 	h.Require.ErrorContains(err, "no cached SSH credential")
 }
 
+func Test_SSH_Proxy_IgnoresCacheFromOtherCredential(t *testing.T) {
+	h := NewCommandHarness(t)
+	sshEnv(t)
+	_, _, err := ssh.EnsureKeypair()
+	h.Require.NoError(err)
+
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", "/v1/models/m1/deployments/d1/ssh/sign", 200,
+		signResponse("tok", "127.0.0.1:9"))
+	h.Require.NoError(h.Execute("ssh", "sign", "model-m1-d1.ssh.baseten.co"))
+
+	// Workload ids repeat across workspaces and remotes, so the same hostname
+	// under a different credential must not pick up the token and proxy address
+	// cached for the first one.
+	t.Setenv("BASETEN_API_KEY", "other-key")
+	err = h.Execute("ssh", "proxy", "model-m1-d1.ssh.baseten.co")
+	h.Require.ErrorContains(err, "no cached SSH credential")
+}
+
 func Test_SSH_Proxy_RelaysUsingCachedCredential(t *testing.T) {
 	h := NewCommandHarness(t)
 	sshEnv(t)

--- a/internal/ssh/connect.go
+++ b/internal/ssh/connect.go
@@ -16,8 +16,13 @@ import (
 
 // Sign signs an SSH certificate for the workload named by hostname, writes the
 // cert next to the private key, and caches the JWT and proxy address for the
-// subsequent Proxy call.
-func Sign(ctx context.Context, mgmt *client.ManagementClient, hostname string) (*managementapi.SignSSHCertificateResponse, error) {
+// subsequent Proxy call. cacheIdentity scopes that cache entry to the credential
+// the JWT was issued under; Proxy must be passed the same value.
+func Sign(
+	ctx context.Context,
+	mgmt *client.ManagementClient,
+	cacheIdentity, hostname string,
+) (*managementapi.SignSSHCertificateResponse, error) {
 	h, err := parseHostname(hostname)
 	if err != nil {
 		return nil, err
@@ -74,7 +79,7 @@ func Sign(ctx context.Context, mgmt *client.ManagementClient, hostname string) (
 	if err := os.WriteFile(keyPath+"-cert.pub", []byte(resp.SshCertificate), 0o644); err != nil {
 		return nil, fmt.Errorf("writing ssh certificate: %w", err)
 	}
-	if err := saveJWT(d, h, resp.Jwt, resp.ProxyAddress); err != nil {
+	if err := saveJWT(d, cacheIdentity, h, resp.Jwt, resp.ProxyAddress); err != nil {
 		return nil, err
 	}
 	return resp, nil
@@ -106,8 +111,14 @@ func resolveTrainingProject(ctx context.Context, mgmt *client.ManagementClient, 
 }
 
 // Proxy connects to the SSH proxy for the workload named by hostname using the
-// JWT cached by Sign, then relays between in and out until either side closes.
-func Proxy(ctx context.Context, hostname string, in io.Reader, out io.Writer) error {
+// JWT cached by Sign under cacheIdentity, then relays between in and out until
+// either side closes.
+func Proxy(
+	ctx context.Context,
+	cacheIdentity, hostname string,
+	in io.Reader,
+	out io.Writer,
+) error {
 	h, err := parseHostname(hostname)
 	if err != nil {
 		return err
@@ -116,7 +127,7 @@ func Proxy(ctx context.Context, hostname string, in io.Reader, out io.Writer) er
 	if err != nil {
 		return err
 	}
-	cache, ok := loadJWT(d, h)
+	cache, ok := loadJWT(d, cacheIdentity, h)
 	if !ok {
 		return fmt.Errorf("no cached SSH credential for %s; the signing step did not run", hostname)
 	}

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -107,7 +107,12 @@ type jwtCache struct {
 	ProxyAddress string `json:"proxy_address"`
 }
 
-func jwtCachePath(d string, h hostname) string {
+// jwtCachePath locates the cache entry for a workload under one credential.
+// Workload ids repeat across remotes and workspaces, so an unscoped key let a
+// sign under one credential overwrite the token and proxy address another
+// connection was about to read. cacheIdentity comes from
+// auth.Session.CacheIdentity and is already safe to use as a path segment.
+func jwtCachePath(d, cacheIdentity string, h hostname) string {
 	parts := []string{"model", h.id}
 	if h.kind == workloadTraining {
 		parts[0] = "training"
@@ -124,25 +129,25 @@ func jwtCachePath(d string, h hostname) string {
 	if h.replica != "" {
 		parts = append(parts, h.replica)
 	}
-	return filepath.Join(d, ".jwt-cache", strings.Join(parts, "-")+".json")
+	return filepath.Join(d, ".jwt-cache", cacheIdentity, strings.Join(parts, "-")+".json")
 }
 
-func saveJWT(d string, h hostname, jwt, proxyAddr string) error {
-	if err := os.MkdirAll(filepath.Join(d, ".jwt-cache"), 0o700); err != nil {
+func saveJWT(d, cacheIdentity string, h hostname, jwt, proxyAddr string) error {
+	if err := os.MkdirAll(filepath.Join(d, ".jwt-cache", cacheIdentity), 0o700); err != nil {
 		return fmt.Errorf("creating jwt cache directory: %w", err)
 	}
 	b, err := json.Marshal(jwtCache{JWT: jwt, ProxyAddress: proxyAddr})
 	if err != nil {
 		return fmt.Errorf("encoding jwt cache: %w", err)
 	}
-	if err := os.WriteFile(jwtCachePath(d, h), b, 0o600); err != nil {
+	if err := os.WriteFile(jwtCachePath(d, cacheIdentity, h), b, 0o600); err != nil {
 		return fmt.Errorf("writing jwt cache: %w", err)
 	}
 	return nil
 }
 
-func loadJWT(d string, h hostname) (jwtCache, bool) {
-	b, err := os.ReadFile(jwtCachePath(d, h))
+func loadJWT(d, cacheIdentity string, h hostname) (jwtCache, bool) {
+	b, err := os.ReadFile(jwtCachePath(d, cacheIdentity, h))
 	if err != nil {
 		return jwtCache{}, false
 	}

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -64,10 +64,11 @@ func TestJWTCacheRoundTrip(t *testing.T) {
 	d := t.TempDir()
 	h := hostname{kind: workloadModel, id: "abc", deploymentID: "def", replica: "7"}
 
-	require.NoError(t, saveJWT(d, h, "jwt-value", "proxy:443"))
-	requirePerm(t, jwtCachePath(d, h), 0o600)
+	require.NoError(t, saveJWT(d, "profile-abc123", h, "jwt-value", "proxy:443"))
+	requirePerm(t, jwtCachePath(d, "profile-abc123", h), 0o600)
+	requirePerm(t, filepath.Join(d, ".jwt-cache", "profile-abc123"), 0o700)
 
-	c, ok := loadJWT(d, h)
+	c, ok := loadJWT(d, "profile-abc123", h)
 	require.True(t, ok)
 	require.Equal(t, "jwt-value", c.JWT)
 	require.Equal(t, "proxy:443", c.ProxyAddress)
@@ -80,14 +81,46 @@ func TestJWTCachePath_EnvFormDistinctFromDeployment(t *testing.T) {
 
 	// The env tag keeps an environment named like a deployment id from
 	// colliding with the deployment cache entry.
-	require.Contains(t, jwtCachePath(d, env), "model-abc-env-staging")
-	require.NotEqual(t, jwtCachePath(d, dep), jwtCachePath(d, env))
+	require.Contains(t, jwtCachePath(d, "profile-abc123", env), "model-abc-env-staging")
+	require.NotEqual(t,
+		jwtCachePath(d, "profile-abc123", dep),
+		jwtCachePath(d, "profile-abc123", env))
+}
+
+func TestJWTCache_ScopedByCacheIdentity(t *testing.T) {
+	d := t.TempDir()
+	// Same workload id under two credentials: ids repeat across workspaces and
+	// remotes, so each credential must get its own entry rather than overwriting
+	// the token and proxy address cached for the other.
+	h := hostname{kind: workloadModel, id: "abc", deploymentID: "def"}
+
+	require.NoError(t, saveJWT(d, "profile-one", h, "one-jwt", "one-proxy:443"))
+	require.NoError(t, saveJWT(d, "key-two", h, "two-jwt", "two-proxy:443"))
+
+	one, ok := loadJWT(d, "profile-one", h)
+	require.True(t, ok)
+	require.Equal(t, "one-jwt", one.JWT)
+	require.Equal(t, "one-proxy:443", one.ProxyAddress)
+
+	two, ok := loadJWT(d, "key-two", h)
+	require.True(t, ok)
+	require.Equal(t, "two-jwt", two.JWT)
+	require.Equal(t, "two-proxy:443", two.ProxyAddress)
 }
 
 func TestLoadJWT_MissingReturnsFalse(t *testing.T) {
 	d := t.TempDir()
 	h := hostname{kind: workloadModel, id: "abc", deploymentID: "def"}
-	_, ok := loadJWT(d, h)
+	_, ok := loadJWT(d, "profile-abc123", h)
+	require.False(t, ok)
+}
+
+func TestLoadJWT_OtherCacheIdentityNotRead(t *testing.T) {
+	d := t.TempDir()
+	h := hostname{kind: workloadModel, id: "abc", deploymentID: "def"}
+	require.NoError(t, saveJWT(d, "profile-one", h, "one-jwt", "one-proxy:443"))
+
+	_, ok := loadJWT(d, "profile-two", h)
 	require.False(t, ok)
 }
 


### PR DESCRIPTION
## :rocket: What

- Scope the SSH JWT cache by resolved credential, so a `sign` under one credential can't overwrite the token and proxy address another connection is about to read.
- Ports basetenlabs/truss#2587, which scopes by remote; the CLI has no remote label in the SSH hostname, so it keys on the credential instead.

## :computer: How

- Add `auth.Session.CacheIdentity()`: `profile-<hash>`, `key-<hash>`, or `anonymous`. Hashed to keep the profile name (an email by default) and the API key out of file paths.
- `sign`/`proxy` pass it through, nesting entries under `.jwt-cache/<identity>/`.
- Existing unscoped entries are never read again; `sign` runs before every connection, so nothing breaks.

## :microscope: Testing

- Cache entries don't collide across identities, `proxy` rejects an entry written under a different credential, and `CacheIdentity` is stable and leaks neither name nor key.
- `go test ./internal/ssh/... ./internal/auth/... ./internal/cmd/...`