### PR TITLE
Add loops commands

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -33,6 +33,7 @@ var Root = Command{
 	Children: []Command{
 		commandAPI,
 		commandAuth,
+		commandLoops,
 		commandModel,
 		commandModelAPI,
 		commandOrg,

--- a/cmd/command.loops.go
+++ b/cmd/command.loops.go
@@ -1,0 +1,376 @@
+package cmd
+
+import (
+	"time"
+
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+)
+
+// commandLoops groups the `baseten loops` subcommands.
+var commandLoops = Command{
+	Name:    "loops",
+	Summary: "Manage Loops runs and checkpoints",
+	Children: []Command{
+		commandLoopsCheckpoint,
+		commandLoopsRun,
+		{
+			Name:    "usage",
+			Summary: "Report Loops GPU capacity",
+			Description: "Report Loops GPU capacity, one row per trainer deployment plus a row " +
+				"for each standalone sampler.\n\n" +
+				"A summary above the table totals the GPUs in use and scaled to zero. Rows " +
+				"holding no live GPUs (scaled to zero, or in a terminal state) are counted in " +
+				"the summary but hidden unless you pass --all.",
+			Flags: LoopsUsageFlags{},
+			Output: &CommandOutput[LoopsUsageResult]{
+				TextDescription: "A summary line of trainer and sampler GPU totals, then a table with " +
+					"columns: RUN, OWNER (with --org), BASE MODEL, TRAINER GPU, TRAINER STATUS, " +
+					"SAMPLER GPU, SAMPLER STATUS, CREATED.",
+				JSONDescription: "An object with the GPU summary and one entry per row, each carrying the " +
+					"trainer and sampler allocation and status.",
+				Examples: []CommandExample{
+					{
+						Description: "Report your own Loops GPU usage.",
+						Command:     "baseten loops usage",
+					},
+					{
+						Description: "Report GPU usage across the organization, including idle allocations.",
+						Command:     "baseten loops usage --org --all",
+					},
+					{
+						Description: "Report GPU usage for one owner.",
+						Command:     "baseten loops usage --org --user someone@example.com",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the total trainer GPUs in use.",
+					Command:     "baseten loops usage --jq '.summary.trainer_in_use'",
+				},
+			},
+		},
+	},
+}
+
+// commandLoopsRun groups the `baseten loops run` subcommands.
+var commandLoopsRun = Command{
+	Name:    "run",
+	Summary: "Manage Loops runs",
+	Children: []Command{
+		{
+			Name:    "create",
+			Summary: "Create a Loops run and its paired sampler",
+			Description: "Create a Loops session, a run for the given base model, and the run's " +
+				"paired sampler.\n\n" +
+				"Returns as soon as the resources are provisioned. Both halves finish coming up " +
+				"in the background; poll with 'baseten loops run describe' or watch " +
+				"'baseten loops run logs'.",
+			Flags: LoopsRunCreateFlags{},
+			Output: &CommandOutput[managementapi.LoopsRun]{
+				TextDescription: "On success, prints the new run's ID and base model to stderr; no stdout output.",
+				JSONDescription: "The created run, including its paired sampler.",
+				Examples: []CommandExample{
+					{
+						Description: "Create a run for a base model.",
+						Command:     "baseten loops run create --base-model Qwen/Qwen3-8B",
+					},
+					{
+						Description: "Create a named run with four data-parallel trainer replicas.",
+						Command:     "baseten loops run create --base-model Qwen/Qwen3-8B --name experiment-1 --replicas 4",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print just the new run's ID.",
+					Command:     "baseten loops run create --base-model Qwen/Qwen3-8B --jq '.id'",
+				},
+			},
+		},
+		{
+			Name:    "list",
+			Summary: "List Loops runs",
+			Description: "List Loops runs, newest first.\n\n" +
+				"Lists your own runs; pass --org to list every run in the organization, which " +
+				"adds an Owner column. Inactive runs are hidden unless you pass --all.",
+			Flags: LoopsRunListFlags{},
+			Output: &CommandOutput[managementapi.ListLoopsRunsResponse]{
+				TextDescription: "Table with columns: ID, OWNER (with --org), BASE MODEL, STATUS, CREATED. " +
+					"When no runs match, prints \"No Loops runs found.\" to stderr.",
+				Examples: []CommandExample{
+					{
+						Description: "List your active runs.",
+						Command:     "baseten loops run list",
+					},
+					{
+						Description: "List every run in the organization, including inactive ones.",
+						Command:     "baseten loops run list --org --all",
+					},
+					{
+						Description: "List runs for one base model, oldest first.",
+						Command:     "baseten loops run list --base-model Qwen/Qwen3-8B --direction asc",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print just the run IDs.",
+					Command:     "baseten loops run list --jq '.runs[].id'",
+				},
+			},
+		},
+		{
+			Name:        "describe",
+			Summary:     "Describe a Loops run",
+			Description: "Describe a Loops run by ID, including its paired sampler.",
+			Flags:       LoopsRunDescribeFlags{},
+			Output: &CommandOutput[managementapi.LoopsRun]{
+				TextDescription: "Field-per-line summary of the run, followed by its sampler when one exists.",
+				Examples: []CommandExample{
+					{
+						Description: "Describe a run by ID.",
+						Command:     "baseten loops run describe --run-id <run-id>",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the run's sampler base URL.",
+					Command:     "baseten loops run describe --run-id <run-id> --jq '.sampler.base_url'",
+				},
+			},
+		},
+		{
+			Name:    "deactivate",
+			Summary: "Deactivate a Loops run",
+			Description: "Deactivate a Loops run, tearing down both the run and its paired " +
+				"sampler. Saved checkpoints remain accessible.\n\n" +
+				"Prompts for yes/no confirmation. Pass --yes to skip the prompt. When " +
+				"stdin is not a terminal, --yes is required.",
+			Flags: LoopsRunDeactivateFlags{},
+			Output: &CommandOutput[managementapi.DeactivateLoopsRunResponse]{
+				TextDescription: "On success, prints \"Deactivated Loops run <id>\" to stderr; no stdout output.",
+				Examples: []CommandExample{
+					{
+						Description: "Deactivate a run without the confirmation prompt.",
+						Command:     "baseten loops run deactivate --run-id <run-id> --yes",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the deactivated run's base model.",
+					Command:     "baseten loops run deactivate --run-id <run-id> --yes --jq '.base_model'",
+				},
+			},
+		},
+		{
+			Name:    "logs",
+			Summary: "Stream or tail logs for a Loops run",
+			Description: "Fetch logs for a Loops run.\n\n" +
+				"By default returns the run's trainer logs; pass --sampler for the paired " +
+				"sampler's logs instead, which are a separate stream.\n\n" +
+				"By default returns up to --limit lines from the last 30 minutes, newest first. " +
+				"Use --start/--end or --since to scope the window (max 7 days). Use --tail to " +
+				"stream live logs until the run stops producing them or you interrupt with Ctrl-C.\n\n" +
+				"For machine-readable streaming, prefer --output jsonl over --output json.",
+			Flags: LoopsRunLogsFlags{},
+			Output: &CommandOutput[managementapi.Log]{
+				JSONArrayStreamed: true,
+				TextDescription:   "One line per log record: \"[YYYY-MM-DD HH:MM:SS]: (replica) message\".",
+				Examples: []CommandExample{
+					{
+						Description: "Print a run's trainer logs over the last hour.",
+						Command:     "baseten loops run logs --run-id <run-id> --since 1h",
+					},
+					{
+						Description: "Tail the paired sampler's logs.",
+						Command:     "baseten loops run logs --run-id <run-id> --sampler --tail",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Stream just the log messages as a JSONL stream.",
+					Command:     "baseten loops run logs --run-id <run-id> --output jsonl --jq '.message'",
+				},
+			},
+		},
+	},
+}
+
+// commandLoopsCheckpoint groups the `baseten loops checkpoint` subcommands.
+var commandLoopsCheckpoint = Command{
+	Name:    "checkpoint",
+	Summary: "Work with Loops checkpoints",
+	Children: []Command{
+		{
+			Name:    "list",
+			Summary: "List Loops checkpoints",
+			Description: "List checkpoints for a Loops run, newest first.\n\n" +
+				"Identify the run with --run-id, or pass --base-model to list checkpoints " +
+				"across all of your runs of that base model.",
+			Flags: LoopsCheckpointListFlags{},
+			Output: &CommandOutput[managementapi.ListLoopsCheckpointsResponse]{
+				TextDescription: "Table with columns: ID, NAME, RUN, TARGET, TYPE, SIZE, CREATED. When no " +
+					"checkpoints match, prints \"No Loops checkpoints found.\" to stderr.",
+				Examples: []CommandExample{
+					{
+						Description: "List a run's checkpoints.",
+						Command:     "baseten loops checkpoint list --run-id <run-id>",
+					},
+					{
+						Description: "List every checkpoint for a base model, oldest first.",
+						Command:     "baseten loops checkpoint list --base-model Qwen/Qwen3-8B --direction asc",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the deployable checkpoint names.",
+					Command:     "baseten loops checkpoint list --run-id <run-id> --jq '.checkpoints[] | select(.target != \"trainer\") | .checkpoint_id'",
+				},
+			},
+		},
+		{
+			Name:    "files",
+			Summary: "List a Loops checkpoint's files",
+			Description: "List presigned download URLs for the files under a Loops checkpoint.\n\n" +
+				"The URLs are short-lived. Use 'baseten loops checkpoint list' to find " +
+				"checkpoint IDs.\n\n" +
+				"For machine-readable streaming, prefer --output jsonl over --output json.",
+			Flags: LoopsCheckpointFilesFlags{},
+			Output: &CommandOutput[managementapi.CheckpointFile]{
+				JSONArrayStreamed: true,
+				TextDescription:   "Table with columns: NAME, SIZE, URL.",
+				Examples: []CommandExample{
+					{
+						Description: "List a checkpoint's files.",
+						Command:     "baseten loops checkpoint files --checkpoint-id <checkpoint-id>",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print just the download URLs.",
+					Command:     "baseten loops checkpoint files --checkpoint-id <checkpoint-id> --output jsonl --jq '.url'",
+				},
+			},
+		},
+	},
+}
+
+// LoopsRunRefFlags identifies a Loops run. Embedded by commands that act on a
+// specific run.
+type LoopsRunRefFlags struct {
+	RunID string `flag:"run-id" desc:"ID of the Loops run." required:"true"`
+}
+
+// LoopsRunCreateFlags configures `baseten loops run create`.
+type LoopsRunCreateFlags struct {
+	CommandFlags
+
+	BaseModel string `flag:"base-model" desc:"HuggingFace ID of the base model to fine-tune (for example 'Qwen/Qwen3-8B')." required:"true"`
+	Name      string `flag:"name" desc:"Display name for the run. Defaults to the base model."`
+	Replicas  int    `flag:"replicas" desc:"Number of data-parallel trainer replicas. The trainer deployment runs this many copies of the model's preset node group, so --replicas 4 on a 4-node preset provisions 16 nodes. Defaults to 1."`
+	Team      string `flag:"team" desc:"Team name or ID that owns the run's infrastructure. Defaults to the organization's default team."`
+}
+
+// LoopsRunListFlags configures `baseten loops run list`.
+type LoopsRunListFlags struct {
+	CommandFlags
+
+	BaseModel string `flag:"base-model" desc:"Only list runs of this base model."`
+	Org       bool   `flag:"org" desc:"List every run in the organization, with its owner, instead of only your own."`
+	All       bool   `flag:"all" desc:"Include inactive runs."`
+	Direction string `flag:"direction" desc:"Sort order by creation time: 'desc' (newest first) or 'asc' (oldest first)." enum:"asc,desc" default:"desc"`
+}
+
+// LoopsRunDescribeFlags configures `baseten loops run describe`.
+type LoopsRunDescribeFlags struct {
+	CommandFlags
+	LoopsRunRefFlags
+}
+
+// LoopsRunDeactivateFlags configures `baseten loops run deactivate`.
+type LoopsRunDeactivateFlags struct {
+	CommandFlags
+	LoopsRunRefFlags
+
+	Yes bool `flag:"yes" desc:"Skip the interactive confirmation prompt. Required when stdin is not a terminal."`
+}
+
+// LoopsRunLogsFlags configures `baseten loops run logs`.
+type LoopsRunLogsFlags struct {
+	CommandFlags
+	LoopsRunRefFlags
+	LoopsLogFlags
+
+	Sampler bool `flag:"sampler" desc:"Fetch the paired sampler's logs instead of the run's trainer logs."`
+}
+
+// LoopsLogFlags is the log-query flag set for `baseten loops run logs`. It is a
+// subset of [LogFlags]: the Loops trainer logs endpoint supports only the window,
+// limit, and severity filters, so the message and replica filters that model
+// deployment logs accept are not offered here.
+type LoopsLogFlags struct {
+	Tail bool `flag:"tail" desc:"Stream new logs as they arrive until the run stops producing them or you interrupt with Ctrl-C. Cannot be combined with the time-range or filter flags. For machine-readable streaming, prefer --output jsonl over --output json."`
+
+	Start time.Time     `flag:"start" desc:"Start of the log time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. Default is 30 minutes before the end. Window must be at most 7 days."`
+	End   time.Time     `flag:"end" desc:"End of the log time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. Default is now. Window must be at most 7 days."`
+	Since time.Duration `flag:"since" desc:"Shortcut for fetching logs from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
+
+	Limit int `flag:"limit" desc:"Maximum number of log lines to return, paging backward from the end of the window. Use 0 for no limit (every log line in the window). Not applicable with --tail." default:"5000"`
+
+	// PageSize is the per-request fetch size while paging. Hidden; exists so
+	// tests can force multiple pages without generating a full page of logs.
+	PageSize int `flag:"page-size" hidden:"true" desc:"Log lines fetched per backend request while paging." default:"1000"`
+
+	MinLevel string `flag:"min-level" desc:"Only return logs at or above this severity level." enum:"debug,info,warning,error"`
+}
+
+// LoopsUsageFlags configures `baseten loops usage`.
+type LoopsUsageFlags struct {
+	CommandFlags
+
+	Org  bool   `flag:"org" desc:"Report usage across the organization, with each allocation's owner, instead of only your own."`
+	User string `flag:"user" desc:"Only report allocations owned by this email. Implies --org."`
+	All  bool   `flag:"all" desc:"Include allocations holding no live GPUs (scaled to zero, or in a terminal state)."`
+}
+
+// LoopsUsageResult is the JSON output of `baseten loops usage`: the GPU summary
+// plus one entry per displayed row. The rows are a client-side join of trainer
+// deployments and standalone samplers, so this has no generated equivalent.
+type LoopsUsageResult struct {
+	Summary LoopsUsageSummary `json:"summary"`
+	Rows    []LoopsUsageRow   `json:"rows"`
+}
+
+// LoopsUsageSummary totals GPU capacity across every allocation, including rows
+// hidden from the table.
+type LoopsUsageSummary struct {
+	TrainerInUse        int `json:"trainer_in_use"`
+	TrainerScaledToZero int `json:"trainer_scaled_to_zero"`
+	SamplerInUse        int `json:"sampler_in_use"`
+	SamplerScaledToZero int `json:"sampler_scaled_to_zero"`
+}
+
+// LoopsUsageRow is one row of `baseten loops usage`: a trainer deployment with
+// its paired sampler, or a standalone sampler with the trainer fields empty.
+type LoopsUsageRow struct {
+	RunID     string `json:"run_id,omitempty"`
+	Owner     string `json:"owner,omitempty"`
+	BaseModel string `json:"base_model"`
+	CreatedAt string `json:"created_at"`
+
+	TrainerStatus       string `json:"trainer_status,omitempty"`
+	TrainerInstanceType string `json:"trainer_instance_type,omitempty"`
+	TrainerNodeCount    int    `json:"trainer_node_count,omitempty"`
+	TrainerGPUs         int    `json:"trainer_gpus"`
+
+	SamplerStatus       string `json:"sampler_status,omitempty"`
+	SamplerInstanceType string `json:"sampler_instance_type,omitempty"`
+	SamplerNodeCount    int    `json:"sampler_node_count,omitempty"`
+	SamplerGPUs         int    `json:"sampler_gpus"`
+}
+
+// LoopsCheckpointListFlags configures `baseten loops checkpoint list`.
+type LoopsCheckpointListFlags struct {
+	CommandFlags
+
+	RunID     string `flag:"run-id" desc:"List checkpoints saved by this run." oneof:"loops-checkpoint-scope"`
+	BaseModel string `flag:"base-model" desc:"List checkpoints across your runs of this base model." oneof:"loops-checkpoint-scope"`
+	Direction string `flag:"direction" desc:"Sort order by creation time: 'desc' (newest first) or 'asc' (oldest first)." enum:"asc,desc" default:"desc"`
+}
+
+// LoopsCheckpointFilesFlags configures `baseten loops checkpoint files`.
+type LoopsCheckpointFilesFlags struct {
+	CommandFlags
+
+	CheckpointID string `flag:"checkpoint-id" desc:"ID of the Loops checkpoint." required:"true"`
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.2.1-0.20260806171929-da03c3ec35ae
+	github.com/basetenlabs/baseten-go v0.2.1-0.20260810200818-157866ebaf81
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.1.1-0.20260720143708-a98e2103a143
+	github.com/basetenlabs/baseten-go v0.2.1-0.20260806171929-da03c3ec35ae
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.2.1-0.20260806171929-da03c3ec35ae h1:1TKTaDUX4YdTF5H43ZavyXo79qoBJ5ViiaJ2SDWLEUY=
-github.com/basetenlabs/baseten-go v0.2.1-0.20260806171929-da03c3ec35ae/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260810200818-157866ebaf81 h1:8AE8QO3mCpltz2besI3ElQw3b2SaG3iYyYBcnFVPUiE=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260810200818-157866ebaf81/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.1.1-0.20260720143708-a98e2103a143 h1:tApns1tFcWfBl3/jXFj6yNtcPzZLwQHpeD+SNOKRuhs=
-github.com/basetenlabs/baseten-go v0.1.1-0.20260720143708-a98e2103a143/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260806171929-da03c3ec35ae h1:1TKTaDUX4YdTF5H43ZavyXo79qoBJ5ViiaJ2SDWLEUY=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260806171929-da03c3ec35ae/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -61,6 +61,11 @@ type ExecuteOptions struct {
 	Stdout       io.Writer
 	Stderr       io.Writer
 	ExitWithCode func(int)
+	// StrictOutputChecks panics on output that is malformed in a way a user
+	// would see but the code cannot detect for itself, such as a table row whose
+	// cell count does not match its headers. Tests set it; production renders
+	// whatever it was given rather than failing a command over its formatting.
+	StrictOutputChecks bool
 }
 
 func (o *ExecuteOptions) applyDefaults() {
@@ -201,6 +206,7 @@ func buildCommand(def cmd.Command, parentPath string, options *ExecuteOptions) *
 				Stdout:       options.Stdout,
 				Stderr:       options.Stderr,
 				ExitWithCode: options.ExitWithCode,
+				strictOutput: options.StrictOutputChecks,
 				authInfo:     authInfo{profileFlag: cmdFlags.Profile},
 			}
 

--- a/internal/cmd/command.loops.go
+++ b/internal/cmd/command.loops.go
@@ -430,6 +430,7 @@ func commandLoopsUsage(ctx *CommandContext, flags *cmd.LoopsUsageFlags) error {
 			out = append(out, row.Owner)
 		}
 		tableRows = append(tableRows, append(out,
+			row.BaseModel,
 			loopsFormatGPUCell(row.TrainerInstanceType, row.TrainerNodeCount, row.TrainerGPUs),
 			row.TrainerStatus,
 			loopsFormatGPUCell(row.SamplerInstanceType, row.SamplerNodeCount, row.SamplerGPUs),

--- a/internal/cmd/command.loops.go
+++ b/internal/cmd/command.loops.go
@@ -1,0 +1,602 @@
+package cmd
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+)
+
+func init() {
+	Register("loops run create", commandLoopsRunCreate)
+	Register("loops run list", commandLoopsRunList)
+	Register("loops run describe", commandLoopsRunDescribe)
+	Register("loops run deactivate", commandLoopsRunDeactivate)
+	Register("loops run logs", commandLoopsRunLogs)
+	Register("loops usage", commandLoopsUsage)
+	Register("loops checkpoint list", commandLoopsCheckpointList)
+	Register("loops checkpoint files", commandLoopsCheckpointFiles)
+}
+
+// loopsTrainerLiveStatuses are the trainer deployment statuses where the trainer
+// is alive: coming up, or running. A live trainer both holds GPUs and may still
+// produce logs. SCALED_TO_ZERO holds no GPUs and is tracked separately in the
+// usage summary; STOPPED and FAILED are terminal and hold none either.
+var loopsTrainerLiveStatuses = []managementapi.Name{
+	managementapi.Name_CREATED,
+	managementapi.Name_DEPLOYING,
+	managementapi.Name_RUNNING,
+}
+
+// loopsSamplerLiveStatuses are the sampler statuses where the sampler is alive:
+// serving, or on the way there. A sampler keeps reporting the instance type it
+// last ran on after it dies, so capacity has to key off status rather than the
+// presence of an instance type.
+var loopsSamplerLiveStatuses = []managementapi.DeploymentStatus{
+	managementapi.DeploymentStatus_ACTIVE,
+	managementapi.DeploymentStatus_BUILDING,
+	managementapi.DeploymentStatus_DEPLOYING,
+	managementapi.DeploymentStatus_LOADING_MODEL,
+	managementapi.DeploymentStatus_UPDATING,
+	managementapi.DeploymentStatus_WAKING_UP,
+}
+
+func commandLoopsRunCreate(ctx *CommandContext, flags *cmd.LoopsRunCreateFlags) error {
+	if ctx.Command.Flags().Changed("replicas") && flags.Replicas < 1 {
+		return cmd.NewErrUsagef("--replicas must be a positive number")
+	}
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	teamID, err := ResolveTeam(ctx, cl.API(), flags.Team)
+	if err != nil {
+		return err
+	}
+
+	// A run belongs to a session, so creating one takes two calls. The session is
+	// otherwise invisible: no CLI command surfaces it, and the SDK makes its own.
+	ctx.VerboseLogf("Creating Loops session...\n")
+	var session *managementapi.CreateLoopsSessionResponse
+	if teamID != "" {
+		session, err = cl.API().PostTeamsLoopsSessions(ctx, teamID)
+	} else {
+		session, err = cl.API().PostLoopsSessions(ctx)
+	}
+	if err != nil {
+		return fmt.Errorf("create Loops session: %w", err)
+	}
+
+	req := managementapi.CreateLoopsRunRequest{
+		SessionId: session.Session.Id,
+		BaseModel: flags.BaseModel,
+	}
+	if flags.Name != "" {
+		req.Name = &flags.Name
+	}
+	if flags.Replicas > 0 {
+		req.Replicas = &flags.Replicas
+	}
+
+	ctx.Logf("Provisioning Loops run and sampler for %s...\n", flags.BaseModel)
+	var created *managementapi.CreateLoopsRunResponse
+	if teamID != "" {
+		created, err = cl.API().PostTeamsLoopsRuns(ctx, teamID, req)
+	} else {
+		created, err = cl.API().PostLoopsRuns(ctx, req)
+	}
+	if err != nil {
+		return fmt.Errorf("create Loops run for base model %s: %w", flags.BaseModel, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(created.Run)
+		return nil
+	}
+	// Readiness is the SDK's concern: its clients block on construction. The CLI
+	// only reports that both halves were provisioned.
+	ctx.Logf("Created Loops run %s for %s. The trainer and sampler finish coming up in the background.\n",
+		created.Run.Id, created.Run.BaseModel)
+	return nil
+}
+
+func commandLoopsRunList(ctx *CommandContext, flags *cmd.LoopsRunListFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	params := managementapi.GetV1LoopsRunsParams{}
+	if flags.BaseModel != "" {
+		params.BaseModel = &flags.BaseModel
+	}
+	if flags.Org {
+		scope := "org"
+		params.Scope = &scope
+	}
+	resp, err := cl.API().GetLoopsRuns(ctx, params)
+	if err != nil {
+		return fmt.Errorf("list Loops runs: %w", err)
+	}
+
+	runs := resp.Runs
+	if !flags.All {
+		runs = slices.DeleteFunc(runs, func(run managementapi.LoopsRun) bool {
+			return run.Status.Name == managementapi.LoopsRunStatusName_INACTIVE
+		})
+	}
+	slices.SortStableFunc(runs, func(a, b managementapi.LoopsRun) int {
+		if flags.Direction == "asc" {
+			return a.CreatedAt.Compare(b.CreatedAt)
+		}
+		return b.CreatedAt.Compare(a.CreatedAt)
+	})
+
+	if ctx.JSON {
+		ctx.OutputJSON(managementapi.ListLoopsRunsResponse{Runs: runs})
+		return nil
+	}
+	if len(runs) == 0 {
+		if flags.All {
+			ctx.LogLine("No Loops runs found.")
+		} else {
+			ctx.LogLine("No active Loops runs found. Pass --all to include inactive runs.")
+		}
+		return nil
+	}
+	headers := []string{"ID", "BASE MODEL", "STATUS", "CREATED"}
+	if flags.Org {
+		headers = slices.Insert(headers, 1, "OWNER")
+	}
+	rows := make([][]string, 0, len(runs))
+	for _, run := range runs {
+		row := []string{run.Id}
+		if flags.Org {
+			owner := ""
+			if run.User.Email != nil {
+				owner = *run.User.Email
+			}
+			row = append(row, owner)
+		}
+		rows = append(rows, append(row,
+			run.BaseModel,
+			string(run.Status.Name),
+			run.CreatedAt.UTC().Format(time.RFC3339),
+		))
+	}
+	ctx.OutputTable(TableOutput{Headers: headers, Rows: rows})
+	return nil
+}
+
+func commandLoopsRunDescribe(ctx *CommandContext, flags *cmd.LoopsRunDescribeFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	resp, err := cl.API().GetLoopsRunsRunId(ctx, flags.RunID)
+	if err != nil {
+		return fmt.Errorf("describe Loops run %s: %w", flags.RunID, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(resp.Run)
+		return nil
+	}
+	run := resp.Run
+	ctx.Outputf("ID:          %s\n", run.Id)
+	ctx.Outputf("Name:        %s\n", run.Name)
+	ctx.Outputf("Base Model:  %s\n", run.BaseModel)
+	ctx.Outputf("Status:      %s\n", run.Status.Name)
+	if run.User.Email != nil {
+		ctx.Outputf("Owner:       %s\n", *run.User.Email)
+	}
+	ctx.Outputf("Session:     %s\n", run.SessionId)
+	ctx.Outputf("Deployment:  %s\n", run.DeploymentId)
+	ctx.Outputf("Base URL:    %s\n", hyperlink(ctx.Stdout, run.BaseUrl))
+	ctx.Outputf("Created:     %s\n", run.CreatedAt.UTC().Format(time.RFC3339))
+	if run.Sampler != nil {
+		ctx.Outputf("\nSampler\n")
+		ctx.Outputf("  ID:         %s\n", run.Sampler.Id)
+		ctx.Outputf("  Status:     %s\n", run.Sampler.Status.Name)
+		ctx.Outputf("  Model:      %s\n", run.Sampler.ModelId)
+		ctx.Outputf("  Deployment: %s\n", run.Sampler.DeploymentId)
+		ctx.Outputf("  Base URL:   %s\n", hyperlink(ctx.Stdout, run.Sampler.BaseUrl))
+	}
+	return nil
+}
+
+func commandLoopsRunDeactivate(ctx *CommandContext, flags *cmd.LoopsRunDeactivateFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	if !flags.Yes {
+		if err := ctx.ConfirmYesNo(fmt.Sprintf(
+			"Deactivate Loops run %s? This tears down its trainer and sampler.", flags.RunID)); err != nil {
+			return err
+		}
+	}
+	resp, err := cl.API().PostLoopsRunsDeactivate(ctx, flags.RunID)
+	if err != nil {
+		return fmt.Errorf("deactivate Loops run %s: %w", flags.RunID, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(resp)
+		return nil
+	}
+	ctx.Logf("Deactivated Loops run %s. Saved checkpoints remain accessible.\n", resp.Id)
+	return nil
+}
+
+func commandLoopsRunLogs(ctx *CommandContext, flags *cmd.LoopsRunLogsFlags) error {
+	// The filters Loops does not offer stay zero-valued, which the shared logs
+	// flow treats as absent.
+	logFlags := cmd.LogFlags{
+		Tail:     flags.Tail,
+		Start:    flags.Start,
+		End:      flags.End,
+		Since:    flags.Since,
+		Limit:    flags.Limit,
+		PageSize: flags.PageSize,
+		MinLevel: flags.MinLevel,
+	}
+	if err := validateLogFlags(ctx, &logFlags); err != nil {
+		return err
+	}
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	// One run resolves both log sources: the run's own trainer deployment, and the
+	// paired sampler's inference deployment plus the model that owns it.
+	run, err := cl.API().GetLoopsRunsRunId(ctx, flags.RunID)
+	if err != nil {
+		return fmt.Errorf("describe Loops run %s: %w", flags.RunID, err)
+	}
+
+	if flags.Sampler {
+		sampler := run.Run.Sampler
+		if sampler == nil {
+			return fmt.Errorf("Loops run %s has no paired sampler to fetch logs from; omit --sampler for the run's trainer logs", flags.RunID)
+		}
+		fetchLogs := func(q logQuery) (*managementapi.GetLogsResponse, error) {
+			return cl.API().GetModelsDeploymentsLogs(ctx, sampler.ModelId, sampler.DeploymentId, deploymentLogParams(q))
+		}
+		fetchStatus := func() (*tailStatus, error) {
+			dep, err := cl.API().GetModelsDeploymentsDeploymentId(ctx, sampler.ModelId, sampler.DeploymentId)
+			if err != nil {
+				return nil, err
+			}
+			return deploymentTailStatus(dep, false), nil
+		}
+		return runLogsCommand(ctx, &logFlags, fetchLogs, fetchStatus)
+	}
+
+	deploymentID := run.Run.DeploymentId
+	fetchLogs := func(q logQuery) (*managementapi.GetLogsResponse, error) {
+		direction := managementapi.SortOrder_desc
+		return cl.API().GetLoopsDeploymentsLogs(ctx, deploymentID,
+			managementapi.GetV1LoopsDeploymentsDeploymentIdLogsParams{
+				StartEpochMillis: q.StartEpochMillis,
+				EndEpochMillis:   q.EndEpochMillis,
+				Limit:            q.Limit,
+				Direction:        &direction,
+				MinLevel:         q.MinLevel,
+			})
+	}
+	fetchStatus := func() (*tailStatus, error) {
+		// The per-deployment endpoint carries the latest status directly, which is
+		// cheaper than paging the deployment list.
+		deployment, err := cl.API().GetLoopsDeploymentsDeploymentId(ctx, deploymentID)
+		if err != nil {
+			return nil, err
+		}
+		name := deployment.Deployment.Status.Name
+		return &tailStatus{
+			Label: string(name),
+			// A trainer only produces logs while it is coming up or running;
+			// anything else, including unknown statuses, ends the tail.
+			Runnable: slices.Contains(loopsTrainerLiveStatuses, name),
+		}, nil
+	}
+	return runLogsCommand(ctx, &logFlags, fetchLogs, fetchStatus)
+}
+
+func commandLoopsUsage(ctx *CommandContext, flags *cmd.LoopsUsageFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	// --user filters org-wide data client-side, so it only means anything against
+	// the org-wide listing.
+	orgWide := flags.Org || flags.User != ""
+
+	deploymentParams := managementapi.GetV1LoopsDeploymentsParams{}
+	samplerParams := managementapi.GetV1LoopsSamplersParams{}
+	if orgWide {
+		scope := "org"
+		deploymentParams.Scope = &scope
+		samplerParams.Scope = &scope
+	}
+	deploymentsResp, err := cl.API().GetLoopsDeployments(ctx, deploymentParams)
+	if err != nil {
+		return fmt.Errorf("list Loops deployments: %w", err)
+	}
+	samplersResp, err := cl.API().GetLoopsSamplers(ctx, samplerParams)
+	if err != nil {
+		return fmt.Errorf("list Loops samplers: %w", err)
+	}
+
+	// Samplers paired to a trainer already appear as that trainer's row. Match
+	// them by id across every deployment before the owner filter, so a
+	// filtered-out trainer's sampler is not then counted as standalone.
+	paired := map[string]struct{}{}
+	for _, deployment := range deploymentsResp.Deployments {
+		if deployment.Sampler != nil {
+			paired[deployment.Sampler.Id] = struct{}{}
+		}
+	}
+
+	rows := make([]cmd.LoopsUsageRow, 0, len(deploymentsResp.Deployments)+len(samplersResp.Samplers))
+	for _, deployment := range deploymentsResp.Deployments {
+		row := cmd.LoopsUsageRow{
+			BaseModel:           deployment.BaseModel,
+			CreatedAt:           deployment.CreatedAt.UTC().Format(time.RFC3339),
+			TrainerStatus:       string(deployment.Status.Name),
+			TrainerInstanceType: deployment.InstanceType.Name,
+			TrainerNodeCount:    1,
+		}
+		// An idle trainer has no active run but still exposes the most recent one
+		// as a usable handle.
+		if deployment.ActiveRunId != nil {
+			row.RunID = *deployment.ActiveRunId
+		} else if deployment.LatestRunId != nil {
+			row.RunID = *deployment.LatestRunId
+		}
+		if deployment.User.Email != nil {
+			row.Owner = *deployment.User.Email
+		}
+		if deployment.NodeCount != nil && *deployment.NodeCount > 1 {
+			row.TrainerNodeCount = *deployment.NodeCount
+		}
+		row.TrainerGPUs = deployment.InstanceType.GpuCount * row.TrainerNodeCount
+		if deployment.Sampler != nil {
+			loopsApplySamplerToRow(&row, *deployment.Sampler)
+		}
+		if flags.User != "" && row.Owner != flags.User {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	for _, sampler := range samplersResp.Samplers {
+		if _, dup := paired[sampler.Id]; dup {
+			continue
+		}
+		row := cmd.LoopsUsageRow{
+			BaseModel: sampler.BaseModel,
+			CreatedAt: sampler.CreatedAt.UTC().Format(time.RFC3339),
+		}
+		if sampler.User.Email != nil {
+			row.Owner = *sampler.User.Email
+		}
+		loopsApplySamplerToRow(&row, sampler)
+		if flags.User != "" && row.Owner != flags.User {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	// Timestamps are RFC 3339 in UTC, so they sort lexicographically.
+	slices.SortStableFunc(rows, func(a, b cmd.LoopsUsageRow) int {
+		return strings.Compare(b.CreatedAt, a.CreatedAt)
+	})
+
+	// The summary totals every row, including the ones the table hides, so it
+	// reports true capacity rather than what happens to be on screen.
+	summary := loopsUsageSummaryOf(rows)
+	shown := rows
+	if !flags.All {
+		shown = slices.DeleteFunc(slices.Clone(rows), func(row cmd.LoopsUsageRow) bool {
+			return !loopsRowHoldsLiveGPUs(row)
+		})
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(cmd.LoopsUsageResult{Summary: summary, Rows: shown})
+		return nil
+	}
+	ctx.Outputf("Trainer GPUs: %d in use, %d scaled to zero. Sampler GPUs: %d in use, %d scaled to zero.\n",
+		summary.TrainerInUse, summary.TrainerScaledToZero, summary.SamplerInUse, summary.SamplerScaledToZero)
+	if len(rows) == 0 {
+		ctx.LogLine("No Loops trainers or samplers found.")
+		return nil
+	}
+	if hidden := len(rows) - len(shown); hidden > 0 {
+		ctx.Logf("%d allocation(s) holding no live GPUs hidden; pass --all to show them.\n", hidden)
+	}
+	if len(shown) == 0 {
+		return nil
+	}
+	headers := []string{"RUN", "BASE MODEL", "TRAINER GPU", "TRAINER STATUS", "SAMPLER GPU", "SAMPLER STATUS", "CREATED"}
+	if orgWide {
+		headers = slices.Insert(headers, 1, "OWNER")
+	}
+	tableRows := make([][]string, 0, len(shown))
+	for _, row := range shown {
+		out := []string{row.RunID}
+		if orgWide {
+			out = append(out, row.Owner)
+		}
+		tableRows = append(tableRows, append(out,
+			loopsFormatGPUCell(row.TrainerInstanceType, row.TrainerNodeCount, row.TrainerGPUs),
+			row.TrainerStatus,
+			loopsFormatGPUCell(row.SamplerInstanceType, row.SamplerNodeCount, row.SamplerGPUs),
+			row.SamplerStatus,
+			row.CreatedAt,
+		))
+	}
+	ctx.OutputTable(TableOutput{Headers: headers, Rows: tableRows})
+	return nil
+}
+
+func commandLoopsCheckpointList(ctx *CommandContext, flags *cmd.LoopsCheckpointListFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	params := managementapi.GetV1LoopsCheckpointsParams{}
+	if flags.RunID != "" {
+		params.RunId = &flags.RunID
+	} else {
+		params.BaseModel = &flags.BaseModel
+	}
+	resp, err := cl.API().GetLoopsCheckpoints(ctx, params)
+	if err != nil {
+		return fmt.Errorf("list Loops checkpoints: %w", err)
+	}
+
+	// The server already returns newest-first, so only asc needs a re-sort.
+	checkpoints := resp.Checkpoints
+	if flags.Direction == "asc" {
+		slices.Reverse(checkpoints)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(managementapi.ListLoopsCheckpointsResponse{Checkpoints: checkpoints})
+		return nil
+	}
+	if len(checkpoints) == 0 {
+		ctx.LogLine("No Loops checkpoints found.")
+		return nil
+	}
+	rows := make([][]string, 0, len(checkpoints))
+	for _, checkpoint := range checkpoints {
+		rows = append(rows, []string{
+			checkpoint.Id,
+			checkpoint.CheckpointId,
+			checkpoint.RunId,
+			string(checkpoint.Target),
+			checkpoint.CheckpointType,
+			formatBytes(int64(checkpoint.SizeBytes)),
+			checkpoint.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"ID", "NAME", "RUN", "TARGET", "TYPE", "SIZE", "CREATED"},
+		Rows:    rows,
+	})
+	return nil
+}
+
+func commandLoopsCheckpointFiles(ctx *CommandContext, flags *cmd.LoopsCheckpointFilesFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	var jw *JSONArrayWriter
+	if ctx.JSON {
+		jw = ctx.NewJSONArrayWriter()
+		defer jw.Close()
+	}
+	var rows [][]string
+
+	// The server pages this at 1000 files by default, so walk every page. The
+	// URLs are short-lived, so emit each record as its page arrives rather than
+	// buffering the whole listing. An empty page also ends the walk, so a server
+	// that keeps handing back a token cannot spin here forever.
+	params := managementapi.GetV1LoopsCheckpointsCheckpointIdFilesParams{}
+	for {
+		resp, err := cl.API().GetLoopsCheckpointsFiles(ctx, flags.CheckpointID, params)
+		if err != nil {
+			return fmt.Errorf("list files for Loops checkpoint %s: %w", flags.CheckpointID, err)
+		}
+		for _, file := range resp.PresignedUrls {
+			if ctx.JSON {
+				jw.Write(file)
+			} else {
+				rows = append(rows, []string{
+					file.RelativeFileName,
+					formatBytes(int64(file.SizeBytes)),
+					file.Url,
+				})
+			}
+		}
+		if resp.NextPageToken == nil || len(resp.PresignedUrls) == 0 {
+			break
+		}
+		params.PageToken = resp.NextPageToken
+	}
+
+	if ctx.JSON {
+		return nil
+	}
+	if len(rows) == 0 {
+		ctx.LogLine("No files found for this Loops checkpoint.")
+		return nil
+	}
+	ctx.OutputTable(TableOutput{Headers: []string{"NAME", "SIZE", "URL"}, Rows: rows})
+	return nil
+}
+
+// loopsApplySamplerToRow fills in a usage row's sampler half.
+func loopsApplySamplerToRow(row *cmd.LoopsUsageRow, sampler managementapi.LoopsSampler) {
+	row.SamplerStatus = string(sampler.Status.Name)
+	row.SamplerNodeCount = 1
+	if sampler.NodeCount != nil && *sampler.NodeCount > 1 {
+		row.SamplerNodeCount = *sampler.NodeCount
+	}
+	if sampler.InstanceType != nil {
+		row.SamplerInstanceType = sampler.InstanceType.Name
+		row.SamplerGPUs = sampler.InstanceType.GpuCount * row.SamplerNodeCount
+	}
+}
+
+// loopsUsageSummaryOf totals GPU capacity across rows, splitting each half into
+// in-use versus scaled to zero. Terminal allocations hold no GPUs at all and land
+// in neither bucket, even though they still report the instance type they last
+// ran on.
+func loopsUsageSummaryOf(rows []cmd.LoopsUsageRow) cmd.LoopsUsageSummary {
+	var summary cmd.LoopsUsageSummary
+	for _, row := range rows {
+		switch {
+		case slices.Contains(loopsTrainerLiveStatuses, managementapi.Name(row.TrainerStatus)):
+			summary.TrainerInUse += row.TrainerGPUs
+		case row.TrainerStatus == string(managementapi.Name_SCALED_TO_ZERO):
+			summary.TrainerScaledToZero += row.TrainerGPUs
+		}
+		switch {
+		case slices.Contains(loopsSamplerLiveStatuses, managementapi.DeploymentStatus(row.SamplerStatus)):
+			summary.SamplerInUse += row.SamplerGPUs
+		case row.SamplerStatus == string(managementapi.DeploymentStatus_SCALED_TO_ZERO):
+			summary.SamplerScaledToZero += row.SamplerGPUs
+		}
+	}
+	return summary
+}
+
+// loopsRowHoldsLiveGPUs reports whether either half of a usage row is holding
+// GPUs right now. Idle (scaled to zero) and terminal allocations return false so
+// the default view can hide them while the summary still counts them.
+func loopsRowHoldsLiveGPUs(row cmd.LoopsUsageRow) bool {
+	return slices.Contains(loopsTrainerLiveStatuses, managementapi.Name(row.TrainerStatus)) ||
+		slices.Contains(loopsSamplerLiveStatuses, managementapi.DeploymentStatus(row.SamplerStatus))
+}
+
+// loopsFormatGPUCell renders an allocation as "<instance-type> (<gpus> GPUs)",
+// appending the node count when the allocation spans more than one node. An
+// allocation with no GPUs renders as just its instance type, and an absent one as
+// the empty cell.
+func loopsFormatGPUCell(instanceType string, nodeCount, gpus int) string {
+	if instanceType == "" {
+		return ""
+	}
+	if gpus == 0 {
+		return instanceType
+	}
+	if nodeCount > 1 {
+		return fmt.Sprintf("%s (%d GPUs across %d nodes)", instanceType, gpus, nodeCount)
+	}
+	return fmt.Sprintf("%s (%d GPUs)", instanceType, gpus)
+}

--- a/internal/cmd/command.loops_test.go
+++ b/internal/cmd/command.loops_test.go
@@ -392,6 +392,31 @@ func Test_Loops_Run_Logs_Trainer(t *testing.T) {
 	h.Require.Nil(m.FindCall("GET", loopsSamplerLogsPath))
 }
 
+func Test_Loops_Run_Logs_Empty(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", loopsRunPath, 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+	m.SetRoute("GET", loopsTrainerLogsPath, 200, logsResponse())
+
+	h.Require.NoError(h.Execute("loops", "run", "logs", "--run-id", "r-1"))
+	h.Require.Empty(h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "No logs found.")
+}
+
+func Test_Loops_Run_Logs_EmptyJSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", loopsRunPath, 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+	m.SetRoute("GET", loopsTrainerLogsPath, 200, logsResponse())
+
+	// The empty array is already unambiguous, so the note is suppressed the same
+	// way the list commands suppress theirs.
+	h.Require.NoError(h.Execute("loops", "run", "logs", "--run-id", "r-1", "--output", "json"))
+	h.Require.NotContains(h.Stderr.String(), "No logs found.")
+}
+
 func Test_Loops_Run_Logs_Sampler(t *testing.T) {
 	h := NewCommandHarness(t)
 	m := h.MockManagementAPI()
@@ -435,6 +460,23 @@ func Test_Loops_Run_Logs_Tail_StopsOnTerminalTrainerStatus(t *testing.T) {
 
 	h.Require.NoError(h.Execute("loops", "run", "logs", "--run-id", "r-1", "--tail"))
 	h.Require.Contains(h.Stdout.String(), "step 1")
+	h.Require.Contains(h.Stderr.String(), "Tailing stopped: deployment status STOPPED")
+}
+
+func Test_Loops_Run_Logs_Tail_StopsOnTerminalTrainerStatusWithoutLogs(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", loopsRunPath, 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+	// A trainer that stopped before the log window opened returns nothing, so
+	// there is no log line to trigger the status check that ends the tail.
+	m.SetRoute("GET", loopsTrainerLogsPath, 200, logsResponse())
+	m.SetRoute("GET", loopsTrainerPath, 200, map[string]any{
+		"deployment": loopsDeploymentFixture("dep-1", "STOPPED", "H100", 8, 1, "2026-05-14T12:00:00Z", nil),
+	})
+	h.Context = cmd.WithSleep(h.Context, func(_ context.Context, _ time.Duration) error { return nil })
+
+	h.Require.NoError(h.Execute("loops", "run", "logs", "--run-id", "r-1", "--tail"))
 	h.Require.Contains(h.Stderr.String(), "Tailing stopped: deployment status STOPPED")
 }
 

--- a/internal/cmd/command.loops_test.go
+++ b/internal/cmd/command.loops_test.go
@@ -1,0 +1,929 @@
+package cmd_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/internal/cmd"
+)
+
+const (
+	loopsRunPath         = "/v1/loops/runs/r-1"
+	loopsTrainerLogsPath = "/v1/loops/deployments/dep-1/logs"
+	loopsTrainerPath     = "/v1/loops/deployments/dep-1"
+	loopsSamplerLogsPath = "/v1/models/model-1/deployments/sdep-1/logs"
+	loopsSamplerDepPath  = "/v1/models/model-1/deployments/sdep-1"
+)
+
+// loopsSamplerFixture is a sampler payload. instanceType "" omits the instance
+// type entirely, which is how the backend reports a sampler that never ran.
+func loopsSamplerFixture(id, status, instanceType string, gpuCount, nodeCount int, createdAt string) map[string]any {
+	s := map[string]any{
+		"id":            id,
+		"base_model":    "Qwen/Qwen3-8B",
+		"base_url":      "https://sampler.example.com",
+		"created_at":    createdAt,
+		"deployment_id": "sdep-1",
+		"model_id":      "model-1",
+		"node_count":    nodeCount,
+		"status":        map[string]any{"name": status},
+		"user":          map[string]any{"email": "owner@example.com"},
+	}
+	if instanceType != "" {
+		s["instance_type"] = loopsInstanceTypeFixture(instanceType, gpuCount)
+	}
+	return s
+}
+
+func loopsInstanceTypeFixture(name string, gpuCount int) map[string]any {
+	return map[string]any{
+		"id":                   name,
+		"name":                 name,
+		"gpu_count":            gpuCount,
+		"gpu_type":             "H100",
+		"gpu_memory_limit_mib": 81920,
+		"memory_limit_mib":     262144,
+		"millicpu_limit":       26000,
+	}
+}
+
+func loopsRunFixture(id, status string, sampler map[string]any) map[string]any {
+	r := map[string]any{
+		"id":            id,
+		"name":          "run-" + id,
+		"base_model":    "Qwen/Qwen3-8B",
+		"base_url":      "https://trainer.example.com",
+		"created_at":    "2026-05-14T12:00:00Z",
+		"deployment_id": "dep-1",
+		"session_id":    "sess-1",
+		"status":        map[string]any{"name": status},
+		"user":          map[string]any{"email": "owner@example.com"},
+	}
+	if sampler != nil {
+		r["sampler"] = sampler
+	}
+	return r
+}
+
+// loopsDeploymentFixture is a trainer deployment payload for `loops usage`.
+func loopsDeploymentFixture(id, status, instanceType string, gpuCount, nodeCount int, createdAt string, sampler map[string]any) map[string]any {
+	d := map[string]any{
+		"id":            id,
+		"base_model":    "Qwen/Qwen3-8B",
+		"base_url":      "https://trainer.example.com",
+		"created_at":    createdAt,
+		"instance_type": loopsInstanceTypeFixture(instanceType, gpuCount),
+		"node_count":    nodeCount,
+		"active_run_id": "r-" + id,
+		"status":        map[string]any{"name": status},
+		"user":          map[string]any{"email": "owner@example.com"},
+	}
+	if sampler != nil {
+		d["sampler"] = sampler
+	}
+	return d
+}
+
+func loopsCheckpointFixture(id, runID, target, createdAt string) map[string]any {
+	return map[string]any{
+		"id":                  id,
+		"checkpoint_id":       "checkpoint-" + id,
+		"checkpoint_type":     "full",
+		"created_at":          createdAt,
+		"base_model":          "Qwen/Qwen3-8B",
+		"lora_adapter_config": nil,
+		"run_id":              runID,
+		"size_bytes":          1024,
+		"target":              target,
+	}
+}
+
+func Test_Loops_Run_Create(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", "/v1/loops/sessions", 200, map[string]any{"session": map[string]any{"id": "sess-1"}})
+	m.SetRoute("POST", "/v1/loops/runs", 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+
+	h.Require.NoError(h.Execute("loops", "run", "create", "--base-model", "Qwen/Qwen3-8B"))
+	call := m.FindCall("POST", "/v1/loops/runs")
+	h.Require.NotNil(call)
+	body := call.BodyJSON(t)
+	h.Require.Equal("sess-1", body["session_id"])
+	h.Require.Equal("Qwen/Qwen3-8B", body["base_model"])
+	// Unset optional fields are omitted rather than sent as zero values.
+	h.Require.NotContains(body, "name")
+	h.Require.NotContains(body, "replicas")
+	h.Require.Equal("", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "Created Loops run r-1")
+}
+
+func Test_Loops_Run_Create_NameAndReplicas(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", "/v1/loops/sessions", 200, map[string]any{"session": map[string]any{"id": "sess-1"}})
+	m.SetRoute("POST", "/v1/loops/runs", 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+
+	h.Require.NoError(h.Execute("loops", "run", "create",
+		"--base-model", "Qwen/Qwen3-8B", "--name", "experiment-1", "--replicas", "4"))
+	body := m.FindCall("POST", "/v1/loops/runs").BodyJSON(t)
+	h.Require.Equal("experiment-1", body["name"])
+	h.Require.Equal(float64(4), body["replicas"])
+}
+
+func Test_Loops_Run_Create_ScopedByTeam(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/teams", 200, map[string]any{
+		"teams": []any{map[string]any{"id": "team-abc", "name": "ml"}},
+	})
+	m.SetRoute("POST", "/v1/teams/team-abc/loops/sessions", 200,
+		map[string]any{"session": map[string]any{"id": "sess-1"}})
+	m.SetRoute("POST", "/v1/teams/team-abc/loops/runs", 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+
+	h.Require.NoError(h.Execute("loops", "run", "create",
+		"--base-model", "Qwen/Qwen3-8B", "--team", "ml"))
+	h.Require.NotNil(m.FindCall("POST", "/v1/teams/team-abc/loops/sessions"))
+	h.Require.NotNil(m.FindCall("POST", "/v1/teams/team-abc/loops/runs"))
+	h.Require.Nil(m.FindCall("POST", "/v1/loops/runs"))
+}
+
+func Test_Loops_Run_Create_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", "/v1/loops/sessions", 200, map[string]any{"session": map[string]any{"id": "sess-1"}})
+	m.SetRoute("POST", "/v1/loops/runs", 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", loopsSamplerFixture("s-1", "ACTIVE", "H100", 8, 1, "2026-05-14T12:00:00Z"))})
+
+	h.Require.NoError(h.Execute("loops", "run", "create",
+		"--base-model", "Qwen/Qwen3-8B", "--output", "json"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, `"id": "r-1"`)
+	h.Require.Contains(out, `"sampler"`)
+}
+
+func Test_Loops_Run_Create_ReplicasNotPositiveRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+
+	err := h.Execute("loops", "run", "create", "--base-model", "Qwen/Qwen3-8B", "--replicas", "0")
+	h.Require.ErrorContains(err, "--replicas must be a positive number")
+	h.Require.Empty(m.Calls())
+}
+
+func Test_Loops_Run_Create_MissingBaseModel(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("loops", "run", "create")
+	h.Require.ErrorContains(err, "base-model")
+}
+
+func Test_Loops_Run_List_Empty(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/loops/runs", 200, map[string]any{"runs": []any{}})
+
+	h.Require.NoError(h.Execute("loops", "run", "list"))
+	h.Require.Equal("", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "No active Loops runs found. Pass --all to include inactive runs.")
+}
+
+func Test_Loops_Run_List_Empty_All(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/loops/runs", 200, map[string]any{"runs": []any{}})
+
+	h.Require.NoError(h.Execute("loops", "run", "list", "--all"))
+	h.Require.Contains(h.Stderr.String(), "No Loops runs found.")
+	h.Require.NotContains(h.Stderr.String(), "--all")
+}
+
+func Test_Loops_Run_List_HidesInactiveByDefault(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/loops/runs", 200, map[string]any{"runs": []any{
+		loopsRunFixture("r-1", "ACTIVE", nil),
+		loopsRunFixture("r-2", "INACTIVE", nil),
+	}})
+
+	h.Require.NoError(h.Execute("loops", "run", "list"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "BASE MODEL")
+	h.Require.NotContains(out, "OWNER")
+	h.Require.Contains(out, "r-1")
+	h.Require.NotContains(out, "r-2")
+}
+
+func Test_Loops_Run_List_All(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/loops/runs", 200, map[string]any{"runs": []any{
+		loopsRunFixture("r-1", "ACTIVE", nil),
+		loopsRunFixture("r-2", "INACTIVE", nil),
+	}})
+
+	h.Require.NoError(h.Execute("loops", "run", "list", "--all"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "r-1")
+	h.Require.Contains(out, "r-2")
+	h.Require.Contains(out, "INACTIVE")
+}
+
+func Test_Loops_Run_List_Org(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/loops/runs", 200, map[string]any{"runs": []any{
+		loopsRunFixture("r-1", "ACTIVE", nil),
+	}})
+
+	h.Require.NoError(h.Execute("loops", "run", "list", "--org"))
+	h.Require.Equal("org", m.FindCall("GET", "/v1/loops/runs").Query().Get("scope"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "OWNER")
+	h.Require.Contains(out, "owner@example.com")
+}
+
+func Test_Loops_Run_List_BaseModelFilter(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/loops/runs", 200, map[string]any{"runs": []any{}})
+
+	h.Require.NoError(h.Execute("loops", "run", "list", "--base-model", "Qwen/Qwen3-8B"))
+	q := m.FindCall("GET", "/v1/loops/runs").Query()
+	h.Require.Equal("Qwen/Qwen3-8B", q.Get("base_model"))
+	_, hasScope := q["scope"]
+	h.Require.False(hasScope)
+}
+
+func Test_Loops_Run_List_Direction(t *testing.T) {
+	older := loopsRunFixture("r-old", "ACTIVE", nil)
+	older["created_at"] = "2026-05-01T12:00:00Z"
+	newer := loopsRunFixture("r-new", "ACTIVE", nil)
+	newer["created_at"] = "2026-05-14T12:00:00Z"
+
+	for _, tc := range []struct{ direction, first, second string }{
+		{"desc", "r-new", "r-old"},
+		{"asc", "r-old", "r-new"},
+	} {
+		h := NewCommandHarness(t)
+		// Served oldest-first so the default desc ordering is a real re-sort.
+		h.MockManagementAPI().SetRoute("GET", "/v1/loops/runs", 200,
+			map[string]any{"runs": []any{older, newer}})
+
+		h.Require.NoError(h.Execute("loops", "run", "list", "--direction", tc.direction))
+		out := h.Stdout.String()
+		h.Require.Less(strings.Index(out, tc.first), strings.Index(out, tc.second),
+			"--direction %s should list %s before %s", tc.direction, tc.first, tc.second)
+	}
+}
+
+func Test_Loops_Run_List_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/loops/runs", 200, map[string]any{"runs": []any{
+		loopsRunFixture("r-1", "ACTIVE", nil),
+		loopsRunFixture("r-2", "INACTIVE", nil),
+	}})
+
+	h.Require.NoError(h.Execute("loops", "run", "list", "--output", "json"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, `"runs"`)
+	h.Require.Contains(out, `"id": "r-1"`)
+	// The default filtering applies to the JSON output too.
+	h.Require.NotContains(out, `"id": "r-2"`)
+}
+
+func Test_Loops_Run_Describe(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", loopsRunPath, 200, map[string]any{
+		"run": loopsRunFixture("r-1", "ACTIVE",
+			loopsSamplerFixture("s-1", "ACTIVE", "H100", 8, 1, "2026-05-14T12:00:00Z")),
+	})
+
+	h.Require.NoError(h.Execute("loops", "run", "describe", "--run-id", "r-1"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "r-1")
+	h.Require.Contains(out, "Qwen/Qwen3-8B")
+	h.Require.Contains(out, "owner@example.com")
+	h.Require.Contains(out, "sess-1")
+	h.Require.Contains(out, "dep-1")
+	h.Require.Contains(out, "Sampler")
+	h.Require.Contains(out, "s-1")
+	h.Require.Contains(out, "sdep-1")
+	h.Require.Contains(out, "model-1")
+}
+
+func Test_Loops_Run_Describe_NoSampler(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", loopsRunPath, 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+
+	h.Require.NoError(h.Execute("loops", "run", "describe", "--run-id", "r-1"))
+	h.Require.NotContains(h.Stdout.String(), "Sampler")
+}
+
+func Test_Loops_Run_Describe_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", loopsRunPath, 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+
+	h.Require.NoError(h.Execute("loops", "run", "describe", "--run-id", "r-1", "--output", "json"))
+	h.Require.Contains(h.Stdout.String(), `"id": "r-1"`)
+}
+
+func Test_Loops_Run_Describe_MissingRunID(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("loops", "run", "describe")
+	h.Require.ErrorContains(err, "run-id")
+}
+
+func Test_Loops_Run_Deactivate_Yes(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", "/v1/loops/runs/r-1/deactivate", 200, map[string]any{
+		"id": "r-1", "base_model": "Qwen/Qwen3-8B",
+		"user": map[string]any{"email": "owner@example.com"},
+	})
+
+	h.Require.NoError(h.Execute("loops", "run", "deactivate", "--run-id", "r-1", "--yes"))
+	h.Require.NotNil(m.FindCall("POST", "/v1/loops/runs/r-1/deactivate"))
+	h.Require.Equal("", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "Deactivated Loops run r-1")
+}
+
+func Test_Loops_Run_Deactivate_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("POST", "/v1/loops/runs/r-1/deactivate", 200, map[string]any{
+		"id": "r-1", "base_model": "Qwen/Qwen3-8B",
+		"user": map[string]any{"email": "owner@example.com"},
+	})
+
+	h.Require.NoError(h.Execute("loops", "run", "deactivate",
+		"--run-id", "r-1", "--yes", "--output", "json"))
+	h.Require.Contains(h.Stdout.String(), `"base_model": "Qwen/Qwen3-8B"`)
+}
+
+func Test_Loops_Run_Deactivate_NoTTY_RequiresYes(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+
+	err := h.Execute("loops", "run", "deactivate", "--run-id", "r-1")
+	h.Require.ErrorContains(err, "stdin is not a terminal")
+	h.Require.Nil(m.FindCall("POST", "/v1/loops/runs/r-1/deactivate"))
+}
+
+func Test_Loops_Run_Logs_Trainer(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", loopsRunPath, 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+	logAt := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	m.SetRoute("GET", loopsTrainerLogsPath, 200, logsResponse(
+		map[string]any{"timestamp": strconv.FormatInt(logAt.UnixNano(), 10), "message": "step 1", "replica": "g0"},
+	))
+
+	h.Require.NoError(h.Execute("loops", "run", "logs", "--run-id", "r-1", "--min-level", "info"))
+	h.Require.Contains(h.Stdout.String(), "(g0) step 1")
+	// The trainer logs endpoint is always queried newest-first so paging works.
+	q := m.FindCall("GET", loopsTrainerLogsPath).Query()
+	h.Require.Equal("desc", q.Get("direction"))
+	h.Require.Equal("INFO", q.Get("min_level"))
+	h.Require.Nil(m.FindCall("GET", loopsSamplerLogsPath))
+}
+
+func Test_Loops_Run_Logs_Sampler(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", loopsRunPath, 200, map[string]any{
+		"run": loopsRunFixture("r-1", "ACTIVE",
+			loopsSamplerFixture("s-1", "ACTIVE", "H100", 8, 1, "2026-05-14T12:00:00Z")),
+	})
+	m.SetRoute("GET", loopsSamplerLogsPath, 200, logsResponse(
+		map[string]any{"timestamp": "1", "message": "serving", "replica": nil},
+	))
+
+	h.Require.NoError(h.Execute("loops", "run", "logs", "--run-id", "r-1", "--sampler"))
+	h.Require.Contains(h.Stdout.String(), "serving")
+	h.Require.NotNil(m.FindCall("GET", loopsSamplerLogsPath))
+	h.Require.Nil(m.FindCall("GET", loopsTrainerLogsPath))
+}
+
+func Test_Loops_Run_Logs_Sampler_MissingSampler(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", loopsRunPath, 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+
+	err := h.Execute("loops", "run", "logs", "--run-id", "r-1", "--sampler")
+	h.Require.ErrorContains(err, "has no paired sampler")
+	h.Require.Nil(m.FindCall("GET", loopsSamplerLogsPath))
+}
+
+func Test_Loops_Run_Logs_Tail_StopsOnTerminalTrainerStatus(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", loopsRunPath, 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+	m.SetRoute("GET", loopsTrainerLogsPath, 200, logsResponse(
+		map[string]any{"timestamp": "1", "message": "step 1", "replica": nil},
+	))
+	m.SetRoute("GET", loopsTrainerPath, 200, map[string]any{
+		"deployment": loopsDeploymentFixture("dep-1", "STOPPED", "H100", 8, 1, "2026-05-14T12:00:00Z", nil),
+	})
+	h.Context = cmd.WithSleep(h.Context, func(_ context.Context, _ time.Duration) error { return nil })
+
+	h.Require.NoError(h.Execute("loops", "run", "logs", "--run-id", "r-1", "--tail"))
+	h.Require.Contains(h.Stdout.String(), "step 1")
+	h.Require.Contains(h.Stderr.String(), "Tailing stopped: deployment status STOPPED")
+}
+
+func Test_Loops_Run_Logs_Tail_StopsOnUnknownTrainerStatus(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", loopsRunPath, 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+	m.SetRoute("GET", loopsTrainerLogsPath, 200, logsResponse(
+		map[string]any{"timestamp": "1", "message": "step 1", "replica": nil},
+	))
+	m.SetRoute("GET", loopsTrainerPath, 200, map[string]any{
+		"deployment": loopsDeploymentFixture("dep-1", "SOME_NEW_STATE", "H100", 8, 1, "2026-05-14T12:00:00Z", nil),
+	})
+	h.Context = cmd.WithSleep(h.Context, func(_ context.Context, _ time.Duration) error { return nil })
+
+	h.Require.NoError(h.Execute("loops", "run", "logs", "--run-id", "r-1", "--tail"))
+	h.Require.Contains(h.Stderr.String(), "SOME_NEW_STATE")
+}
+
+func Test_Loops_Run_Logs_Tail_KeepsGoingWhileTrainerRuns(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", loopsRunPath, 200,
+		map[string]any{"run": loopsRunFixture("r-1", "ACTIVE", nil)})
+	logsCalls := 0
+	m.SetRouteFunc("GET", loopsTrainerLogsPath, func(w http.ResponseWriter, _ *http.Request) {
+		logsCalls++
+		payload := logsResponse(map[string]any{"timestamp": "1", "message": "step 1", "replica": nil})
+		if logsCalls > 1 {
+			payload = logsResponse(
+				map[string]any{"timestamp": "1", "message": "step 1", "replica": nil},
+				map[string]any{"timestamp": "2", "message": "step 2", "replica": nil},
+			)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	})
+	statusCalls := 0
+	m.SetRouteFunc("GET", loopsTrainerPath, func(w http.ResponseWriter, _ *http.Request) {
+		statusCalls++
+		status := "RUNNING"
+		if statusCalls > 1 {
+			status = "STOPPED"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"deployment": loopsDeploymentFixture("dep-1", status, "H100", 8, 1, "2026-05-14T12:00:00Z", nil),
+		})
+	})
+	h.Context = cmd.WithSleep(h.Context, func(_ context.Context, _ time.Duration) error { return nil })
+
+	h.Require.NoError(h.Execute("loops", "run", "logs", "--run-id", "r-1", "--tail"))
+	out := h.Stdout.String()
+	// RUNNING keeps the tail alive for a second poll, and the repeated line is
+	// not emitted twice.
+	h.Require.Equal(1, strings.Count(out, "step 1"))
+	h.Require.Contains(out, "step 2")
+}
+
+func Test_Loops_Run_Logs_TailWithFilterRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+
+	err := h.Execute("loops", "run", "logs", "--run-id", "r-1", "--tail", "--min-level", "info")
+	h.Require.ErrorContains(err, "--tail cannot be combined")
+	// The flags are rejected before the run is resolved, so a flag mistake is not
+	// masked by a lookup failure.
+	h.Require.Empty(m.Calls())
+}
+
+func Test_Loops_Run_Logs_SinceOver7DaysRejectedBeforeLookup(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+
+	err := h.Execute("loops", "run", "logs", "--run-id", "r-1", "--since", "8d")
+	h.Require.ErrorContains(err, "at most 7d")
+	h.Require.Empty(m.Calls())
+}
+
+func Test_Loops_Usage_Empty(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/loops/deployments", 200, map[string]any{"deployments": []any{}})
+	m.SetRoute("GET", "/v1/loops/samplers", 200, map[string]any{"samplers": []any{}})
+
+	h.Require.NoError(h.Execute("loops", "usage"))
+	h.Require.Contains(h.Stdout.String(), "Trainer GPUs: 0 in use, 0 scaled to zero.")
+	h.Require.Contains(h.Stderr.String(), "No Loops trainers or samplers found.")
+}
+
+func Test_Loops_Usage_PairedSamplerNotDoubleCounted(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	sampler := loopsSamplerFixture("s-1", "ACTIVE", "H100", 2, 1, "2026-05-14T12:00:00Z")
+	m.SetRoute("GET", "/v1/loops/deployments", 200, map[string]any{"deployments": []any{
+		loopsDeploymentFixture("dep-1", "RUNNING", "H100", 8, 1, "2026-05-14T12:00:00Z", sampler),
+	}})
+	// The same sampler also comes back from the samplers listing.
+	m.SetRoute("GET", "/v1/loops/samplers", 200, map[string]any{"samplers": []any{sampler}})
+
+	h.Require.NoError(h.Execute("loops", "usage", "--output", "json"))
+	var result struct {
+		Summary struct {
+			TrainerInUse int `json:"trainer_in_use"`
+			SamplerInUse int `json:"sampler_in_use"`
+		} `json:"summary"`
+		Rows []map[string]any `json:"rows"`
+	}
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &result))
+	h.Require.Len(result.Rows, 1)
+	h.Require.Equal(8, result.Summary.TrainerInUse)
+	h.Require.Equal(2, result.Summary.SamplerInUse)
+	h.Require.Equal("r-dep-1", result.Rows[0]["run_id"])
+}
+
+func Test_Loops_Usage_StandaloneSampler(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/loops/deployments", 200, map[string]any{"deployments": []any{}})
+	m.SetRoute("GET", "/v1/loops/samplers", 200, map[string]any{"samplers": []any{
+		loopsSamplerFixture("s-1", "ACTIVE", "H100", 2, 1, "2026-05-14T12:00:00Z"),
+	}})
+
+	h.Require.NoError(h.Execute("loops", "usage"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "Sampler GPUs: 2 in use, 0 scaled to zero.")
+	h.Require.Contains(out, "H100 (2 GPUs)")
+}
+
+func Test_Loops_Usage_MultiNodeGPUCell(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/loops/deployments", 200, map[string]any{"deployments": []any{
+		loopsDeploymentFixture("dep-1", "RUNNING", "H100", 8, 2, "2026-05-14T12:00:00Z", nil),
+	}})
+	m.SetRoute("GET", "/v1/loops/samplers", 200, map[string]any{"samplers": []any{}})
+
+	h.Require.NoError(h.Execute("loops", "usage"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "H100 (16 GPUs across 2 nodes)")
+	h.Require.Contains(out, "Trainer GPUs: 16 in use")
+}
+
+func Test_Loops_Usage_HidesIdleRowsButCountsThem(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/loops/deployments", 200, map[string]any{"deployments": []any{
+		loopsDeploymentFixture("dep-live", "RUNNING", "H100", 8, 1, "2026-05-14T12:00:00Z", nil),
+		loopsDeploymentFixture("dep-idle", "SCALED_TO_ZERO", "H100", 8, 1, "2026-05-13T12:00:00Z", nil),
+		loopsDeploymentFixture("dep-dead", "FAILED", "H100", 8, 1, "2026-05-12T12:00:00Z", nil),
+	}})
+	m.SetRoute("GET", "/v1/loops/samplers", 200, map[string]any{"samplers": []any{}})
+
+	h.Require.NoError(h.Execute("loops", "usage"))
+	out := h.Stdout.String()
+	// The summary counts live and idle GPUs; the terminal row counts in neither.
+	h.Require.Contains(out, "Trainer GPUs: 8 in use, 8 scaled to zero.")
+	h.Require.Contains(out, "r-dep-live")
+	h.Require.NotContains(out, "r-dep-idle")
+	h.Require.NotContains(out, "r-dep-dead")
+	h.Require.Contains(h.Stderr.String(), "2 allocation(s) holding no live GPUs hidden")
+}
+
+func Test_Loops_Usage_All(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/loops/deployments", 200, map[string]any{"deployments": []any{
+		loopsDeploymentFixture("dep-live", "RUNNING", "H100", 8, 1, "2026-05-14T12:00:00Z", nil),
+		loopsDeploymentFixture("dep-idle", "SCALED_TO_ZERO", "H100", 8, 1, "2026-05-13T12:00:00Z", nil),
+	}})
+	m.SetRoute("GET", "/v1/loops/samplers", 200, map[string]any{"samplers": []any{}})
+
+	h.Require.NoError(h.Execute("loops", "usage", "--all"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "r-dep-live")
+	h.Require.Contains(out, "r-dep-idle")
+	// Rows are newest-first.
+	h.Require.Less(strings.Index(out, "r-dep-live"), strings.Index(out, "r-dep-idle"))
+	h.Require.NotContains(h.Stderr.String(), "hidden")
+}
+
+func Test_Loops_Usage_ScaledToZeroSampler(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	sampler := loopsSamplerFixture("s-1", "SCALED_TO_ZERO", "H100", 2, 1, "2026-05-14T12:00:00Z")
+	m.SetRoute("GET", "/v1/loops/deployments", 200, map[string]any{"deployments": []any{
+		loopsDeploymentFixture("dep-1", "SCALED_TO_ZERO", "H100", 8, 1, "2026-05-14T12:00:00Z", sampler),
+	}})
+	m.SetRoute("GET", "/v1/loops/samplers", 200, map[string]any{"samplers": []any{sampler}})
+
+	h.Require.NoError(h.Execute("loops", "usage"))
+	h.Require.Contains(h.Stdout.String(),
+		"Trainer GPUs: 0 in use, 8 scaled to zero. Sampler GPUs: 0 in use, 2 scaled to zero.")
+	// Neither half holds live GPUs, so the row is hidden by default.
+	h.Require.Contains(h.Stderr.String(), "1 allocation(s) holding no live GPUs hidden")
+}
+
+func Test_Loops_Usage_IdleTrainerFallsBackToLatestRun(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	idle := loopsDeploymentFixture("dep-1", "SCALED_TO_ZERO", "H100", 8, 1, "2026-05-14T12:00:00Z", nil)
+	idle["active_run_id"] = nil
+	idle["latest_run_id"] = "r-latest"
+	m.SetRoute("GET", "/v1/loops/deployments", 200, map[string]any{"deployments": []any{idle}})
+	m.SetRoute("GET", "/v1/loops/samplers", 200, map[string]any{"samplers": []any{}})
+
+	h.Require.NoError(h.Execute("loops", "usage", "--all"))
+	h.Require.Contains(h.Stdout.String(), "r-latest")
+}
+
+func Test_Loops_Usage_Org(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/loops/deployments", 200, map[string]any{"deployments": []any{
+		loopsDeploymentFixture("dep-1", "RUNNING", "H100", 8, 1, "2026-05-14T12:00:00Z", nil),
+	}})
+	m.SetRoute("GET", "/v1/loops/samplers", 200, map[string]any{"samplers": []any{}})
+
+	h.Require.NoError(h.Execute("loops", "usage", "--org"))
+	h.Require.Equal("org", m.FindCall("GET", "/v1/loops/deployments").Query().Get("scope"))
+	h.Require.Equal("org", m.FindCall("GET", "/v1/loops/samplers").Query().Get("scope"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "OWNER")
+	h.Require.Contains(out, "owner@example.com")
+}
+
+func Test_Loops_Usage_UserImpliesOrg(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	other := loopsDeploymentFixture("dep-2", "RUNNING", "H100", 8, 1, "2026-05-13T12:00:00Z", nil)
+	other["user"] = map[string]any{"email": "someone@example.com"}
+	m.SetRoute("GET", "/v1/loops/deployments", 200, map[string]any{"deployments": []any{
+		loopsDeploymentFixture("dep-1", "RUNNING", "H100", 8, 1, "2026-05-14T12:00:00Z", nil),
+		other,
+	}})
+	m.SetRoute("GET", "/v1/loops/samplers", 200, map[string]any{"samplers": []any{}})
+
+	h.Require.NoError(h.Execute("loops", "usage", "--user", "someone@example.com"))
+	h.Require.Equal("org", m.FindCall("GET", "/v1/loops/deployments").Query().Get("scope"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "OWNER")
+	h.Require.Contains(out, "r-dep-2")
+	h.Require.NotContains(out, "r-dep-1")
+	// Only the matching owner's GPUs are summarized.
+	h.Require.Contains(out, "Trainer GPUs: 8 in use")
+}
+
+func Test_Loops_Usage_FilteredTrainersSamplerNotStandalone(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	sampler := loopsSamplerFixture("s-1", "ACTIVE", "H100", 2, 1, "2026-05-14T12:00:00Z")
+	other := loopsDeploymentFixture("dep-2", "RUNNING", "H100", 8, 1, "2026-05-13T12:00:00Z", sampler)
+	other["user"] = map[string]any{"email": "someone@example.com"}
+	m.SetRoute("GET", "/v1/loops/deployments", 200, map[string]any{"deployments": []any{other}})
+	m.SetRoute("GET", "/v1/loops/samplers", 200, map[string]any{"samplers": []any{sampler}})
+
+	h.Require.NoError(h.Execute("loops", "usage", "--user", "nobody@example.com"))
+	// The owner filter drops the trainer row; its sampler must not resurface as a
+	// standalone row.
+	h.Require.Contains(h.Stdout.String(), "Sampler GPUs: 0 in use")
+	h.Require.Contains(h.Stderr.String(), "No Loops trainers or samplers found.")
+}
+
+func Test_Loops_Usage_SamplerWithoutInstanceType(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/loops/deployments", 200, map[string]any{"deployments": []any{}})
+	m.SetRoute("GET", "/v1/loops/samplers", 200, map[string]any{"samplers": []any{
+		loopsSamplerFixture("s-1", "BUILDING", "", 0, 1, "2026-05-14T12:00:00Z"),
+	}})
+
+	h.Require.NoError(h.Execute("loops", "usage"))
+	out := h.Stdout.String()
+	// A sampler still coming up reports no instance type, so it contributes no
+	// GPUs but is still a live row.
+	h.Require.Contains(out, "Sampler GPUs: 0 in use, 0 scaled to zero.")
+	h.Require.Contains(out, "BUILDING")
+}
+
+func Test_Loops_Checkpoint_List_ByRun(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/loops/checkpoints", 200, map[string]any{"checkpoints": []any{
+		loopsCheckpointFixture("cp-1", "r-1", "sampler", "2026-05-14T12:00:00Z"),
+	}})
+
+	h.Require.NoError(h.Execute("loops", "checkpoint", "list", "--run-id", "r-1"))
+	q := m.FindCall("GET", "/v1/loops/checkpoints").Query()
+	h.Require.Equal("r-1", q.Get("run_id"))
+	_, hasBaseModel := q["base_model"]
+	h.Require.False(hasBaseModel)
+	out := h.Stdout.String()
+	h.Require.Contains(out, "cp-1")
+	h.Require.Contains(out, "checkpoint-cp-1")
+	h.Require.Contains(out, "sampler")
+}
+
+func Test_Loops_Checkpoint_List_ByBaseModel(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/loops/checkpoints", 200, map[string]any{"checkpoints": []any{}})
+
+	h.Require.NoError(h.Execute("loops", "checkpoint", "list", "--base-model", "Qwen/Qwen3-8B"))
+	q := m.FindCall("GET", "/v1/loops/checkpoints").Query()
+	h.Require.Equal("Qwen/Qwen3-8B", q.Get("base_model"))
+	_, hasRunID := q["run_id"]
+	h.Require.False(hasRunID)
+	h.Require.Contains(h.Stderr.String(), "No Loops checkpoints found.")
+}
+
+func Test_Loops_Checkpoint_List_RunAndBaseModelRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("loops", "checkpoint", "list",
+		"--run-id", "r-1", "--base-model", "Qwen/Qwen3-8B")
+	h.Require.Error(err)
+}
+
+func Test_Loops_Checkpoint_List_ScopeRequired(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("loops", "checkpoint", "list")
+	h.Require.Error(err)
+}
+
+func Test_Loops_Checkpoint_List_Direction(t *testing.T) {
+	// The server returns newest-first, so only asc re-sorts.
+	for _, tc := range []struct{ direction, first, second string }{
+		{"desc", "cp-new", "cp-old"},
+		{"asc", "cp-old", "cp-new"},
+	} {
+		h := NewCommandHarness(t)
+		h.MockManagementAPI().SetRoute("GET", "/v1/loops/checkpoints", 200, map[string]any{
+			"checkpoints": []any{
+				loopsCheckpointFixture("cp-new", "r-1", "sampler", "2026-05-14T12:00:00Z"),
+				loopsCheckpointFixture("cp-old", "r-1", "sampler", "2026-05-01T12:00:00Z"),
+			},
+		})
+
+		h.Require.NoError(h.Execute("loops", "checkpoint", "list",
+			"--run-id", "r-1", "--direction", tc.direction))
+		out := h.Stdout.String()
+		h.Require.Less(strings.Index(out, tc.first), strings.Index(out, tc.second),
+			"--direction %s should list %s before %s", tc.direction, tc.first, tc.second)
+	}
+}
+
+func Test_Loops_Checkpoint_List_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/loops/checkpoints", 200, map[string]any{
+		"checkpoints": []any{loopsCheckpointFixture("cp-1", "r-1", "trainer", "2026-05-14T12:00:00Z")},
+	})
+
+	h.Require.NoError(h.Execute("loops", "checkpoint", "list", "--run-id", "r-1", "--output", "json"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, `"checkpoints"`)
+	h.Require.Contains(out, `"id": "cp-1"`)
+}
+
+// loopsCheckpointFile is a presigned file payload for `loops checkpoint files`.
+func loopsCheckpointFile(name string) map[string]any {
+	return map[string]any{
+		"last_modified":      "2026-05-14T12:00:00Z",
+		"node_rank":          0,
+		"relative_file_name": name,
+		"size_bytes":         1024,
+		"url":                "https://files.example.com/" + name,
+	}
+}
+
+// serveCheckpointFilePages serves one page per entry in pages, keyed off the
+// page_token offset, handing out a next_page_token for every page but the last.
+func serveCheckpointFilePages(m *MockManagementAPI, pages [][]map[string]any, tokens *[]string) {
+	m.SetRouteFunc("GET", "/v1/loops/checkpoints/cp-1/files", func(w http.ResponseWriter, r *http.Request) {
+		token := r.URL.Query().Get("page_token")
+		*tokens = append(*tokens, token)
+		index := 0
+		if token != "" {
+			index, _ = strconv.Atoi(token)
+		}
+		payload := map[string]any{"presigned_urls": []map[string]any{}, "total_count": 0}
+		if index < len(pages) {
+			payload["presigned_urls"] = pages[index]
+			payload["total_count"] = len(pages[index])
+		}
+		if index+1 < len(pages) {
+			payload["next_page_token"] = index + 1
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	})
+}
+
+func Test_Loops_Checkpoint_Files_SinglePage(t *testing.T) {
+	h := NewCommandHarness(t)
+	var tokens []string
+	serveCheckpointFilePages(h.MockManagementAPI(),
+		[][]map[string]any{{loopsCheckpointFile("model.safetensors")}}, &tokens)
+
+	h.Require.NoError(h.Execute("loops", "checkpoint", "files", "--checkpoint-id", "cp-1"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "NAME")
+	h.Require.Contains(out, "model.safetensors")
+	h.Require.Contains(out, "https://files.example.com/model.safetensors")
+	h.Require.Equal([]string{""}, tokens)
+}
+
+func Test_Loops_Checkpoint_Files_PagesThroughEveryPage(t *testing.T) {
+	h := NewCommandHarness(t)
+	var tokens []string
+	serveCheckpointFilePages(h.MockManagementAPI(), [][]map[string]any{
+		{loopsCheckpointFile("a.bin")},
+		{loopsCheckpointFile("b.bin")},
+		{loopsCheckpointFile("c.bin")},
+	}, &tokens)
+
+	h.Require.NoError(h.Execute("loops", "checkpoint", "files", "--checkpoint-id", "cp-1"))
+	out := h.Stdout.String()
+	for _, name := range []string{"a.bin", "b.bin", "c.bin"} {
+		h.Require.Contains(out, name)
+	}
+	// The first request sends no token; each later one sends the previous page's.
+	h.Require.Equal([]string{"", "1", "2"}, tokens)
+}
+
+func Test_Loops_Checkpoint_Files_EmptyPageEndsWalk(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	// A server that hands back a token forever must not spin: an empty page ends
+	// the walk.
+	calls := 0
+	m.SetRouteFunc("GET", "/v1/loops/checkpoints/cp-1/files", func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"presigned_urls":  []map[string]any{},
+			"next_page_token": 1,
+			"total_count":     0,
+		})
+	})
+
+	h.Require.NoError(h.Execute("loops", "checkpoint", "files", "--checkpoint-id", "cp-1"))
+	h.Require.Equal(1, calls)
+	h.Require.Equal("", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "No files found for this Loops checkpoint.")
+}
+
+func Test_Loops_Checkpoint_Files_JSONStreamsAcrossPages(t *testing.T) {
+	h := NewCommandHarness(t)
+	var tokens []string
+	serveCheckpointFilePages(h.MockManagementAPI(), [][]map[string]any{
+		{loopsCheckpointFile("a.bin")},
+		{loopsCheckpointFile("b.bin")},
+	}, &tokens)
+
+	h.Require.NoError(h.Execute("loops", "checkpoint", "files",
+		"--checkpoint-id", "cp-1", "--output", "json"))
+	out := strings.TrimSpace(h.Stdout.String())
+	// One flat JSON array of files across both pages, with no response envelope.
+	h.Require.True(strings.HasPrefix(out, "["))
+	h.Require.True(strings.HasSuffix(out, "]"))
+	h.Require.NotContains(out, "presigned_urls")
+	h.Require.NotContains(out, "total_count")
+	var files []map[string]any
+	h.Require.NoError(json.Unmarshal([]byte(out), &files))
+	h.Require.Len(files, 2)
+	h.Require.Equal("a.bin", files[0]["relative_file_name"])
+	h.Require.Equal("b.bin", files[1]["relative_file_name"])
+}
+
+func Test_Loops_Checkpoint_Files_JSONL(t *testing.T) {
+	h := NewCommandHarness(t)
+	var tokens []string
+	serveCheckpointFilePages(h.MockManagementAPI(), [][]map[string]any{
+		{loopsCheckpointFile("a.bin")},
+		{loopsCheckpointFile("b.bin")},
+	}, &tokens)
+
+	h.Require.NoError(h.Execute("loops", "checkpoint", "files",
+		"--checkpoint-id", "cp-1", "--output", "jsonl"))
+	lines := strings.Split(strings.TrimRight(h.Stdout.String(), "\n"), "\n")
+	h.Require.Len(lines, 2)
+	for _, line := range lines {
+		var v map[string]any
+		h.Require.NoError(json.Unmarshal([]byte(line), &v))
+	}
+}
+
+func Test_Loops_Checkpoint_Files_MissingCheckpointID(t *testing.T) {
+	h := NewCommandHarness(t)
+	err := h.Execute("loops", "checkpoint", "files")
+	h.Require.ErrorContains(err, "checkpoint-id")
+}

--- a/internal/cmd/command.model_deployment_logs.go
+++ b/internal/cmd/command.model_deployment_logs.go
@@ -188,7 +188,7 @@ func runLogsCommand(ctx *CommandContext, flags *cmd.LogFlags, fetchLogs logFetch
 
 	if flags.Tail {
 		res := tailLogs(ctx, tailLogsOptions{FetchLogs: fetchLogs, FetchStatus: fetchStatus})
-		if err := emitLogs(ctx, res.Logs); err != nil {
+		if _, err := emitLogs(ctx, res.Logs); err != nil {
 			return err
 		}
 		if status := res.FinalFetchedStatus(); status != nil {
@@ -251,11 +251,13 @@ func runLogsCommand(ctx *CommandContext, flags *cmd.LogFlags, fetchLogs logFetch
 	// paginateLogs signals why the stream ended via a sentinel error after the
 	// last line it emitted; hitting the limit is a note, any other error (e.g. a
 	// single-millisecond burst) is a command failure.
-	err := emitLogs(ctx, paginateLogs(q, startMs, endMs, flags.Limit, flags.PageSize, fetchLogs))
+	emitted, err := emitLogs(ctx, paginateLogs(q, startMs, endMs, flags.Limit, flags.PageSize, fetchLogs))
 	if errors.Is(err, errLogsHitLimit) {
 		ctx.Logf("Reached the --limit of %d log lines; older lines in the window were omitted. Increase --limit or use --limit 0 for no limit.\n", flags.Limit)
 	} else if err != nil {
 		return err
+	} else if emitted == 0 && !ctx.JSON {
+		ctx.LogLine("No logs found.")
 	}
 	return nil
 }
@@ -364,25 +366,28 @@ func logTimestampMs(ts string) (int64, bool) {
 // output mode. For ctx.JSON (both json and jsonl) it uses a JSON array writer so
 // jsonl streams one record per line and json buffers into a single closed
 // array. For text it formats each line via FormatDeploymentLogLine.
-func emitLogs(ctx *CommandContext, logs iter.Seq2[*managementapi.Log, error]) error {
+func emitLogs(ctx *CommandContext, logs iter.Seq2[*managementapi.Log, error]) (int, error) {
+	emitted := 0
 	if ctx.JSON {
 		w := ctx.NewJSONArrayWriter()
 		defer w.Close()
 		for log, err := range logs {
 			if err != nil {
-				return err
+				return emitted, err
 			}
 			w.Write(log)
+			emitted++
 		}
-		return nil
+		return emitted, nil
 	}
 	for log, err := range logs {
 		if err != nil {
-			return err
+			return emitted, err
 		}
 		ctx.OutputLine(FormatDeploymentLogLine(*log))
+		emitted++
 	}
-	return nil
+	return emitted, nil
 }
 
 // FormatDeploymentLogLine renders a log record as
@@ -489,6 +494,7 @@ func tailLogs(ctx *CommandContext, opts tailLogsOptions) *TailDeploymentLogsResu
 			warmupDeadline = ctx.Now().Add(opts.WarmupTimeout)
 		}
 		warmedUp := false
+		firstPoll := true
 
 		for {
 			nowMs := ctx.Now().UnixMilli()
@@ -540,12 +546,16 @@ func tailLogs(ctx *CommandContext, opts tailLogsOptions) *TailDeploymentLogsResu
 			}
 			lastPollMs = nowMs
 
-			// Once any log has been seen, refresh status each poll so we can
-			// stop when the deployment leaves a runnable state. This is skipped
-			// until the first log is seen, similar to Truss.
+			// Refresh status once any log has been seen, so the tail ends when the
+			// deployment leaves a runnable state. Truss gates this on the first log
+			// alone; we also check on the very first poll, because a workload that
+			// stopped before the log window opened has no logs to trigger the check
+			// and would otherwise be tailed forever with nothing to show. Staying
+			// silent while a live workload produces nothing is intentional: that is
+			// what tailing is for, and it keeps the poll at one request.
 			// TODO: should the management logs API return current status so
 			// we can drop this extra round-trip per poll?
-			if len(seen) > 0 {
+			if firstPoll || len(seen) > 0 {
 				status, err := opts.FetchStatus()
 				if err != nil {
 					yield(nil, fmt.Errorf("fetch deployment status: %w", err))
@@ -556,6 +566,7 @@ func tailLogs(ctx *CommandContext, opts tailLogsOptions) *TailDeploymentLogsResu
 					return
 				}
 			}
+			firstPoll = false
 
 			if err := ctx.Sleep(deploymentLogPollInterval); err != nil {
 				yield(nil, err)

--- a/internal/cmd/command.model_deployment_logs.go
+++ b/internal/cmd/command.model_deployment_logs.go
@@ -32,6 +32,9 @@ func init() {
 }
 
 func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentLogsFlags) error {
+	if err := validateLogFlags(ctx, &flags.LogFlags); err != nil {
+		return err
+	}
 	api, err := ctx.NewManagementClient()
 	if err != nil {
 		return err
@@ -44,8 +47,12 @@ func commandModelDeploymentLogs(ctx *CommandContext, flags *cmd.ModelDeploymentL
 	fetchLogs := func(q logQuery) (*managementapi.GetLogsResponse, error) {
 		return api.API().GetModelsDeploymentsLogs(ctx, ref.ModelID, ref.DeploymentID, deploymentLogParams(q))
 	}
-	fetchStatus := func() (*managementapi.Deployment, error) {
-		return api.API().GetModelsDeploymentsDeploymentId(ctx, ref.ModelID, ref.DeploymentID)
+	fetchStatus := func() (*tailStatus, error) {
+		dep, err := api.API().GetModelsDeploymentsDeploymentId(ctx, ref.ModelID, ref.DeploymentID)
+		if err != nil {
+			return nil, err
+		}
+		return deploymentTailStatus(dep, false), nil
 	}
 	return runLogsCommand(ctx, &flags.LogFlags, fetchLogs, fetchStatus)
 }
@@ -68,10 +75,48 @@ type logQuery struct {
 // logFetcher fetches a page of logs for the given query.
 type logFetcher func(q logQuery) (*managementapi.GetLogsResponse, error)
 
-// statusFetcher resolves the deployment whose status gates a --tail loop. For a
-// deployment command it is the deployment itself; for an environment command it
-// is the environment's current deployment.
-type statusFetcher func() (*managementapi.Deployment, error)
+// tailStatus is the transport-neutral status that gates a --tail loop. Each log
+// source reports whether its workload is still producing logs, plus the status
+// name to show when tailing stops.
+type tailStatus struct {
+	// Label is the status name reported when tailing stops.
+	Label string
+	// Runnable reports whether the workload may still produce logs.
+	Runnable bool
+	// Deployment is the model deployment this status came from, when there is
+	// one. Only `model push` needs the full record, to fold the final state into
+	// its result; Loops trainer deployments leave it nil.
+	Deployment *managementapi.Deployment
+}
+
+// statusFetcher resolves the status gating a --tail loop. For a deployment
+// command it is the deployment itself; for an environment command it is the
+// environment's current deployment; for a Loops run it is the trainer
+// deployment.
+type statusFetcher func() (*tailStatus, error)
+
+// deploymentTailStatus classifies a model deployment for the tail loop. The
+// runnable set is {BUILDING, DEPLOYING, LOADING_MODEL, UPDATING, WAKING_UP},
+// plus ACTIVE unless stopOnActive is set. Any other status, including unknown
+// ones, stops the tail. A nil deployment, which is what an environment with
+// nothing promoted to it reports, also stops the tail.
+func deploymentTailStatus(dep *managementapi.Deployment, stopOnActive bool) *tailStatus {
+	if dep == nil {
+		return &tailStatus{Label: "NONE", Runnable: false}
+	}
+	runnable := false
+	switch dep.Status {
+	case managementapi.DeploymentStatus_BUILDING,
+		managementapi.DeploymentStatus_DEPLOYING,
+		managementapi.DeploymentStatus_LOADING_MODEL,
+		managementapi.DeploymentStatus_UPDATING,
+		managementapi.DeploymentStatus_WAKING_UP:
+		runnable = true
+	case managementapi.DeploymentStatus_ACTIVE:
+		runnable = !stopOnActive
+	}
+	return &tailStatus{Label: string(dep.Status), Runnable: runnable, Deployment: dep}
+}
 
 // deploymentLogParams maps a transport-neutral logQuery onto the deployment
 // logs GET query-params type.
@@ -91,16 +136,17 @@ func deploymentLogParams(q logQuery) managementapi.GetV1ModelsModelIdDeployments
 	}
 }
 
-// runLogsCommand implements the shared logs command flow for both deployment and
-// environment logs. It validates the flags, resolves the time window and
-// filters, and either tails or fetches a single window via the supplied
-// fetchers. fetchStatus is only used by the --tail path.
-func runLogsCommand(ctx *CommandContext, flags *cmd.LogFlags, fetchLogs logFetcher, fetchStatus statusFetcher) error {
-	hasStart := !flags.Start.IsZero()
-	hasEnd := !flags.End.IsZero()
+// validateLogFlags checks the log flags that stand on their own, needing
+// neither the resolved time window nor the entity being fetched. Every logs
+// command calls this before resolving that entity, so a flag mistake fails
+// before the first network call rather than behind a lookup error. The checks
+// that depend on the resolved window stay in runLogsCommand.
+func validateLogFlags(ctx *CommandContext, flags *cmd.LogFlags) error {
 	// Use Changed rather than the zero value so explicit --since 0 fails
 	// the positive-duration check below instead of being silently dropped.
 	hasSince := ctx.Command.Flags().Changed("since")
+	hasStart := !flags.Start.IsZero()
+	hasEnd := !flags.End.IsZero()
 	hasLimit := ctx.Command.Flags().Changed("limit")
 	hasPageSize := ctx.Command.Flags().Changed("page-size")
 	hasFilters := flags.MinLevel != "" || len(flags.Includes) > 0 || len(flags.Excludes) > 0 ||
@@ -111,6 +157,12 @@ func runLogsCommand(ctx *CommandContext, flags *cmd.LogFlags, fetchLogs logFetch
 	if hasSince && (hasStart || hasEnd) {
 		return cmd.NewErrUsagef("--since cannot be combined with --start or --end")
 	}
+	if hasSince && flags.Since <= 0 {
+		return cmd.NewErrUsagef("--since must be a positive duration")
+	}
+	if hasSince && flags.Since > maxLogTimeRange {
+		return cmd.NewErrUsagef("--since must be at most 7d")
+	}
 	if flags.Limit < 0 {
 		return cmd.NewErrUsagef("--limit must be zero (no limit) or a positive number")
 	}
@@ -120,14 +172,27 @@ func runLogsCommand(ctx *CommandContext, flags *cmd.LogFlags, fetchLogs logFetch
 	if flags.PageSize < 1 || flags.PageSize > maxLogPageSize {
 		return cmd.NewErrUsagef("--page-size must be between 1 and %d", maxLogPageSize)
 	}
+	return nil
+}
+
+// runLogsCommand implements the shared logs command flow for both deployment and
+// environment logs. It resolves the time window and filters, and either tails or
+// fetches a single window via the supplied fetchers. fetchStatus is only used by
+// the --tail path. Callers validate the standalone flags with validateLogFlags
+// before resolving their fetchers, so this only performs the window checks that
+// need those flags resolved against the current time.
+func runLogsCommand(ctx *CommandContext, flags *cmd.LogFlags, fetchLogs logFetcher, fetchStatus statusFetcher) error {
+	hasSince := ctx.Command.Flags().Changed("since")
+	hasStart := !flags.Start.IsZero()
+	hasEnd := !flags.End.IsZero()
 
 	if flags.Tail {
 		res := tailLogs(ctx, tailLogsOptions{FetchLogs: fetchLogs, FetchStatus: fetchStatus})
 		if err := emitLogs(ctx, res.Logs); err != nil {
 			return err
 		}
-		if dep := res.FinalFetchedDeployment(); dep != nil {
-			ctx.Logf("Tailing stopped: deployment status %s\n", dep.Status)
+		if status := res.FinalFetchedStatus(); status != nil {
+			ctx.Logf("Tailing stopped: deployment status %s\n", status.Label)
 		}
 		return nil
 	}
@@ -140,12 +205,6 @@ func runLogsCommand(ctx *CommandContext, flags *cmd.LogFlags, fetchLogs logFetch
 	now := ctx.Now()
 	var startMs, endMs int
 	if hasSince {
-		if flags.Since <= 0 {
-			return cmd.NewErrUsagef("--since must be a positive duration")
-		}
-		if flags.Since > maxLogTimeRange {
-			return cmd.NewErrUsagef("--since must be at most 7d")
-		}
 		endMs = int(now.UnixMilli())
 		startMs = int(now.Add(-flags.Since).UnixMilli())
 	} else {
@@ -363,18 +422,18 @@ type TailDeploymentLogsOptions struct {
 }
 
 // TailDeploymentLogsResult bundles the streaming log iterator with an
-// accessor for the final fetched deployment.
+// accessor for the final fetched status.
 type TailDeploymentLogsResult struct {
 	// Logs yields log records in arrival order. A non-nil error indicates
 	// the stream is ending due to that error and the log pointer is nil.
 	// The iterator is single-use.
 	Logs iter.Seq2[*managementapi.Log, error]
 
-	// FinalFetchedDeployment returns the deployment as last fetched when
-	// the tail loop ended. Valid only after Logs is fully consumed. Nil
-	// if the loop ended before any status fetch (no logs ever arrived, or
-	// ctx was cancelled during phase 1).
-	FinalFetchedDeployment func() *managementapi.Deployment
+	// FinalFetchedStatus returns the status as last fetched when the tail
+	// loop ended. Valid only after Logs is fully consumed. Nil if the loop
+	// ended before any status fetch (no logs ever arrived, or ctx was
+	// cancelled during phase 1).
+	FinalFetchedStatus func() *tailStatus
 }
 
 // TailDeploymentLogs tails a specific deployment's logs. It is a thin adapter
@@ -384,10 +443,13 @@ func TailDeploymentLogs(ctx *CommandContext, opts TailDeploymentLogsOptions) *Ta
 		FetchLogs: func(q logQuery) (*managementapi.GetLogsResponse, error) {
 			return opts.API.GetModelsDeploymentsLogs(ctx, opts.ModelID, opts.DeploymentID, deploymentLogParams(q))
 		},
-		FetchStatus: func() (*managementapi.Deployment, error) {
-			return opts.API.GetModelsDeploymentsDeploymentId(ctx, opts.ModelID, opts.DeploymentID)
+		FetchStatus: func() (*tailStatus, error) {
+			dep, err := opts.API.GetModelsDeploymentsDeploymentId(ctx, opts.ModelID, opts.DeploymentID)
+			if err != nil {
+				return nil, err
+			}
+			return deploymentTailStatus(dep, opts.StopOnActive), nil
 		},
-		StopOnActive:  opts.StopOnActive,
 		WarmupTimeout: opts.WarmupTimeout,
 	})
 }
@@ -397,13 +459,8 @@ func TailDeploymentLogs(ctx *CommandContext, opts TailDeploymentLogsOptions) *Ta
 type tailLogsOptions struct {
 	// FetchLogs fetches a poll window of logs. Required.
 	FetchLogs logFetcher
-	// FetchStatus resolves the deployment whose status gates the tail.
-	// Required.
+	// FetchStatus resolves the status gating the tail. Required.
 	FetchStatus statusFetcher
-
-	// StopOnActive stops the tail when the deployment reaches ACTIVE. By
-	// default ACTIVE is treated as a runnable state and tailing continues.
-	StopOnActive bool
 
 	// WarmupTimeout is how long to silently retry 404s from the logs API at
 	// the start of the tail, before any successful poll. Zero means no
@@ -411,15 +468,13 @@ type tailLogsOptions struct {
 	WarmupTimeout time.Duration
 }
 
-// tailLogs polls logs and streams new records until the gating deployment's
-// status leaves the runnable set or the context is cancelled. The runnable set
-// is {BUILDING, DEPLOYING, LOADING_MODEL, UPDATING, WAKING_UP} plus ACTIVE when
-// StopOnActive is false (default). Any other status, including unknown ones,
-// stops the tail. Dedup is by (timestamp, message, replica) across overlapping
-// clock-skew windows. Clock-and-sleep behavior is taken from ctx (overridable
-// via WithNow / WithSleep for tests).
+// tailLogs polls logs and streams new records until FetchStatus reports the
+// workload is no longer runnable or the context is cancelled; which statuses
+// count as runnable is the fetcher's call. Dedup is by (timestamp, message,
+// replica) across overlapping clock-skew windows. Clock-and-sleep behavior is
+// taken from ctx (overridable via WithNow / WithSleep for tests).
 func tailLogs(ctx *CommandContext, opts tailLogsOptions) *TailDeploymentLogsResult {
-	var finalFetched *managementapi.Deployment
+	var finalFetched *tailStatus
 
 	seq := func(yield func(*managementapi.Log, error) bool) {
 		// seen maps each delivered log key to the wall-clock time it was
@@ -491,24 +546,13 @@ func tailLogs(ctx *CommandContext, opts tailLogsOptions) *TailDeploymentLogsResu
 			// TODO: should the management logs API return current status so
 			// we can drop this extra round-trip per poll?
 			if len(seen) > 0 {
-				dep, err := opts.FetchStatus()
+				status, err := opts.FetchStatus()
 				if err != nil {
 					yield(nil, fmt.Errorf("fetch deployment status: %w", err))
 					return
 				}
-				finalFetched = dep
-				switch dep.Status {
-				case managementapi.DeploymentStatus_BUILDING,
-					managementapi.DeploymentStatus_DEPLOYING,
-					managementapi.DeploymentStatus_LOADING_MODEL,
-					managementapi.DeploymentStatus_UPDATING,
-					managementapi.DeploymentStatus_WAKING_UP:
-					// keep polling
-				case managementapi.DeploymentStatus_ACTIVE:
-					if opts.StopOnActive {
-						return
-					}
-				default:
+				finalFetched = status
+				if !status.Runnable {
 					return
 				}
 			}
@@ -521,8 +565,8 @@ func tailLogs(ctx *CommandContext, opts tailLogsOptions) *TailDeploymentLogsResu
 	}
 
 	return &TailDeploymentLogsResult{
-		Logs:                   seq,
-		FinalFetchedDeployment: func() *managementapi.Deployment { return finalFetched },
+		Logs:               seq,
+		FinalFetchedStatus: func() *tailStatus { return finalFetched },
 	}
 }
 

--- a/internal/cmd/command.model_environment.go
+++ b/internal/cmd/command.model_environment.go
@@ -38,11 +38,13 @@ func commandModelEnvironmentList(ctx *CommandContext, flags *cmd.ModelEnvironmen
 	}
 	rows := make([][]string, 0, len(resp.Environments))
 	for _, e := range resp.Environments {
-		rows = append(rows, []string{
-			e.Name,
-			e.CurrentDeployment.Id,
-			string(e.CurrentDeployment.Status),
-		})
+		// The current deployment is null until something is promoted to the
+		// environment.
+		depID, depStatus := "-", "-"
+		if e.CurrentDeployment != nil {
+			depID, depStatus = e.CurrentDeployment.Id, string(e.CurrentDeployment.Status)
+		}
+		rows = append(rows, []string{e.Name, depID, depStatus})
 	}
 	ctx.OutputTable(TableOutput{
 		Headers: []string{"NAME", "CURRENT DEPLOYMENT", "STATUS"},
@@ -75,13 +77,19 @@ func commandModelEnvironmentDescribe(ctx *CommandContext, flags *cmd.ModelEnviro
 	}
 	ctx.Outputf("Name:                %s\n", env.Name)
 	ctx.Outputf("Model:               %s\n", env.ModelId)
-	ctx.Outputf("Current Deployment:  %s\n", env.CurrentDeployment.Id)
-	ctx.Outputf("Status:              %s\n", env.CurrentDeployment.Status)
+	// The current deployment is null until something is promoted to the
+	// environment.
+	if env.CurrentDeployment != nil {
+		ctx.Outputf("Current Deployment:  %s\n", env.CurrentDeployment.Id)
+		ctx.Outputf("Status:              %s\n", env.CurrentDeployment.Status)
+	}
 	if env.CandidateDeployment != nil {
 		ctx.Outputf("Candidate Deployment: %s\n", env.CandidateDeployment.Id)
 	}
 	ctx.Outputf("Invoke URL:          %s\n", hyperlink(ctx.Stdout, remote.EnvironmentPredictURL(env.ModelId, env.Name)))
-	ctx.Outputf("Logs URL:            %s\n", hyperlink(ctx.Stdout, remote.LogsURL(env.ModelId, env.CurrentDeployment.Id)))
+	if env.CurrentDeployment != nil {
+		ctx.Outputf("Logs URL:            %s\n", hyperlink(ctx.Stdout, remote.LogsURL(env.ModelId, env.CurrentDeployment.Id)))
+	}
 	ctx.Outputf("Created:             %s\n", env.CreatedAt.UTC().Format(time.RFC3339))
 	return nil
 }

--- a/internal/cmd/command.model_environment_logs.go
+++ b/internal/cmd/command.model_environment_logs.go
@@ -10,6 +10,9 @@ func init() {
 }
 
 func commandModelEnvironmentLogs(ctx *CommandContext, flags *cmd.ModelEnvironmentLogsFlags) error {
+	if err := validateLogFlags(ctx, &flags.LogFlags); err != nil {
+		return err
+	}
 	api, err := ctx.NewManagementClient()
 	if err != nil {
 		return err
@@ -38,12 +41,12 @@ func commandModelEnvironmentLogs(ctx *CommandContext, flags *cmd.ModelEnvironmen
 	// The tail stop condition tracks the environment's current deployment, so
 	// each status poll resolves the environment and reports its current
 	// deployment's status.
-	fetchStatus := func() (*managementapi.Deployment, error) {
+	fetchStatus := func() (*tailStatus, error) {
 		env, err := api.API().GetModelsEnvironmentsEnvName(ctx, ref.ID, flags.Environment)
 		if err != nil {
 			return nil, err
 		}
-		return &env.CurrentDeployment, nil
+		return deploymentTailStatus(env.CurrentDeployment, false), nil
 	}
 	return runLogsCommand(ctx, &flags.LogFlags, fetchLogs, fetchStatus)
 }

--- a/internal/cmd/command.model_environment_logs_test.go
+++ b/internal/cmd/command.model_environment_logs_test.go
@@ -44,6 +44,18 @@ func Test_Model_Environment_Logs_TailWithStartRejected(t *testing.T) {
 	h.Require.Contains(err.Error(), "--tail cannot be combined")
 }
 
+func Test_Model_Environment_Logs_FlagsRejectedBeforeModelLookup(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+
+	// --model-name needs a lookup to resolve, which must not run ahead of the
+	// flag check, or a flag mistake surfaces as a lookup failure instead.
+	err := h.Execute("model", "environment", "logs",
+		"--model-name", "alpha", "--environment", "production", "--tail", "--limit", "100")
+	h.Require.ErrorContains(err, "--tail cannot be combined")
+	h.Require.Empty(m.Calls())
+}
+
 func Test_Model_Environment_Logs_SinceWithStartRejected(t *testing.T) {
 	h := NewCommandHarness(t)
 	err := h.Execute("model", "environment", "logs",

--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -507,8 +507,8 @@ func tailModelPushDeployment(
 		}
 		ctx.LogLine(FormatDeploymentLogLine(*log))
 	}
-	if dep := res.FinalFetchedDeployment(); dep != nil {
-		created.Deployment = *dep
+	if status := res.FinalFetchedStatus(); status != nil && status.Deployment != nil {
+		created.Deployment = *status.Deployment
 	}
 	return nil
 }

--- a/internal/cmd/command_context.go
+++ b/internal/cmd/command_context.go
@@ -43,8 +43,9 @@ type CommandContext struct {
 	// through the query before encoding. Leaves should not set this directly.
 	JQQuery *gojq.Query
 
-	verbose bool
-	jqErr   error
+	verbose      bool
+	jqErr        error
+	strictOutput bool
 
 	// authInfo lazily resolves the remote and auth session. Use the Remote and
 	// Session accessors; do not read its cached fields directly.
@@ -142,6 +143,16 @@ type TableOutput struct {
 // OutputTable writes a borderless table to stdout with bold headers. Header
 // styling auto-degrades when stdout is not a terminal.
 func (c *CommandContext) OutputTable(out TableOutput) {
+	if c.strictOutput {
+		// A short row is padded on the right by lipgloss, so every cell past the
+		// missing one silently renders under the wrong header.
+		for i, row := range out.Rows {
+			if len(row) != len(out.Headers) {
+				panic(fmt.Sprintf("table row %d has %d cells, want %d for headers %v",
+					i, len(row), len(out.Headers), out.Headers))
+			}
+		}
+	}
 	renderer := lipgloss.NewRenderer(c.Stdout)
 	rightAligned := make(map[int]bool, len(out.RightAlignedColumns))
 	for _, col := range out.RightAlignedColumns {

--- a/internal/cmd/command_test.go
+++ b/internal/cmd/command_test.go
@@ -63,6 +63,7 @@ func (h *CommandHarness) Execute(args ...string) error {
 			h.ExitCode = code
 			h.exited = true
 		},
+		StrictOutputChecks: true,
 	})
 	if err != nil && !h.exited {
 		h.ExitCode = 1

--- a/internal/ssh/connect.go
+++ b/internal/ssh/connect.go
@@ -92,7 +92,7 @@ func resolveEnvDeployment(ctx context.Context, mgmt *client.ManagementClient, mo
 	if err != nil {
 		return "", fmt.Errorf("looking up environment %q for model %s: %w", env, modelID, err)
 	}
-	if resp.CurrentDeployment.Id == "" {
+	if resp.CurrentDeployment == nil {
 		return "", fmt.Errorf("environment %q for model %s has no current deployment", env, modelID)
 	}
 	return resp.CurrentDeployment.Id, nil


### PR DESCRIPTION
## :rocket: What

Adds the `baseten loops` command surface, ported from `truss loops`. Nouns follow the backend (run, sampler, checkpoint); truss's deprecated spellings and its per-command output-format flag are dropped, the latter because the CLI has a global `--output`.

- `loops run create` (truss `loops push`): creates a session, a run, and its paired sampler. Renamed because nothing is uploaded. `--base-model` required; `--name`, `--replicas`, `--team` optional. Returns once provisioned rather than blocking on readiness, which is the SDK's job.
- `loops run list` (truss `loops view`, plus the deprecated `loops runs view`): runs newest-first. `--org` adds an OWNER column, `--all` includes inactive runs, `--base-model` filters, `--direction` sorts.
- `loops run describe` (no truss equivalent): one run, with its paired sampler's URL and model/deployment ids.
- `loops run deactivate` (truss `loops deactivate`): tears down trainer and sampler. Prompts unless `--yes`; `--yes` required when stdin is not a TTY.
- `loops run logs` (truss `loops logs`): trainer logs by default, `--sampler` for the sampler's separate stream. Uses the shared logs flow, so `--tail`, `--since`/`--start`/`--end`, and `--limit` all work. Only `--min-level` is offered as a filter, since the trainer endpoint has no message or replica filters.
- `loops usage` (truss `loops usage`): GPU summary plus one row per trainer and per standalone sampler. `--org`, `--user`, `--all` to include allocations holding no live GPUs. Also covers the deprecated `loops samplers view`.
- `loops checkpoint list` (truss `loops checkpoints view`): top-level rather than nested, matching REST, since checkpoints are queryable across runs. `--run-id` or `--base-model`, one required.
- `loops checkpoint files` (no truss equivalent, SDK-only): presigned download URLs for a checkpoint's files.
- No `loops checkpoint deploy` yet: it is the only GraphQL-backed command in the surface and takes an evaluated Python file as config, so it likely needs to delegate to truss. Deferred until the `train` port, which hits the same question with `train deploy_checkpoints`.

## :computer: How

- All eight commands go through the generated baseten-go management client. No GraphQL.
- `--org`/`--user` map to the REST `scope=org` param; owner filtering for `--user` is client-side.
- `loops usage` joins trainer deployments with standalone samplers client-side, matching paired samplers by id before the owner filter so a filtered-out trainer's sampler is not counted as standalone. The summary totals every row, including ones the table hides.
- `loops checkpoint files` walks every page and streams records via `NewJSONArrayWriter`, since the URLs are short-lived. Dropping the response envelope also drops `total_count` from its JSON.
- Log-flag validation is split: `validateLogFlags` holds the standalone checks and every logs command calls it before resolving the entity it fetches logs for, so a flag mistake no longer costs an API call or hides behind a lookup error. `runLogsCommand` keeps only the checks needing the window resolved against now. This also fixes `model environment logs --model-name`, which had the same ordering.
- go.mod pins a baseten-go branch pseudo-version pending basetenlabs/baseten-go#19; re-pointed once that merges.

## :microscope: Testing

- 53 httptest-backed unit tests in `internal/cmd/command.loops_test.go` covering all eight commands: team-scoped creation, scope/filter/direction handling, the trainer-versus-sampler logs split, tail termination on trainer status, the usage pairing/summary/hidden-row logic, and the checkpoint-files page walk in table, JSON, and JSONL form.
- Flag-validation tests assert the mock server received no requests at all, so an ordering regression fails.
- Full `internal/cmd` package passes.