### PR TITLE
Add train commands

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -38,6 +38,7 @@ var Root = Command{
 		commandModelAPI,
 		commandOrg,
 		commandSSH,
+		commandTrain,
 		commandTruss,
 		commandVersion,
 		commandWhoami,

--- a/cmd/command.train.go
+++ b/cmd/command.train.go
@@ -1,0 +1,574 @@
+package cmd
+
+import (
+	"time"
+
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+)
+
+// commandTrain groups the `baseten train` subcommands.
+var commandTrain = Command{
+	Name:    "train",
+	Summary: "Manage training projects and jobs",
+	Children: []Command{
+		commandTrainCapacity,
+		commandTrainCheckpoint,
+		commandTrainJob,
+		commandTrainProject,
+	},
+}
+
+// commandTrainCapacity groups the `baseten train capacity` subcommands.
+var commandTrainCapacity = Command{
+	Name:    "capacity",
+	Summary: "Manage training GPU capacity",
+	Children: []Command{
+		{
+			Name:    "describe",
+			Summary: "Describe training GPU capacity",
+			Description: "Describe the organization's training GPU limits and current usage, per GPU type.\n\n" +
+				"Per-team limits are listed below the organization totals when any are set.",
+			Flags: TrainCapacityDescribeFlags{},
+			Output: &CommandOutput[managementapi.GetTrainingGpuCapacityResponse]{
+				TextDescription: "An organization table with columns: GPU TYPE, IN USE, LIMIT, BASELINE, then a " +
+					"per-team table with a leading TEAM column when teams have limits set.",
+				Examples: []CommandExample{
+					{
+						Description: "Describe training GPU capacity.",
+						Command:     "baseten train capacity describe",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the organization's H100 limit.",
+					Command:     "baseten train capacity describe --jq '.gpu_capacities[] | select(.gpu_type == \"H100\") | .limit'",
+				},
+			},
+		},
+		{
+			Name:    "update",
+			Summary: "Update a team's training GPU limit",
+			Description: "Update the maximum concurrent GPUs of one type that a team may use.\n\n" +
+				"The limit is per GPU type, so raising H100 leaves other types alone.",
+			Flags: TrainCapacityUpdateFlags{},
+			Output: &CommandOutput[managementapi.PatchTeamTrainingGpuCapacityResponse]{
+				TextDescription: "On success, prints the team, GPU type, and new limit to stderr; no stdout output.",
+				Examples: []CommandExample{
+					{
+						Description: "Raise a team's H100 limit.",
+						Command:     "baseten train capacity update --team research --gpu-type H100 --max-gpus 32",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the applied limit.",
+					Command:     "baseten train capacity update --team research --gpu-type H100 --max-gpus 32 --jq '.team_gpu_capacity.limit'",
+				},
+			},
+		},
+	},
+}
+
+// commandTrainCheckpoint groups the `baseten train checkpoint` subcommands.
+var commandTrainCheckpoint = Command{
+	Name:    "checkpoint",
+	Summary: "Inspect training job checkpoints",
+	Children: []Command{
+		{
+			Name:    "list",
+			Summary: "List a training job's checkpoints",
+			Description: "List the checkpoints a training job has synced, newest first.\n\n" +
+				"Checkpoints only appear for jobs that enabled checkpointing.",
+			Flags: TrainCheckpointListFlags{},
+			Output: &CommandOutput[managementapi.GetTrainingJobCheckpointsResponse]{
+				TextDescription: "Table with columns: ID, TYPE, BASE MODEL, SIZE, SYNC, CREATED. " +
+					"When the job has no checkpoints, prints \"No checkpoints found.\" to stderr.",
+				Examples: []CommandExample{
+					{
+						Description: "List a job's checkpoints.",
+						Command:     "baseten train checkpoint list --job-id p7qr9qv",
+					},
+					{
+						Description: "List a job's checkpoints oldest first.",
+						Command:     "baseten train checkpoint list --job-id p7qr9qv --direction asc",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print just the checkpoint IDs.",
+					Command:     "baseten train checkpoint list --job-id p7qr9qv --jq '.checkpoints[].checkpoint_id'",
+				},
+			},
+		},
+		{
+			Name:    "files",
+			Summary: "List presigned URLs for a job's checkpoint files",
+			Description: "List presigned download URLs for the files of a training job's checkpoints.\n\n" +
+				"The URLs are short-lived.\n\n" +
+				"For machine-readable streaming, prefer --output jsonl over --output json.",
+			Flags: TrainCheckpointFilesFlags{},
+			Output: &CommandOutput[managementapi.CheckpointFile]{
+				JSONArrayStreamed: true,
+				TextDescription: "Table with columns: NODE, NAME, SIZE, MODIFIED, URL. " +
+					"When there are no files, prints \"No checkpoint files found.\" to stderr.",
+				Examples: []CommandExample{
+					{
+						Description: "List every checkpoint file of a job.",
+						Command:     "baseten train checkpoint files --job-id p7qr9qv",
+					},
+					{
+						Description: "Save the URLs to a file for a download script.",
+						Command:     "baseten train checkpoint files --job-id p7qr9qv --output json > checkpoint-urls.json",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print just the download URLs.",
+					Command:     "baseten train checkpoint files --job-id p7qr9qv --output jsonl --jq '.url'",
+				},
+			},
+		},
+	},
+}
+
+// commandTrainJob groups the `baseten train job` subcommands.
+var commandTrainJob = Command{
+	Name:    "job",
+	Summary: "Manage training jobs",
+	Children: []Command{
+		{
+			Name:    "list",
+			Summary: "List training jobs",
+			Description: "List training jobs, newest first.\n\n" +
+				"Lists every job in projects your teams can access. Pass --project to narrow to " +
+				"one project, or --status to narrow to particular job states.",
+			Flags: TrainJobListFlags{},
+			Output: &CommandOutput[managementapi.SearchTrainingJobsResponse]{
+				TextDescription: "Table with columns: ID, PROJECT, NAME, STATUS, INSTANCE TYPE, NODES, CREATED. " +
+					"When no jobs match, prints \"No training jobs found.\" to stderr.",
+				Examples: []CommandExample{
+					{
+						Description: "List every training job you can see.",
+						Command:     "baseten train job list",
+					},
+					{
+						Description: "List the running jobs of one project.",
+						Command:     "baseten train job list --project my-project --status running",
+					},
+					{
+						Description: "List jobs oldest first.",
+						Command:     "baseten train job list --direction asc",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print just the job IDs.",
+					Command:     "baseten train job list --jq '.training_jobs[].id'",
+				},
+			},
+		},
+		{
+			Name:        "describe",
+			Summary:     "Describe a training job",
+			Description: "Describe a training job by ID, including its project, compute, and checkpoint sync state.",
+			Flags:       TrainJobDescribeFlags{},
+			Output: &CommandOutput[managementapi.GetTrainingJobResponse]{
+				TextDescription: "A field-per-line summary of the job and its project.",
+				Examples: []CommandExample{
+					{
+						Description: "Describe a job.",
+						Command:     "baseten train job describe --job-id p7qr9qv",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the job's current status.",
+					Command:     "baseten train job describe --job-id p7qr9qv --jq '.training_job.current_status'",
+				},
+			},
+		},
+		{
+			Name:    "logs",
+			Summary: "Fetch logs for a training job",
+			Description: "Fetch logs for a training job.\n\n" +
+				"Without --tail, returns the logs in a time window; with --tail, streams new logs " +
+				"until the job stops producing them or you interrupt with Ctrl-C.",
+			Flags: TrainJobLogsFlags{},
+			Output: &CommandOutput[managementapi.GetLogsResponse]{
+				TextDescription: "One log line per row, timestamped. With --output jsonl, one JSON log record per line.",
+				Examples: []CommandExample{
+					{
+						Description: "Fetch the last 30 minutes of logs.",
+						Command:     "baseten train job logs --job-id p7qr9qv",
+					},
+					{
+						Description: "Stream logs as they arrive.",
+						Command:     "baseten train job logs --job-id p7qr9qv --tail",
+					},
+					{
+						Description: "Fetch a day of error logs.",
+						Command:     "baseten train job logs --job-id p7qr9qv --since 1d --min-level error",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print just the log messages.",
+					Command:     "baseten train job logs --job-id p7qr9qv --jq '.message'",
+				},
+			},
+		},
+		{
+			Name:    "metrics",
+			Summary: "Report resource metrics for a training job",
+			Description: "Report CPU, memory, GPU, and storage metrics for a training job.\n\n" +
+				"Each series is reported as its most recent sample. Pass --start and --end, or " +
+				"--since, to select the window the samples come from.",
+			Flags: TrainJobMetricsFlags{},
+			Output: &CommandOutput[managementapi.GetTrainingJobMetricsResponse]{
+				TextDescription: "Table with columns: METRIC, NODE, VALUE, MEASURED.",
+				Examples: []CommandExample{
+					{
+						Description: "Report a job's latest metrics.",
+						Command:     "baseten train job metrics --job-id p7qr9qv",
+					},
+					{
+						Description: "Report metrics sampled over the last hour.",
+						Command:     "baseten train job metrics --job-id p7qr9qv --since 1h",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the GPU utilization series.",
+					Command:     "baseten train job metrics --job-id p7qr9qv --jq '.gpu_utilization'",
+				},
+			},
+		},
+		{
+			Name:    "stop",
+			Summary: "Stop a training job",
+			Description: "Stop a running or queued training job.\n\n" +
+				"Stopping is not reversible: use 'baseten train job recreate' to run the same " +
+				"configuration again. Checkpoints already synced remain accessible.",
+			Flags: TrainJobStopFlags{},
+			Output: &CommandOutput[managementapi.StopTrainingJobResponse]{
+				TextDescription: "On success, prints the stopped job's ID to stderr; no stdout output.",
+				Examples: []CommandExample{
+					{
+						Description: "Stop a job, confirming interactively.",
+						Command:     "baseten train job stop --job-id p7qr9qv",
+					},
+					{
+						Description: "Stop a job without confirmation, for scripts.",
+						Command:     "baseten train job stop --job-id p7qr9qv --yes",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the stopped job's status.",
+					Command:     "baseten train job stop --job-id p7qr9qv --yes --jq '.training_job.current_status'",
+				},
+			},
+		},
+		{
+			Name:    "recreate",
+			Summary: "Recreate a training job",
+			Description: "Create a new training job from an existing job's configuration.\n\n" +
+				"The original job is left as it is. The new job gets a new ID and starts from the " +
+				"beginning.",
+			Flags: TrainJobRecreateFlags{},
+			Output: &CommandOutput[managementapi.RecreateTrainingJobResponse]{
+				TextDescription: "On success, prints the new job's ID to stderr; no stdout output.",
+				Examples: []CommandExample{
+					{
+						Description: "Rerun a job's configuration.",
+						Command:     "baseten train job recreate --job-id p7qr9qv",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print just the new job's ID.",
+					Command:     "baseten train job recreate --job-id p7qr9qv --jq '.training_job.id'",
+				},
+			},
+		},
+		{
+			Name:    "update",
+			Summary: "Update a training job's queue priority",
+			Description: "Update a queued training job's priority. Higher values are dequeued first.\n\n" +
+				"Only jobs in the PENDING state can have their priority changed.",
+			Flags: TrainJobUpdateFlags{},
+			Output: &CommandOutput[managementapi.UpdateTrainingJobResponse]{
+				TextDescription: "On success, prints the job's ID and new priority to stderr; no stdout output.",
+				Examples: []CommandExample{
+					{
+						Description: "Raise a queued job's priority.",
+						Command:     "baseten train job update --job-id p7qr9qv --priority 10",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the job's new priority.",
+					Command:     "baseten train job update --job-id p7qr9qv --priority 10 --jq '.training_job.priority'",
+				},
+			},
+		},
+		{
+			Name:    "download",
+			Summary: "Download a training job's artifacts",
+			Description: "Download the code archive that was uploaded with a training job.\n\n" +
+				"Writes into --dir either way: an extracted '<project>-<job-id>' directory, or " +
+				"'<project>-<job-id>.tgz' when you pass --no-extract.\n\n" +
+				"This is the job's input code, not its checkpoints; use " +
+				"'baseten train checkpoint files' for those.",
+			Flags: TrainJobDownloadFlags{},
+			Output: &CommandOutput[TrainJobDownloadResult]{
+				TextDescription: "The path written, to stderr.",
+				JSONDescription: "An object naming the job and the paths written.",
+				Examples: []CommandExample{
+					{
+						Description: "Download and extract a job's code into the current directory.",
+						Command:     "baseten train job download --job-id p7qr9qv",
+					},
+					{
+						Description: "Keep the archive instead of extracting it.",
+						Command:     "baseten train job download --job-id p7qr9qv --dir ./artifacts --no-extract",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the path written.",
+					Command:     "baseten train job download --job-id p7qr9qv --jq '.paths[0]'",
+				},
+			},
+		},
+		commandTrainJobSession,
+	},
+}
+
+// commandTrainJobSession groups the `baseten train job session` subcommands.
+// Only `describe` exists: truss's `update_session` targets a route the backend
+// does not serve, and the route that does exist can only adjust a session that
+// is already running.
+var commandTrainJobSession = Command{
+	Name:    "session",
+	Summary: "Inspect a training job's interactive sessions",
+	Children: []Command{
+		{
+			Name:    "describe",
+			Summary: "Describe a training job's interactive sessions",
+			Description: "Describe the interactive sessions of a training job, one per replica.\n\n" +
+				"Only replicas with a live session are listed, so a job whose session has not " +
+				"started yet reports none.",
+			Flags: TrainJobSessionDescribeFlags{},
+			Output: &CommandOutput[managementapi.GetAuthCodesResponse]{
+				TextDescription: "Table with columns: REPLICA, SESSION, AUTH URL, EXPIRES. " +
+					"When no session is live, prints \"No interactive sessions found.\" to stderr.",
+				Examples: []CommandExample{
+					{
+						Description: "Show a job's interactive sessions.",
+						Command:     "baseten train job session describe --job-id p7qr9qv",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the first replica's auth URL.",
+					Command:     "baseten train job session describe --job-id p7qr9qv --jq '.auth_codes[0].auth_url'",
+				},
+			},
+		},
+	},
+}
+
+// commandTrainProject groups the `baseten train project` subcommands.
+var commandTrainProject = Command{
+	Name:    "project",
+	Summary: "Manage training projects",
+	Children: []Command{
+		{
+			Name:        "list",
+			Summary:     "List training projects",
+			Description: "List the training projects your teams can access, newest first.",
+			Flags:       TrainProjectListFlags{},
+			Output: &CommandOutput[managementapi.ListTrainingProjectsResponse]{
+				TextDescription: "Table with columns: ID, NAME, TEAM, LATEST JOB, LATEST STATUS, CREATED. " +
+					"When there are no projects, prints \"No training projects found.\" to stderr.",
+				Examples: []CommandExample{
+					{
+						Description: "List your training projects.",
+						Command:     "baseten train project list",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print just the project names.",
+					Command:     "baseten train project list --jq '.training_projects[].name'",
+				},
+			},
+		},
+		commandTrainProjectCache,
+	},
+}
+
+// commandTrainProjectCache groups the `baseten train project cache` subcommands.
+var commandTrainProjectCache = Command{
+	Name:    "cache",
+	Summary: "Inspect a training project's cache",
+	Children: []Command{
+		{
+			Name:    "describe",
+			Summary: "Describe a training project's cache contents",
+			Description: "Describe the files in a training project's shared cache, largest first.\n\n" +
+				"The cache is shared by every job in the project and persists between runs.",
+			Flags: TrainProjectCacheDescribeFlags{},
+			Output: &CommandOutput[managementapi.GetCacheSummaryResponse]{
+				TextDescription: "A total size line, then a table with columns: PATH, TYPE, SIZE, PERMISSIONS, MODIFIED. " +
+					"When the cache is empty, prints \"Cache is empty.\" to stderr.",
+				Examples: []CommandExample{
+					{
+						Description: "Describe a project's cache.",
+						Command:     "baseten train project cache describe --project my-project",
+					},
+					{
+						Description: "Sort the cache listing by path.",
+						Command:     "baseten train project cache describe --project my-project --sort path",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print the cached file paths.",
+					Command:     "baseten train project cache describe --project my-project --jq '.file_summaries[].path'",
+				},
+			},
+		},
+	},
+}
+
+// TrainJobRefFlags identifies a training job. The project is resolved from the
+// job ID, so callers never pass one: every job endpoint is nested under a
+// project, but the search endpoint returns the owning project with the job.
+type TrainJobRefFlags struct {
+	JobID string `flag:"job-id" desc:"ID of the training job." required:"true"`
+}
+
+// TrainCapacityDescribeFlags configures `baseten train capacity describe`.
+type TrainCapacityDescribeFlags struct {
+	CommandFlags
+}
+
+// TrainCapacityUpdateFlags configures `baseten train capacity update`.
+type TrainCapacityUpdateFlags struct {
+	CommandFlags
+
+	Team    string `flag:"team" desc:"Team name or ID whose limit changes." required:"true"`
+	GPUType string `flag:"gpu-type" desc:"GPU type the limit applies to (for example H100)." required:"true"`
+	MaxGPUs int    `flag:"max-gpus" desc:"Maximum concurrent GPUs of this type the team may use." required:"true"`
+}
+
+// TrainCheckpointListFlags configures `baseten train checkpoint list`.
+type TrainCheckpointListFlags struct {
+	CommandFlags
+	TrainJobRefFlags
+
+	Direction string `flag:"direction" desc:"Sort order by creation time: 'desc' (newest first) or 'asc' (oldest first)." enum:"asc,desc" default:"desc"`
+}
+
+// TrainCheckpointFilesFlags configures `baseten train checkpoint files`.
+type TrainCheckpointFilesFlags struct {
+	CommandFlags
+	TrainJobRefFlags
+}
+
+// TrainJobListFlags configures `baseten train job list`.
+type TrainJobListFlags struct {
+	CommandFlags
+
+	Project   string   `flag:"project" desc:"Only list jobs in this training project, by name or ID."`
+	Status    []string `flag:"status" desc:"Only list jobs in these states: pending, created, deploying, deploy-failed, running, completed, failed, stopped, preempted. Repeatable."`
+	Direction string   `flag:"direction" desc:"Sort order by creation time: 'desc' (newest first) or 'asc' (oldest first)." enum:"asc,desc" default:"desc"`
+}
+
+// TrainJobDescribeFlags configures `baseten train job describe`.
+type TrainJobDescribeFlags struct {
+	CommandFlags
+	TrainJobRefFlags
+}
+
+// TrainJobLogsFlags configures `baseten train job logs`.
+type TrainJobLogsFlags struct {
+	CommandFlags
+	TrainJobRefFlags
+	TrainLogFlags
+}
+
+// TrainLogFlags is the log-query flag set for `baseten train job logs`. Like
+// Loops, the training logs endpoint supports only the window, limit, and
+// severity filters, so the message and replica filters that model deployment
+// logs accept are not offered here.
+type TrainLogFlags struct {
+	Tail bool `flag:"tail" desc:"Stream new logs as they arrive until the job stops producing them or you interrupt with Ctrl-C. Cannot be combined with the time-range or filter flags. For machine-readable streaming, prefer --output jsonl over --output json."`
+
+	Start time.Time     `flag:"start" desc:"Start of the log time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. Default is 30 minutes before the end. Window must be at most 7 days."`
+	End   time.Time     `flag:"end" desc:"End of the log time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. Default is now. Window must be at most 7 days."`
+	Since time.Duration `flag:"since" desc:"Shortcut for fetching logs from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
+
+	Limit int `flag:"limit" desc:"Maximum number of log lines to return, paging backward from the end of the window. Use 0 for no limit (every log line in the window). Not applicable with --tail." default:"5000"`
+
+	// PageSize is the per-request fetch size while paging. Hidden; exists so
+	// tests can force multiple pages without generating a full page of logs.
+	PageSize int `flag:"page-size" hidden:"true" desc:"Log lines fetched per backend request while paging." default:"1000"`
+
+	MinLevel string `flag:"min-level" desc:"Only return logs at or above this severity level." enum:"debug,info,warning,error"`
+}
+
+// TrainJobMetricsFlags configures `baseten train job metrics`.
+type TrainJobMetricsFlags struct {
+	CommandFlags
+	TrainJobRefFlags
+
+	Start time.Time     `flag:"start" desc:"Start of the sample window. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone."`
+	End   time.Time     `flag:"end" desc:"End of the sample window. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. Default is now."`
+	Since time.Duration `flag:"since" desc:"Shortcut for sampling from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Mutually exclusive with --start and --end."`
+}
+
+// TrainJobStopFlags configures `baseten train job stop`.
+type TrainJobStopFlags struct {
+	CommandFlags
+	TrainJobRefFlags
+
+	Yes bool `flag:"yes" desc:"Skip the interactive confirmation prompt. Required when stdin is not a terminal."`
+}
+
+// TrainJobRecreateFlags configures `baseten train job recreate`.
+type TrainJobRecreateFlags struct {
+	CommandFlags
+	TrainJobRefFlags
+}
+
+// TrainJobUpdateFlags configures `baseten train job update`.
+type TrainJobUpdateFlags struct {
+	CommandFlags
+	TrainJobRefFlags
+
+	Priority int `flag:"priority" desc:"New queue priority. Higher values are dequeued first." required:"true"`
+}
+
+// TrainJobDownloadFlags configures `baseten train job download`.
+type TrainJobDownloadFlags struct {
+	CommandFlags
+	TrainJobRefFlags
+
+	Dir       string `flag:"dir" desc:"Directory to write into. Created if missing." default:"."`
+	NoExtract bool   `flag:"no-extract" desc:"Keep the downloaded archive instead of extracting it."`
+}
+
+// TrainJobDownloadResult is the JSON output of `baseten train job download`.
+// The API returns presigned URLs rather than files, so the useful result is
+// what landed on disk, which has no generated equivalent.
+type TrainJobDownloadResult struct {
+	JobID string   `json:"job_id"`
+	Paths []string `json:"paths"`
+}
+
+// TrainJobSessionDescribeFlags configures `baseten train job session describe`.
+type TrainJobSessionDescribeFlags struct {
+	CommandFlags
+	TrainJobRefFlags
+}
+
+// TrainProjectListFlags configures `baseten train project list`.
+type TrainProjectListFlags struct {
+	CommandFlags
+}
+
+// TrainProjectCacheDescribeFlags configures `baseten train project cache describe`.
+type TrainProjectCacheDescribeFlags struct {
+	CommandFlags
+
+	Project string `flag:"project" desc:"Training project to describe, by name or ID." required:"true"`
+	Sort    string `flag:"sort" desc:"Sort the listing by 'size' (largest first) or 'path' (alphabetical)." enum:"size,path" default:"size"`
+}

--- a/cmd/command.train.go
+++ b/cmd/command.train.go
@@ -304,28 +304,32 @@ var commandTrainJob = Command{
 		{
 			Name:    "download",
 			Summary: "Download a training job's artifacts",
-			Description: "Download the code archive that was uploaded with a training job.\n\n" +
-				"Writes into --dir either way: an extracted '<project>-<job-id>' directory, or " +
-				"'<project>-<job-id>.tgz' when you pass --no-extract.\n\n" +
+			Description: "Download the code archive that was uploaded with a training job as an " +
+				"uncompressed tar.\n\n" +
+				"Exactly one of --out-file or --out-dir is required. --out-file writes the " +
+				"raw tar bytes; --out-dir extracts the tar into the directory. Use " +
+				"--overwrite to replace an existing file or write into a non-empty directory.\n\n" +
 				"This is the job's input code, not its checkpoints; use " +
 				"'baseten train checkpoint files' for those.",
 			Flags: TrainJobDownloadFlags{},
 			Output: &CommandOutput[TrainJobDownloadResult]{
-				TextDescription: "The path written, to stderr.",
-				JSONDescription: "An object naming the job and the paths written.",
+				TextDescription: "Writes the artifact to disk; prints progress and the final destination " +
+					"path to stderr; no stdout output.",
+				JSONDescription: "On success, stdout is a JSON object naming the job, with either " +
+					"out_file or out_dir set to the path written.",
 				Examples: []CommandExample{
 					{
-						Description: "Download and extract a job's code into the current directory.",
-						Command:     "baseten train job download --job-id p7qr9qv",
+						Description: "Extract a job's code into a directory.",
+						Command:     "baseten train job download --job-id p7qr9qv --out-dir ./job-code",
 					},
 					{
-						Description: "Keep the archive instead of extracting it.",
-						Command:     "baseten train job download --job-id p7qr9qv --dir ./artifacts --no-extract",
+						Description: "Save the archive as a tar file instead of extracting it.",
+						Command:     "baseten train job download --job-id p7qr9qv --out-file job.tar",
 					},
 				},
 				JQExample: CommandExample{
-					Description: "Print the path written.",
-					Command:     "baseten train job download --job-id p7qr9qv --jq '.paths[0]'",
+					Description: "Print just the destination path.",
+					Command:     "baseten train job download --job-id p7qr9qv --out-file job.tar --jq '.out_file'",
 				},
 			},
 		},
@@ -542,16 +546,19 @@ type TrainJobDownloadFlags struct {
 	CommandFlags
 	TrainJobRefFlags
 
-	Dir       string `flag:"dir" desc:"Directory to write into. Created if missing." default:"."`
-	NoExtract bool   `flag:"no-extract" desc:"Keep the downloaded archive instead of extracting it."`
+	OutFile   string `flag:"out-file" desc:"Save the artifact as an uncompressed tar file at this path." oneof:"download-out"`
+	OutDir    string `flag:"out-dir" desc:"Extract the artifact tar into this directory." oneof:"download-out"`
+	Overwrite bool   `flag:"overwrite" desc:"Allow overwriting an existing file or non-empty directory."`
 }
 
 // TrainJobDownloadResult is the JSON output of `baseten train job download`.
 // The API returns presigned URLs rather than files, so the useful result is
-// what landed on disk, which has no generated equivalent.
+// what landed on disk, which has no generated equivalent. Exactly one of
+// OutFile or OutDir is set, matching whichever flag the caller passed.
 type TrainJobDownloadResult struct {
-	JobID string   `json:"job_id"`
-	Paths []string `json:"paths"`
+	JobID   string `json:"job_id"`
+	OutFile string `json:"out_file,omitempty"`
+	OutDir  string `json:"out_dir,omitempty"`
 }
 
 // TrainJobSessionDescribeFlags configures `baseten train job session describe`.

--- a/internal/cmd/command.model_deployment.go
+++ b/internal/cmd/command.model_deployment.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"archive/tar"
+	"bufio"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -277,25 +279,78 @@ func commandModelDeploymentDelete(ctx *CommandContext, flags *cmd.ModelDeploymen
 	return nil
 }
 
-func commandModelDeploymentDownload(ctx *CommandContext, flags *cmd.ModelDeploymentDownloadFlags) error {
-	outPath := flags.OutFile
+// checkDownloadOutTarget rejects an output location that is already occupied,
+// unless the caller passed --overwrite. Exactly one of outFile or outDir is set,
+// matching the --out-file/--out-dir pair the download commands share.
+func checkDownloadOutTarget(outFile, outDir string, overwrite bool) error {
+	outPath := outFile
 	if outPath == "" {
-		outPath = flags.OutDir
+		outPath = outDir
 	}
 	parent := filepath.Dir(outPath)
 	if st, err := os.Stat(parent); err != nil || !st.IsDir() {
 		return fmt.Errorf("parent directory does not exist: %s", parent)
 	}
-	if !flags.Overwrite {
-		if flags.OutFile != "" {
-			if _, err := os.Stat(flags.OutFile); err == nil {
-				return fmt.Errorf("file already exists: %s; pass --overwrite to replace it", flags.OutFile)
-			}
-		} else {
-			if entries, err := os.ReadDir(flags.OutDir); err == nil && len(entries) > 0 {
-				return fmt.Errorf("directory is not empty: %s; pass --overwrite to write into it", flags.OutDir)
-			}
+	if overwrite {
+		return nil
+	}
+	if outFile != "" {
+		if _, err := os.Stat(outFile); err == nil {
+			return fmt.Errorf("file already exists: %s; pass --overwrite to replace it", outFile)
 		}
+		return nil
+	}
+	if entries, err := os.ReadDir(outDir); err == nil && len(entries) > 0 {
+		return fmt.Errorf("directory is not empty: %s; pass --overwrite to write into it", outDir)
+	}
+	return nil
+}
+
+// downloadTarArchive fetches url and either saves the bytes verbatim to outFile
+// or extracts them into outDir, reporting where they landed. Exactly one of
+// outFile or outDir must be set. what names the archive in messages ("truss",
+// "artifact"). The URL is presigned, carrying its own credentials, so it goes
+// out on the plain client rather than the authenticated management one.
+func downloadTarArchive(ctx *CommandContext, url, what, outFile, outDir string) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("build download request: %w", err)
+	}
+	httpResp, err := ctx.httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", what, err)
+	}
+	defer httpResp.Body.Close()
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return fmt.Errorf("download %s: HTTP %d", what, httpResp.StatusCode)
+	}
+
+	if outFile != "" {
+		f, err := os.Create(outFile)
+		if err != nil {
+			return fmt.Errorf("create %s: %w", outFile, err)
+		}
+		defer f.Close()
+		if _, err := io.Copy(f, httpResp.Body); err != nil {
+			return fmt.Errorf("write %s: %w", outFile, err)
+		}
+		ctx.Logf("Saved to %s\n", outFile)
+		return nil
+	}
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", outDir, err)
+	}
+	if err := extractTar(httpResp.Body, outDir); err != nil {
+		return fmt.Errorf("extract %s into %s: %w", what, outDir, err)
+	}
+	ctx.Logf("Extracted to %s\n", outDir)
+	return nil
+}
+
+func commandModelDeploymentDownload(ctx *CommandContext, flags *cmd.ModelDeploymentDownloadFlags) error {
+	if err := checkDownloadOutTarget(flags.OutFile, flags.OutDir, flags.Overwrite); err != nil {
+		return err
 	}
 
 	cl, err := ctx.NewManagementClient()
@@ -313,52 +368,35 @@ func commandModelDeploymentDownload(ctx *CommandContext, flags *cmd.ModelDeploym
 		return fmt.Errorf("fetch download URL for deployment %s: %w", ref.DeploymentID, err)
 	}
 
-	ctx.Logf("Downloading truss...\n")
-	req, err := http.NewRequestWithContext(ctx, "GET", resp.DownloadUrl, nil)
-	if err != nil {
-		return fmt.Errorf("build download request: %w", err)
+	ctx.Logf("Downloading model source...\n")
+	if err := downloadTarArchive(ctx, resp.DownloadUrl, "model source", flags.OutFile, flags.OutDir); err != nil {
+		return err
 	}
-	httpResp, err := ctx.httpClient().Do(req)
-	if err != nil {
-		return fmt.Errorf("download truss: %w", err)
-	}
-	defer httpResp.Body.Close()
-	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
-		return fmt.Errorf("download truss: HTTP %d", httpResp.StatusCode)
-	}
-
-	if flags.OutFile != "" {
-		f, err := os.Create(flags.OutFile)
-		if err != nil {
-			return fmt.Errorf("create %s: %w", flags.OutFile, err)
-		}
-		defer f.Close()
-		if _, err := io.Copy(f, httpResp.Body); err != nil {
-			return fmt.Errorf("write %s: %w", flags.OutFile, err)
-		}
-		ctx.Logf("Saved to %s\n", flags.OutFile)
-		if ctx.JSON {
-			ctx.OutputJSON(cmd.ModelDeploymentDownloadResult{OutFile: flags.OutFile})
-		}
-		return nil
-	}
-
-	if err := os.MkdirAll(flags.OutDir, 0o755); err != nil {
-		return fmt.Errorf("create %s: %w", flags.OutDir, err)
-	}
-	if err := extractTar(httpResp.Body, flags.OutDir); err != nil {
-		return fmt.Errorf("extract truss into %s: %w", flags.OutDir, err)
-	}
-	ctx.Logf("Extracted to %s\n", flags.OutDir)
 	if ctx.JSON {
-		ctx.OutputJSON(cmd.ModelDeploymentDownloadResult{OutDir: flags.OutDir})
+		ctx.OutputJSON(cmd.ModelDeploymentDownloadResult{OutFile: flags.OutFile, OutDir: flags.OutDir})
 	}
 	return nil
 }
 
-// extractTar extracts a tar stream into dir. Rejects entries with absolute
-// paths or ".." components to avoid path traversal.
+// extractTar extracts a tar stream into dir, transparently decompressing a
+// gzipped one. Rejects entries with absolute paths or ".." components to avoid
+// path traversal.
 func extractTar(r io.Reader, dir string) error {
+	// Truss packs both truss and training archives uncompressed and detects
+	// compression on the way back out, so trust the bytes rather than the file
+	// name a caller gave them. A tar header opens with the NUL-padded entry name,
+	// so the gzip magic cannot start a valid one.
+	br := bufio.NewReader(r)
+	if magic, err := br.Peek(2); err == nil && magic[0] == 0x1f && magic[1] == 0x8b {
+		gz, err := gzip.NewReader(br)
+		if err != nil {
+			return fmt.Errorf("read gzip archive: %w", err)
+		}
+		defer gz.Close()
+		r = gz
+	} else {
+		r = br
+	}
 	tr := tar.NewReader(r)
 	for {
 		hdr, err := tr.Next()

--- a/internal/cmd/command.train.go
+++ b/internal/cmd/command.train.go
@@ -723,7 +723,13 @@ func commandTrainJobDownload(ctx *CommandContext, flags *cmd.TrainJobDownloadFla
 
 	// The archive name follows the job, not the URL, whose path is an opaque
 	// storage key. A job with several artifacts gets each suffixed by index.
-	baseName := strings.ReplaceAll(fmt.Sprintf("%s-%s", ref.ProjectName, ref.JobID), " ", "-")
+	baseName := strings.NewReplacer(" ", "-", "/", "-", `\`, "-").Replace(
+		fmt.Sprintf("%s-%s", ref.ProjectName, ref.JobID))
+	// The backend accepts any project name, so fall back to the job ID, always a
+	// safe component, for a name that is not usable as one.
+	if !filepath.IsLocal(baseName) {
+		baseName = ref.JobID
+	}
 	result := cmd.TrainJobDownloadResult{JobID: ref.JobID}
 	for i, artifactURL := range resp.ArtifactPresignedUrls {
 		name := baseName

--- a/internal/cmd/command.train.go
+++ b/internal/cmd/command.train.go
@@ -1,13 +1,8 @@
 package cmd
 
 import (
-	"compress/gzip"
 	"fmt"
-	"io"
 	"maps"
-	"net/http"
-	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -123,25 +118,30 @@ func commandTrainCapacityDescribe(ctx *CommandContext, flags *cmd.TrainCapacityD
 		ctx.OutputJSON(resp)
 		return nil
 	}
-	if len(resp.GpuCapacities) == 0 {
+	// Team limits are enforced whether or not the org has its own capacity, so
+	// the two tables stand alone: neither absence hides the other.
+	hasTeamCapacities := resp.TeamGpuCapacities != nil && len(*resp.TeamGpuCapacities) > 0
+	if len(resp.GpuCapacities) == 0 && !hasTeamCapacities {
 		ctx.LogLine("No training GPU capacity configured.")
 		return nil
 	}
-	rows := make([][]string, 0, len(resp.GpuCapacities))
-	for _, capacity := range resp.GpuCapacities {
-		rows = append(rows, []string{
-			capacity.GpuType,
-			fmt.Sprint(capacity.UsageCount),
-			fmt.Sprint(capacity.Limit),
-			fmt.Sprint(capacity.Baseline),
+	if len(resp.GpuCapacities) > 0 {
+		rows := make([][]string, 0, len(resp.GpuCapacities))
+		for _, capacity := range resp.GpuCapacities {
+			rows = append(rows, []string{
+				capacity.GpuType,
+				fmt.Sprint(capacity.UsageCount),
+				fmt.Sprint(capacity.Limit),
+				fmt.Sprint(capacity.Baseline),
+			})
+		}
+		ctx.OutputTable(TableOutput{
+			Headers: []string{"GPU TYPE", "IN USE", "LIMIT", "BASELINE"},
+			Rows:    rows,
 		})
 	}
-	ctx.OutputTable(TableOutput{
-		Headers: []string{"GPU TYPE", "IN USE", "LIMIT", "BASELINE"},
-		Rows:    rows,
-	})
 
-	if resp.TeamGpuCapacities == nil || len(*resp.TeamGpuCapacities) == 0 {
+	if !hasTeamCapacities {
 		return nil
 	}
 	teamRows := make([][]string, 0, len(*resp.TeamGpuCapacities))
@@ -154,7 +154,9 @@ func commandTrainCapacityDescribe(ctx *CommandContext, flags *cmd.TrainCapacityD
 			fmt.Sprint(capacity.Baseline),
 		})
 	}
-	ctx.Outputf("\n")
+	if len(resp.GpuCapacities) > 0 {
+		ctx.Outputf("\n")
+	}
 	ctx.OutputTable(TableOutput{
 		Headers: []string{"TEAM", "GPU TYPE", "IN USE", "LIMIT", "BASELINE"},
 		Rows:    teamRows,
@@ -702,6 +704,9 @@ func commandTrainJobUpdate(ctx *CommandContext, flags *cmd.TrainJobUpdateFlags) 
 }
 
 func commandTrainJobDownload(ctx *CommandContext, flags *cmd.TrainJobDownloadFlags) error {
+	if err := checkDownloadOutTarget(flags.OutFile, flags.OutDir, flags.Overwrite); err != nil {
+		return err
+	}
 	cl, err := ctx.NewManagementClient()
 	if err != nil {
 		return err
@@ -717,93 +722,26 @@ func commandTrainJobDownload(ctx *CommandContext, flags *cmd.TrainJobDownloadFla
 	if len(resp.ArtifactPresignedUrls) == 0 {
 		return fmt.Errorf("training job %s has no artifacts to download", flags.JobID)
 	}
-	if err := os.MkdirAll(flags.Dir, 0o755); err != nil {
-		return fmt.Errorf("create download dir: %w", err)
+	// The API can report several artifacts per job, but server-side callers and
+	// truss alike download the first and ignore the rest, so say so rather than
+	// inventing a fan-out no other client has.
+	if len(resp.ArtifactPresignedUrls) > 1 {
+		ctx.Logf("Training job %s has %d artifacts; downloading the first.\n",
+			ref.JobID, len(resp.ArtifactPresignedUrls))
 	}
 
-	// The archive name follows the job, not the URL, whose path is an opaque
-	// storage key. A job with several artifacts gets each suffixed by index.
-	baseName := strings.NewReplacer(" ", "-", "/", "-", `\`, "-").Replace(
-		fmt.Sprintf("%s-%s", ref.ProjectName, ref.JobID))
-	// The backend accepts any project name, so fall back to the job ID, always a
-	// safe component, for a name that is not usable as one.
-	if !filepath.IsLocal(baseName) {
-		baseName = ref.JobID
+	ctx.Logf("Downloading artifact...\n")
+	if err := downloadTarArchive(ctx, resp.ArtifactPresignedUrls[0], "artifact", flags.OutFile, flags.OutDir); err != nil {
+		return err
 	}
-	result := cmd.TrainJobDownloadResult{JobID: ref.JobID}
-	for i, artifactURL := range resp.ArtifactPresignedUrls {
-		name := baseName
-		if len(resp.ArtifactPresignedUrls) > 1 {
-			name = fmt.Sprintf("%s-%d", baseName, i+1)
-		}
-		path, err := trainDownloadArtifact(ctx, artifactURL, flags.Dir, name, !flags.NoExtract)
-		if err != nil {
-			return err
-		}
-		result.Paths = append(result.Paths, path)
-	}
-
 	if ctx.JSON {
-		ctx.OutputJSON(result)
-		return nil
-	}
-	for _, path := range result.Paths {
-		ctx.Logf("Downloaded training job %s to %s\n", ref.JobID, path)
+		ctx.OutputJSON(cmd.TrainJobDownloadResult{
+			JobID:   ref.JobID,
+			OutFile: flags.OutFile,
+			OutDir:  flags.OutDir,
+		})
 	}
 	return nil
-}
-
-// trainDownloadArtifact fetches one presigned artifact into dir, either as
-// "<name>.tgz" or extracted into a "<name>" directory. It returns the absolute
-// path written.
-func trainDownloadArtifact(ctx *CommandContext, artifactURL, dir, name string, extract bool) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, artifactURL, nil)
-	if err != nil {
-		return "", fmt.Errorf("build artifact request: %w", err)
-	}
-	// The URL is presigned, so it carries its own credentials and must not go
-	// through the authenticated management client.
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("fetch artifact: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("fetch artifact: unexpected status %s", resp.Status)
-	}
-
-	if !extract {
-		path, err := filepath.Abs(filepath.Join(dir, name+".tgz"))
-		if err != nil {
-			return "", err
-		}
-		f, err := os.Create(path)
-		if err != nil {
-			return "", fmt.Errorf("create %s: %w", path, err)
-		}
-		defer f.Close()
-		if _, err := io.Copy(f, resp.Body); err != nil {
-			return "", fmt.Errorf("write %s: %w", path, err)
-		}
-		return path, nil
-	}
-
-	root, err := filepath.Abs(filepath.Join(dir, name))
-	if err != nil {
-		return "", err
-	}
-	gz, err := gzip.NewReader(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("read artifact archive: %w", err)
-	}
-	defer gz.Close()
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		return "", fmt.Errorf("create %s: %w", root, err)
-	}
-	if err := extractTar(gz, root); err != nil {
-		return "", fmt.Errorf("extract archive into %s: %w", root, err)
-	}
-	return root, nil
 }
 
 func commandTrainJobSessionDescribe(ctx *CommandContext, flags *cmd.TrainJobSessionDescribeFlags) error {

--- a/internal/cmd/command.train.go
+++ b/internal/cmd/command.train.go
@@ -1,0 +1,947 @@
+package cmd
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+)
+
+func init() {
+	Register("train capacity describe", commandTrainCapacityDescribe)
+	Register("train capacity update", commandTrainCapacityUpdate)
+	Register("train checkpoint list", commandTrainCheckpointList)
+	Register("train checkpoint files", commandTrainCheckpointFiles)
+	Register("train job list", commandTrainJobList)
+	Register("train job describe", commandTrainJobDescribe)
+	Register("train job logs", commandTrainJobLogs)
+	Register("train job metrics", commandTrainJobMetrics)
+	Register("train job stop", commandTrainJobStop)
+	Register("train job recreate", commandTrainJobRecreate)
+	Register("train job update", commandTrainJobUpdate)
+	Register("train job download", commandTrainJobDownload)
+	Register("train job session describe", commandTrainJobSessionDescribe)
+	Register("train project list", commandTrainProjectList)
+	Register("train project cache describe", commandTrainProjectCacheDescribe)
+}
+
+// trainJobStatusPrefix is the prefix every training job status carries. The CLI
+// spells statuses without it, so 'running' means TRAINING_JOB_RUNNING, and both
+// spellings are accepted on input. The mapping is mechanical rather than a fixed
+// table so a status added to the backend works without a CLI release, and so an
+// unrecognized one still renders readably.
+const trainJobStatusPrefix = "TRAINING_JOB_"
+
+// trainJobStatusToAPI turns a CLI status into its API spelling. A value that
+// already carries the prefix passes through, so both forms work.
+func trainJobStatusToAPI(status string) string {
+	upper := strings.ToUpper(strings.ReplaceAll(status, "-", "_"))
+	if strings.HasPrefix(upper, trainJobStatusPrefix) {
+		return upper
+	}
+	return trainJobStatusPrefix + upper
+}
+
+// trainJobStatusFromAPI turns an API status into its CLI spelling. A value
+// without the expected prefix is lowercased as-is rather than dropped.
+func trainJobStatusFromAPI(status string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimPrefix(status, trainJobStatusPrefix), "_", "-"))
+}
+
+// trainJobRef is a training job and the project that owns it. Every job
+// endpoint is nested under a project, but users only supply a job ID.
+type trainJobRef struct {
+	ProjectID   string
+	ProjectName string
+	JobID       string
+}
+
+// resolveTrainJob finds the project owning a job. The search endpoint is the
+// only lookup that takes a bare job ID, and it returns the job with its project
+// attached.
+func resolveTrainJob(ctx *CommandContext, api *managementapi.Client, jobID string) (*trainJobRef, error) {
+	resp, err := api.PostTrainingJobsSearch(ctx, managementapi.SearchTrainingJobsRequest{JobId: &jobID})
+	if err != nil {
+		return nil, fmt.Errorf("search training job %s: %w", jobID, err)
+	}
+	if len(resp.TrainingJobs) == 0 {
+		return nil, fmt.Errorf("no training job found with ID %s", jobID)
+	}
+	job := resp.TrainingJobs[0]
+	return &trainJobRef{
+		ProjectID:   job.TrainingProject.Id,
+		ProjectName: job.TrainingProject.Name,
+		JobID:       job.Id,
+	}, nil
+}
+
+// resolveTrainProject translates a --project value (project name or ID) into a
+// project ID. An exact ID match wins over a name match, matching ResolveTeam.
+func resolveTrainProject(ctx *CommandContext, api *managementapi.Client, input string) (string, error) {
+	resp, err := api.GetTrainingProjects(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list training projects: %w", err)
+	}
+	found := ""
+	for _, project := range resp.TrainingProjects {
+		if project.Id == input {
+			return project.Id, nil
+		}
+		if project.Name == input {
+			if found != "" {
+				return "", cmd.NewErrUsagef("multiple training projects named %q; pass the project ID instead", input)
+			}
+			found = project.Id
+		}
+	}
+	if found == "" {
+		return "", fmt.Errorf("no training project found named %q", input)
+	}
+	return found, nil
+}
+
+func commandTrainCapacityDescribe(ctx *CommandContext, flags *cmd.TrainCapacityDescribeFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	resp, err := cl.API().GetTrainingCapacity(ctx)
+	if err != nil {
+		return fmt.Errorf("describe training capacity: %w", err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(resp)
+		return nil
+	}
+	if len(resp.GpuCapacities) == 0 {
+		ctx.LogLine("No training GPU capacity configured.")
+		return nil
+	}
+	rows := make([][]string, 0, len(resp.GpuCapacities))
+	for _, capacity := range resp.GpuCapacities {
+		rows = append(rows, []string{
+			capacity.GpuType,
+			fmt.Sprint(capacity.UsageCount),
+			fmt.Sprint(capacity.Limit),
+			fmt.Sprint(capacity.Baseline),
+		})
+	}
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"GPU TYPE", "IN USE", "LIMIT", "BASELINE"},
+		Rows:    rows,
+	})
+
+	if resp.TeamGpuCapacities == nil || len(*resp.TeamGpuCapacities) == 0 {
+		return nil
+	}
+	teamRows := make([][]string, 0, len(*resp.TeamGpuCapacities))
+	for _, capacity := range *resp.TeamGpuCapacities {
+		teamRows = append(teamRows, []string{
+			capacity.TeamName,
+			capacity.GpuType,
+			fmt.Sprint(capacity.UsageCount),
+			fmt.Sprint(capacity.Limit),
+			fmt.Sprint(capacity.Baseline),
+		})
+	}
+	ctx.Outputf("\n")
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"TEAM", "GPU TYPE", "IN USE", "LIMIT", "BASELINE"},
+		Rows:    teamRows,
+	})
+	return nil
+}
+
+func commandTrainCapacityUpdate(ctx *CommandContext, flags *cmd.TrainCapacityUpdateFlags) error {
+	if flags.MaxGPUs < 0 {
+		return cmd.NewErrUsagef("--max-gpus must be zero or a positive number")
+	}
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	teamID, err := ResolveTeam(ctx, cl.API(), flags.Team)
+	if err != nil {
+		return err
+	}
+	resp, err := cl.API().PatchTrainingCapacity(ctx, managementapi.PatchTeamTrainingGpuCapacityRequest{
+		TeamId:  teamID,
+		GpuType: flags.GPUType,
+		MaxGpus: flags.MaxGPUs,
+	})
+	if err != nil {
+		return fmt.Errorf("update training capacity for team %s: %w", flags.Team, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(resp)
+		return nil
+	}
+	ctx.Logf("Set %s limit to %d GPUs for team %s.\n",
+		resp.TeamGpuCapacity.GpuType, resp.TeamGpuCapacity.Limit, resp.TeamGpuCapacity.TeamName)
+	return nil
+}
+
+func commandTrainCheckpointList(ctx *CommandContext, flags *cmd.TrainCheckpointListFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := resolveTrainJob(ctx, cl.API(), flags.JobID)
+	if err != nil {
+		return err
+	}
+	resp, err := cl.API().GetTrainingProjectsJobsCheckpoints(ctx, ref.ProjectID, ref.JobID)
+	if err != nil {
+		return fmt.Errorf("list checkpoints for training job %s: %w", flags.JobID, err)
+	}
+
+	checkpoints := resp.Checkpoints
+	slices.SortStableFunc(checkpoints, func(a, b managementapi.TrainingJobCheckpoint) int {
+		if flags.Direction == "asc" {
+			return a.CreatedAt.Compare(b.CreatedAt)
+		}
+		return b.CreatedAt.Compare(a.CreatedAt)
+	})
+
+	if ctx.JSON {
+		ctx.OutputJSON(managementapi.GetTrainingJobCheckpointsResponse{
+			Checkpoints: checkpoints,
+			TrainingJob: resp.TrainingJob,
+		})
+		return nil
+	}
+	if len(checkpoints) == 0 {
+		ctx.LogLine("No checkpoints found.")
+		return nil
+	}
+	rows := make([][]string, 0, len(checkpoints))
+	for _, checkpoint := range checkpoints {
+		baseModel := ""
+		if checkpoint.BaseModel != nil {
+			baseModel = *checkpoint.BaseModel
+		}
+		syncStatus := ""
+		if checkpoint.SyncStatus != nil {
+			syncStatus = *checkpoint.SyncStatus
+		}
+		rows = append(rows, []string{
+			checkpoint.CheckpointId,
+			checkpoint.CheckpointType,
+			baseModel,
+			formatBytes(int64(checkpoint.SizeBytes)),
+			syncStatus,
+			checkpoint.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"ID", "TYPE", "BASE MODEL", "SIZE", "SYNC", "CREATED"},
+		Rows:    rows,
+	})
+	return nil
+}
+
+func commandTrainCheckpointFiles(ctx *CommandContext, flags *cmd.TrainCheckpointFilesFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := resolveTrainJob(ctx, cl.API(), flags.JobID)
+	if err != nil {
+		return err
+	}
+	var jw *JSONArrayWriter
+	if ctx.JSON {
+		jw = ctx.NewJSONArrayWriter()
+		defer jw.Close()
+	}
+	var rows [][]string
+
+	// The URLs are short-lived, so emit each record as its page arrives rather
+	// than buffering the whole listing. An empty page also ends the walk, so a
+	// server that keeps handing back a token cannot spin here forever.
+	params := managementapi.GetV1TrainingProjectsTrainingProjectIdJobsTrainingJobIdCheckpointFilesParams{}
+	for {
+		resp, err := cl.API().GetTrainingProjectsJobsCheckpointFiles(ctx, ref.ProjectID, ref.JobID, params)
+		if err != nil {
+			return fmt.Errorf("list checkpoint files for training job %s: %w", flags.JobID, err)
+		}
+		for _, file := range resp.PresignedUrls {
+			if ctx.JSON {
+				jw.Write(file)
+			} else {
+				rows = append(rows, []string{
+					fmt.Sprint(file.NodeRank),
+					file.RelativeFileName,
+					formatBytes(int64(file.SizeBytes)),
+					file.LastModified,
+					file.Url,
+				})
+			}
+		}
+		if resp.NextPageToken == nil || len(resp.PresignedUrls) == 0 {
+			break
+		}
+		params.PageToken = resp.NextPageToken
+	}
+
+	if ctx.JSON {
+		return nil
+	}
+	if len(rows) == 0 {
+		ctx.LogLine("No checkpoint files found.")
+		return nil
+	}
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"NODE", "NAME", "SIZE", "MODIFIED", "URL"},
+		Rows:    rows,
+	})
+	return nil
+}
+
+func commandTrainJobList(ctx *CommandContext, flags *cmd.TrainJobListFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	req := managementapi.SearchTrainingJobsRequest{}
+	if flags.Project != "" {
+		projectID, err := resolveTrainProject(ctx, cl.API(), flags.Project)
+		if err != nil {
+			return err
+		}
+		req.ProjectId = &projectID
+	}
+	if len(flags.Status) > 0 {
+		statuses := make([]string, 0, len(flags.Status))
+		for _, status := range flags.Status {
+			statuses = append(statuses, trainJobStatusToAPI(status))
+		}
+		req.Statuses = &statuses
+	}
+	order := []managementapi.OrderBy{{Field: "created_at", Order: flags.Direction}}
+	req.OrderBy = &order
+
+	resp, err := cl.API().PostTrainingJobsSearch(ctx, req)
+	if err != nil {
+		return fmt.Errorf("list training jobs: %w", err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(resp)
+		return nil
+	}
+	if len(resp.TrainingJobs) == 0 {
+		ctx.LogLine("No training jobs found.")
+		return nil
+	}
+	rows := make([][]string, 0, len(resp.TrainingJobs))
+	for _, job := range resp.TrainingJobs {
+		name := ""
+		if job.Name != nil {
+			name = *job.Name
+		}
+		nodes := ""
+		if job.NodeCount != nil {
+			nodes = fmt.Sprint(*job.NodeCount)
+		}
+		rows = append(rows, []string{
+			job.Id,
+			job.TrainingProject.Name,
+			name,
+			trainJobStatusFromAPI(job.CurrentStatus),
+			job.InstanceType.Name,
+			nodes,
+			job.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"ID", "PROJECT", "NAME", "STATUS", "INSTANCE TYPE", "NODES", "CREATED"},
+		Rows:    rows,
+	})
+	return nil
+}
+
+func commandTrainJobDescribe(ctx *CommandContext, flags *cmd.TrainJobDescribeFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := resolveTrainJob(ctx, cl.API(), flags.JobID)
+	if err != nil {
+		return err
+	}
+	resp, err := cl.API().GetTrainingProjectsJobsTrainingJobId(ctx, ref.ProjectID, ref.JobID)
+	if err != nil {
+		return fmt.Errorf("describe training job %s: %w", flags.JobID, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(resp)
+		return nil
+	}
+	job := resp.TrainingJob
+	ctx.Outputf("ID:             %s\n", job.Id)
+	if job.Name != nil {
+		ctx.Outputf("Name:           %s\n", *job.Name)
+	}
+	ctx.Outputf("Project:        %s (%s)\n", resp.TrainingProject.Name, resp.TrainingProject.Id)
+	ctx.Outputf("Status:         %s\n", trainJobStatusFromAPI(job.CurrentStatus))
+	if job.ErrorMessage != nil && *job.ErrorMessage != "" {
+		ctx.Outputf("Error:          %s\n", *job.ErrorMessage)
+	}
+	ctx.Outputf("Instance Type:  %s\n", job.InstanceType.Name)
+	if job.NodeCount != nil {
+		ctx.Outputf("Nodes:          %d\n", *job.NodeCount)
+	}
+	if job.AvailabilityModel != nil {
+		ctx.Outputf("Availability:   %s\n", *job.AvailabilityModel)
+	}
+	if job.Priority != nil {
+		ctx.Outputf("Priority:       %d\n", *job.Priority)
+	}
+	if job.CheckpointSyncStatus != nil {
+		ctx.Outputf("Checkpoints:    %s\n", *job.CheckpointSyncStatus)
+	}
+	if job.User != nil && job.User.Email != nil {
+		ctx.Outputf("Owner:          %s\n", *job.User.Email)
+	}
+	ctx.Outputf("Created:        %s\n", job.CreatedAt.UTC().Format(time.RFC3339))
+	ctx.Outputf("Updated:        %s\n", job.UpdatedAt.UTC().Format(time.RFC3339))
+	return nil
+}
+
+func commandTrainJobLogs(ctx *CommandContext, flags *cmd.TrainJobLogsFlags) error {
+	// The filters training logs do not offer stay zero-valued, which the shared
+	// logs flow treats as absent.
+	logFlags := cmd.LogFlags{
+		Tail:     flags.Tail,
+		Start:    flags.Start,
+		End:      flags.End,
+		Since:    flags.Since,
+		Limit:    flags.Limit,
+		PageSize: flags.PageSize,
+		MinLevel: flags.MinLevel,
+	}
+	if err := validateLogFlags(ctx, &logFlags); err != nil {
+		return err
+	}
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := resolveTrainJob(ctx, cl.API(), flags.JobID)
+	if err != nil {
+		return err
+	}
+
+	fetchLogs := func(q logQuery) (*managementapi.GetLogsResponse, error) {
+		direction := managementapi.SortOrder_desc
+		return cl.API().GetTrainingProjectsJobsLogs(ctx, ref.ProjectID, ref.JobID,
+			managementapi.GetV1TrainingProjectsTrainingProjectIdJobsTrainingJobIdLogsParams{
+				StartEpochMillis: q.StartEpochMillis,
+				EndEpochMillis:   q.EndEpochMillis,
+				Limit:            q.Limit,
+				Direction:        &direction,
+				MinLevel:         q.MinLevel,
+			})
+	}
+	fetchStatus := func() (*tailStatus, error) {
+		resp, err := cl.API().GetTrainingProjectsJobsTrainingJobId(ctx, ref.ProjectID, ref.JobID)
+		if err != nil {
+			return nil, err
+		}
+		status := resp.TrainingJob.CurrentStatus
+		return &tailStatus{
+			Label: trainJobStatusFromAPI(status),
+			// A job only produces logs while it is coming up or running. Every
+			// other status, including ones this build does not know, is treated
+			// as terminal so the tail cannot hang on a finished job.
+			Runnable: slices.Contains(trainJobRunnableStatuses, status),
+		}, nil
+	}
+	return runLogsCommand(ctx, &logFlags, fetchLogs, fetchStatus)
+}
+
+// trainJobRunnableStatuses are the statuses where a training job may still
+// produce logs: waiting for capacity, starting up, or running.
+var trainJobRunnableStatuses = []string{
+	"TRAINING_JOB_PENDING",
+	"TRAINING_JOB_CREATED",
+	"TRAINING_JOB_DEPLOYING",
+	"TRAINING_JOB_QUEUED",
+	"TRAINING_JOB_RUNNING",
+}
+
+func commandTrainJobMetrics(ctx *CommandContext, flags *cmd.TrainJobMetricsFlags) error {
+	hasStart := !flags.Start.IsZero()
+	hasEnd := !flags.End.IsZero()
+	// Use Changed rather than the zero value so explicit --since 0 fails the
+	// positive-duration check below instead of being silently dropped.
+	hasSince := ctx.Command.Flags().Changed("since")
+	if hasSince && (hasStart || hasEnd) {
+		return cmd.NewErrUsagef("--since cannot be combined with --start or --end")
+	}
+	if hasSince && flags.Since <= 0 {
+		return cmd.NewErrUsagef("--since must be a positive duration")
+	}
+	if hasStart && hasEnd && !flags.End.After(flags.Start) {
+		return cmd.NewErrUsagef("--end must be after --start")
+	}
+
+	params := managementapi.GetV1TrainingProjectsTrainingProjectIdJobsTrainingJobIdMetricsParams{}
+	if hasSince {
+		now := ctx.Now()
+		start := int(now.Add(-flags.Since).UnixMilli())
+		end := int(now.UnixMilli())
+		params.StartEpochMillis = &start
+		params.EndEpochMillis = &end
+	} else {
+		if hasStart {
+			start := int(flags.Start.UnixMilli())
+			params.StartEpochMillis = &start
+		}
+		if hasEnd {
+			end := int(flags.End.UnixMilli())
+			params.EndEpochMillis = &end
+		}
+	}
+
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := resolveTrainJob(ctx, cl.API(), flags.JobID)
+	if err != nil {
+		return err
+	}
+	resp, err := cl.API().GetTrainingProjectsJobsMetrics(ctx, ref.ProjectID, ref.JobID, params)
+	if err != nil {
+		return fmt.Errorf("fetch metrics for training job %s: %w", flags.JobID, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(resp)
+		return nil
+	}
+	var rows [][]string
+	// Per-node metrics carry the same series as the top-level fields, broken out
+	// by node, so a multi-node job reports each node rather than one blended
+	// figure. Single-node jobs still report one row per series.
+	for _, node := range resp.PerNodeMetrics {
+		rows = append(rows, trainMetricRows(node.NodeId, node.Metrics)...)
+	}
+	if len(resp.PerNodeMetrics) == 0 {
+		rows = append(rows, trainMetricRows("", managementapi.TrainingJobMetrics{
+			CpuUsage:            resp.CpuUsage,
+			CpuMemoryUsageBytes: resp.CpuMemoryUsageBytes,
+			GpuUtilization:      resp.GpuUtilization,
+			GpuMemoryUsageBytes: resp.GpuMemoryUsageBytes,
+			EphemeralStorage:    resp.EphemeralStorage,
+		})...)
+	}
+	if resp.Cache != nil {
+		rows = append(rows, trainStorageRows("", "cache", *resp.Cache)...)
+	}
+	if len(rows) == 0 {
+		ctx.LogLine("No metrics reported for this training job.")
+		return nil
+	}
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"METRIC", "NODE", "VALUE", "MEASURED"},
+		Rows:    rows,
+	})
+	return nil
+}
+
+// trainMetricRows renders one row per series, each holding that series' most
+// recent sample.
+func trainMetricRows(nodeID string, metrics managementapi.TrainingJobMetrics) [][]string {
+	var rows [][]string
+	if row, ok := trainMetricRow("cpu usage", nodeID, metrics.CpuUsage, func(v float32) string {
+		return fmt.Sprintf("%.2f cores", v)
+	}); ok {
+		rows = append(rows, row)
+	}
+	if row, ok := trainMetricRow("cpu memory", nodeID, metrics.CpuMemoryUsageBytes, func(v float32) string {
+		return formatBytes(int64(v))
+	}); ok {
+		rows = append(rows, row)
+	}
+	for _, gpu := range slices.Sorted(maps.Keys(metrics.GpuUtilization)) {
+		if row, ok := trainMetricRow(fmt.Sprintf("gpu %s utilization", gpu), nodeID, metrics.GpuUtilization[gpu], func(v float32) string {
+			return fmt.Sprintf("%.1f%%", v*100)
+		}); ok {
+			rows = append(rows, row)
+		}
+	}
+	for _, gpu := range slices.Sorted(maps.Keys(metrics.GpuMemoryUsageBytes)) {
+		if row, ok := trainMetricRow(fmt.Sprintf("gpu %s memory", gpu), nodeID, metrics.GpuMemoryUsageBytes[gpu], func(v float32) string {
+			return formatBytes(int64(v))
+		}); ok {
+			rows = append(rows, row)
+		}
+	}
+	return append(rows, trainStorageRows(nodeID, "ephemeral storage", metrics.EphemeralStorage)...)
+}
+
+// trainStorageRows renders the usage and utilization series of one storage
+// volume.
+func trainStorageRows(nodeID, label string, storage managementapi.StorageMetrics) [][]string {
+	var rows [][]string
+	if row, ok := trainMetricRow(label+" usage", nodeID, storage.UsageBytes, func(v float32) string {
+		return formatBytes(int64(v))
+	}); ok {
+		rows = append(rows, row)
+	}
+	if row, ok := trainMetricRow(label+" utilization", nodeID, storage.Utilization, func(v float32) string {
+		return fmt.Sprintf("%.1f%%", v*100)
+	}); ok {
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// trainMetricRow renders a series' most recent sample, reporting false when the
+// series is empty so the caller can omit the row entirely.
+func trainMetricRow(label, nodeID string, series []managementapi.TrainingJobMetric, format func(float32) string) ([]string, bool) {
+	if len(series) == 0 {
+		return nil, false
+	}
+	latest := series[0]
+	for _, sample := range series[1:] {
+		if sample.Timestamp.After(latest.Timestamp) {
+			latest = sample
+		}
+	}
+	return []string{label, nodeID, format(latest.Value), latest.Timestamp.UTC().Format(time.RFC3339)}, true
+}
+
+func commandTrainJobStop(ctx *CommandContext, flags *cmd.TrainJobStopFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := resolveTrainJob(ctx, cl.API(), flags.JobID)
+	if err != nil {
+		return err
+	}
+	if !flags.Yes {
+		if err := ctx.ConfirmYesNo(fmt.Sprintf(
+			"Stop training job %s in project %s? This cannot be undone.", ref.JobID, ref.ProjectName)); err != nil {
+			return err
+		}
+	}
+	resp, err := cl.API().PostTrainingProjectsJobsStop(ctx, ref.ProjectID, ref.JobID,
+		managementapi.StopTrainingJobRequest{})
+	if err != nil {
+		return fmt.Errorf("stop training job %s: %w", flags.JobID, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(resp)
+		return nil
+	}
+	ctx.Logf("Stopped training job %s. Synced checkpoints remain accessible.\n", resp.TrainingJob.Id)
+	return nil
+}
+
+func commandTrainJobRecreate(ctx *CommandContext, flags *cmd.TrainJobRecreateFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := resolveTrainJob(ctx, cl.API(), flags.JobID)
+	if err != nil {
+		return err
+	}
+	resp, err := cl.API().PostTrainingProjectsJobsRecreate(ctx, ref.ProjectID, ref.JobID)
+	if err != nil {
+		return fmt.Errorf("recreate training job %s: %w", flags.JobID, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(resp)
+		return nil
+	}
+	ctx.Logf("Created training job %s from %s.\n", resp.TrainingJob.Id, flags.JobID)
+	return nil
+}
+
+func commandTrainJobUpdate(ctx *CommandContext, flags *cmd.TrainJobUpdateFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := resolveTrainJob(ctx, cl.API(), flags.JobID)
+	if err != nil {
+		return err
+	}
+	resp, err := cl.API().PatchTrainingProjectsJobs(ctx, ref.ProjectID, ref.JobID,
+		managementapi.UpdateTrainingJobRequest{Priority: flags.Priority})
+	if err != nil {
+		return fmt.Errorf("update training job %s: %w", flags.JobID, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(resp)
+		return nil
+	}
+	ctx.Logf("Set training job %s priority to %d.\n", resp.TrainingJob.Id, flags.Priority)
+	return nil
+}
+
+func commandTrainJobDownload(ctx *CommandContext, flags *cmd.TrainJobDownloadFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := resolveTrainJob(ctx, cl.API(), flags.JobID)
+	if err != nil {
+		return err
+	}
+	resp, err := cl.API().GetTrainingProjectsJobsDownload(ctx, ref.ProjectID, ref.JobID)
+	if err != nil {
+		return fmt.Errorf("download training job %s: %w", flags.JobID, err)
+	}
+	if len(resp.ArtifactPresignedUrls) == 0 {
+		return fmt.Errorf("training job %s has no artifacts to download", flags.JobID)
+	}
+	if err := os.MkdirAll(flags.Dir, 0o755); err != nil {
+		return fmt.Errorf("create download dir: %w", err)
+	}
+
+	// The archive name follows the job, not the URL, whose path is an opaque
+	// storage key. A job with several artifacts gets each suffixed by index.
+	baseName := strings.ReplaceAll(fmt.Sprintf("%s-%s", ref.ProjectName, ref.JobID), " ", "-")
+	result := cmd.TrainJobDownloadResult{JobID: ref.JobID}
+	for i, artifactURL := range resp.ArtifactPresignedUrls {
+		name := baseName
+		if len(resp.ArtifactPresignedUrls) > 1 {
+			name = fmt.Sprintf("%s-%d", baseName, i+1)
+		}
+		path, err := trainDownloadArtifact(ctx, artifactURL, flags.Dir, name, !flags.NoExtract)
+		if err != nil {
+			return err
+		}
+		result.Paths = append(result.Paths, path)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(result)
+		return nil
+	}
+	for _, path := range result.Paths {
+		ctx.Logf("Downloaded training job %s to %s\n", ref.JobID, path)
+	}
+	return nil
+}
+
+// trainDownloadArtifact fetches one presigned artifact into dir, either as
+// "<name>.tgz" or extracted into a "<name>" directory. It returns the absolute
+// path written.
+func trainDownloadArtifact(ctx *CommandContext, artifactURL, dir, name string, extract bool) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, artifactURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build artifact request: %w", err)
+	}
+	// The URL is presigned, so it carries its own credentials and must not go
+	// through the authenticated management client.
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch artifact: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch artifact: unexpected status %s", resp.Status)
+	}
+
+	if !extract {
+		path, err := filepath.Abs(filepath.Join(dir, name+".tgz"))
+		if err != nil {
+			return "", err
+		}
+		f, err := os.Create(path)
+		if err != nil {
+			return "", fmt.Errorf("create %s: %w", path, err)
+		}
+		defer f.Close()
+		if _, err := io.Copy(f, resp.Body); err != nil {
+			return "", fmt.Errorf("write %s: %w", path, err)
+		}
+		return path, nil
+	}
+
+	root, err := filepath.Abs(filepath.Join(dir, name))
+	if err != nil {
+		return "", err
+	}
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read artifact archive: %w", err)
+	}
+	defer gz.Close()
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return "", fmt.Errorf("create %s: %w", root, err)
+	}
+	if err := extractTar(gz, root); err != nil {
+		return "", fmt.Errorf("extract archive into %s: %w", root, err)
+	}
+	return root, nil
+}
+
+func commandTrainJobSessionDescribe(ctx *CommandContext, flags *cmd.TrainJobSessionDescribeFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	ref, err := resolveTrainJob(ctx, cl.API(), flags.JobID)
+	if err != nil {
+		return err
+	}
+	resp, err := cl.API().GetTrainingProjectsJobsAuthCodes(ctx, ref.ProjectID, ref.JobID)
+	if err != nil {
+		return fmt.Errorf("describe interactive sessions for training job %s: %w", flags.JobID, err)
+	}
+
+	if ctx.JSON {
+		ctx.OutputJSON(resp)
+		return nil
+	}
+	if len(resp.AuthCodes) == 0 {
+		ctx.LogLine("No interactive sessions found.")
+		return nil
+	}
+	rows := make([][]string, 0, len(resp.AuthCodes))
+	for _, code := range resp.AuthCodes {
+		expires := ""
+		if code.ExpiresAt != nil {
+			expires = code.ExpiresAt.UTC().Format(time.RFC3339)
+		}
+		rows = append(rows, []string{
+			code.ReplicaId,
+			code.SessionId,
+			hyperlink(ctx.Stdout, code.AuthUrl),
+			expires,
+		})
+	}
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"REPLICA", "SESSION", "AUTH URL", "EXPIRES"},
+		Rows:    rows,
+	})
+	return nil
+}
+
+func commandTrainProjectList(ctx *CommandContext, flags *cmd.TrainProjectListFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	resp, err := cl.API().GetTrainingProjects(ctx)
+	if err != nil {
+		return fmt.Errorf("list training projects: %w", err)
+	}
+
+	projects := resp.TrainingProjects
+	slices.SortStableFunc(projects, func(a, b managementapi.TrainingProject) int {
+		return b.CreatedAt.Compare(a.CreatedAt)
+	})
+
+	if ctx.JSON {
+		ctx.OutputJSON(managementapi.ListTrainingProjectsResponse{TrainingProjects: projects})
+		return nil
+	}
+	if len(projects) == 0 {
+		ctx.LogLine("No training projects found.")
+		return nil
+	}
+	rows := make([][]string, 0, len(projects))
+	for _, project := range projects {
+		team := ""
+		if project.TeamName != nil {
+			team = *project.TeamName
+		}
+		latestJob, latestStatus := "", ""
+		if project.LatestJob != nil {
+			latestJob = project.LatestJob.Id
+			latestStatus = trainJobStatusFromAPI(project.LatestJob.CurrentStatus)
+		}
+		rows = append(rows, []string{
+			project.Id,
+			project.Name,
+			team,
+			latestJob,
+			latestStatus,
+			project.CreatedAt.UTC().Format(time.RFC3339),
+		})
+	}
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"ID", "NAME", "TEAM", "LATEST JOB", "LATEST STATUS", "CREATED"},
+		Rows:    rows,
+	})
+	return nil
+}
+
+func commandTrainProjectCacheDescribe(ctx *CommandContext, flags *cmd.TrainProjectCacheDescribeFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	projectID, err := resolveTrainProject(ctx, cl.API(), flags.Project)
+	if err != nil {
+		return err
+	}
+	resp, err := cl.API().GetTrainingProjectsCacheSummary(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("describe cache for training project %s: %w", flags.Project, err)
+	}
+
+	files := resp.FileSummaries
+	slices.SortStableFunc(files, func(a, b managementapi.FileSummary) int {
+		if flags.Sort == "path" {
+			return strings.Compare(a.Path, b.Path)
+		}
+		return b.SizeBytes - a.SizeBytes
+	})
+
+	if ctx.JSON {
+		ctx.OutputJSON(managementapi.GetCacheSummaryResponse{
+			FileSummaries: files,
+			ProjectId:     resp.ProjectId,
+			Timestamp:     resp.Timestamp,
+		})
+		return nil
+	}
+	if len(files) == 0 {
+		ctx.LogLine("Cache is empty.")
+		return nil
+	}
+	total := 0
+	rows := make([][]string, 0, len(files))
+	for _, file := range files {
+		total += file.SizeBytes
+		rows = append(rows, []string{
+			file.Path,
+			file.FileType,
+			formatBytes(int64(file.SizeBytes)),
+			file.Permissions,
+			file.Modified,
+		})
+	}
+	ctx.Outputf("Total: %s across %d files\n\n", formatBytes(int64(total)), len(files))
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"PATH", "TYPE", "SIZE", "PERMISSIONS", "MODIFIED"},
+		Rows:    rows,
+	})
+	return nil
+}

--- a/internal/cmd/command.train_test.go
+++ b/internal/cmd/command.train_test.go
@@ -1,0 +1,812 @@
+package cmd_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/internal/cmd"
+)
+
+const (
+	trainSearchPath      = "/v1/training_jobs/search"
+	trainProjectsPath    = "/v1/training_projects"
+	trainJobPath         = "/v1/training_projects/proj-1/jobs/job-1"
+	trainCapacityPath    = "/v1/training/capacity"
+	trainCacheSummaryPat = "/v1/training_projects/proj-1/cache/summary"
+)
+
+func trainInstanceTypeFixture() map[string]any {
+	return map[string]any{
+		"id":                   "4xH100",
+		"name":                 "4xH100",
+		"gpu_count":            4,
+		"gpu_type":             "H100",
+		"gpu_memory_limit_mib": 81920,
+		"memory_limit_mib":     262144,
+		"millicpu_limit":       26000,
+	}
+}
+
+func trainJobFixture(id, status string) map[string]any {
+	return map[string]any{
+		"id":                  id,
+		"name":                "job-" + id,
+		"created_at":          "2026-05-14T12:00:00Z",
+		"updated_at":          "2026-05-14T13:00:00Z",
+		"current_status":      status,
+		"instance_type":       trainInstanceTypeFixture(),
+		"node_count":          2,
+		"priority":            5,
+		"availability_model":  "DEDICATED",
+		"training_project":    map[string]any{"id": "proj-1", "name": "my-project"},
+		"training_project_id": "proj-1",
+		"user":                map[string]any{"email": "owner@example.com"},
+	}
+}
+
+// mockTrainJobSearch routes the job-id lookup every job command performs to
+// resolve its project.
+func mockTrainJobSearch(m *MockManagementAPI, job map[string]any) {
+	m.SetRoute("POST", trainSearchPath, 200, map[string]any{"training_jobs": []any{job}})
+}
+
+func Test_Train_Job_List(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", trainSearchPath, 200, map[string]any{
+		"training_jobs": []any{trainJobFixture("job-1", "TRAINING_JOB_RUNNING")},
+	})
+
+	h.Require.NoError(h.Execute("train", "job", "list"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "job-1")
+	h.Require.Contains(out, "my-project")
+	h.Require.Contains(out, "4xH100")
+	// Statuses print in the CLI spelling, not the API's.
+	h.Require.Contains(out, "running")
+	h.Require.NotContains(out, "TRAINING_JOB_RUNNING")
+}
+
+func Test_Train_Job_List_Empty(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("POST", trainSearchPath, 200, map[string]any{"training_jobs": []any{}})
+
+	h.Require.NoError(h.Execute("train", "job", "list"))
+	h.Require.Equal("", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "No training jobs found.")
+}
+
+func Test_Train_Job_List_StatusAndProjectFilters(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", trainProjectsPath, 200, map[string]any{
+		"training_projects": []any{map[string]any{
+			"id": "proj-1", "name": "my-project",
+			"created_at": "2026-05-14T12:00:00Z", "updated_at": "2026-05-14T12:00:00Z",
+			"latest_job": nil,
+		}},
+	})
+	m.SetRoute("POST", trainSearchPath, 200, map[string]any{"training_jobs": []any{}})
+
+	h.Require.NoError(h.Execute("train", "job", "list",
+		"--project", "my-project", "--status", "running", "--status", "deploy-failed", "--direction", "asc"))
+	body := m.FindCall("POST", trainSearchPath).BodyJSON(t)
+	h.Require.Equal("proj-1", body["project_id"])
+	// CLI spellings are expanded to the API's.
+	h.Require.Equal([]any{"TRAINING_JOB_RUNNING", "TRAINING_JOB_DEPLOY_FAILED"}, body["statuses"])
+	h.Require.Equal([]any{map[string]any{"field": "created_at", "order": "asc"}}, body["order_by"])
+}
+
+func Test_Train_Job_List_StatusAcceptsAPISpelling(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", trainSearchPath, 200, map[string]any{"training_jobs": []any{}})
+
+	h.Require.NoError(h.Execute("train", "job", "list", "--status", "TRAINING_JOB_RUNNING"))
+	body := m.FindCall("POST", trainSearchPath).BodyJSON(t)
+	h.Require.Equal([]any{"TRAINING_JOB_RUNNING"}, body["statuses"])
+}
+
+func Test_Train_Job_List_UnknownStatusPassesThrough(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", trainSearchPath, 200, map[string]any{
+		// A status this build predates still renders, rather than showing blank.
+		"training_jobs": []any{trainJobFixture("job-1", "TRAINING_JOB_HIBERNATING")},
+	})
+
+	h.Require.NoError(h.Execute("train", "job", "list", "--status", "hibernating"))
+	h.Require.Equal([]any{"TRAINING_JOB_HIBERNATING"},
+		m.FindCall("POST", trainSearchPath).BodyJSON(t)["statuses"])
+	h.Require.Contains(h.Stdout.String(), "hibernating")
+}
+
+func Test_Train_Job_List_JSONKeepsAPIStatus(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", trainSearchPath, 200, map[string]any{
+		"training_jobs": []any{trainJobFixture("job-1", "TRAINING_JOB_RUNNING")},
+	})
+
+	h.Require.NoError(h.Execute("train", "job", "list", "--output", "json"))
+	h.Require.Contains(h.Stdout.String(), `"current_status": "TRAINING_JOB_RUNNING"`)
+}
+
+func Test_Train_Job_Describe(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_RUNNING"))
+	m.SetRoute("GET", trainJobPath, 200, map[string]any{
+		"training_job": trainJobFixture("job-1", "TRAINING_JOB_RUNNING"),
+		"training_project": map[string]any{
+			"id": "proj-1", "name": "my-project",
+			"created_at": "2026-05-14T12:00:00Z", "updated_at": "2026-05-14T12:00:00Z",
+			"latest_job": nil,
+		},
+	})
+
+	h.Require.NoError(h.Execute("train", "job", "describe", "--job-id", "job-1"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "ID:             job-1")
+	h.Require.Contains(out, "Project:        my-project (proj-1)")
+	h.Require.Contains(out, "Status:         running")
+	h.Require.Contains(out, "Nodes:          2")
+}
+
+func Test_Train_Job_Describe_UnknownJob(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", trainSearchPath, 200, map[string]any{"training_jobs": []any{}})
+
+	err := h.Execute("train", "job", "describe", "--job-id", "nope")
+	h.Require.ErrorContains(err, "no training job found with ID nope")
+	// The job endpoint is never reached without a resolved project.
+	h.Require.Nil(m.FindCall("GET", trainJobPath))
+}
+
+func Test_Train_Job_Stop_RequiresConfirmation(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_RUNNING"))
+
+	err := h.Execute("train", "job", "stop", "--job-id", "job-1")
+	h.Require.Error(err)
+	h.Require.Nil(m.FindCall("POST", trainJobPath+"/stop"))
+}
+
+func Test_Train_Job_Stop(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_RUNNING"))
+	m.SetRoute("POST", trainJobPath+"/stop", 200, map[string]any{
+		"training_job": trainJobFixture("job-1", "TRAINING_JOB_STOPPED"),
+	})
+
+	h.Require.NoError(h.Execute("train", "job", "stop", "--job-id", "job-1", "--yes"))
+	h.Require.NotNil(m.FindCall("POST", trainJobPath+"/stop"))
+	h.Require.Equal("", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "Stopped training job job-1")
+}
+
+func Test_Train_Job_Recreate(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
+	m.SetRoute("POST", trainJobPath+"/recreate", 200, map[string]any{
+		"training_job": trainJobFixture("job-2", "TRAINING_JOB_CREATED"),
+	})
+
+	h.Require.NoError(h.Execute("train", "job", "recreate", "--job-id", "job-1"))
+	h.Require.Contains(h.Stderr.String(), "Created training job job-2 from job-1")
+}
+
+func Test_Train_Job_Update(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_PENDING"))
+	m.SetRoute("PATCH", trainJobPath, 200, map[string]any{
+		"training_job": trainJobFixture("job-1", "TRAINING_JOB_PENDING"),
+	})
+
+	h.Require.NoError(h.Execute("train", "job", "update", "--job-id", "job-1", "--priority", "10"))
+	body := m.FindCall("PATCH", trainJobPath).BodyJSON(t)
+	h.Require.Equal(float64(10), body["priority"])
+	h.Require.Contains(h.Stderr.String(), "priority to 10")
+}
+
+func Test_Train_Job_Logs(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_RUNNING"))
+	m.SetRoute("GET", trainJobPath+"/logs", 200, map[string]any{
+		"logs": []any{map[string]any{
+			"timestamp": "1747224000000000000",
+			"message":   "epoch 1 complete",
+		}},
+	})
+
+	h.Require.NoError(h.Execute("train", "job", "logs", "--job-id", "job-1"))
+	h.Require.Contains(h.Stdout.String(), "epoch 1 complete")
+}
+
+func Test_Train_Job_Metrics(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_RUNNING"))
+	m.SetRoute("GET", trainJobPath+"/metrics", 200, map[string]any{
+		"training_job":           trainJobFixture("job-1", "TRAINING_JOB_RUNNING"),
+		"cpu_usage":              []any{},
+		"cpu_memory_usage_bytes": []any{},
+		"gpu_utilization":        map[string]any{},
+		"gpu_memory_usage_bytes": map[string]any{},
+		"ephemeral_storage":      map[string]any{"usage_bytes": []any{}, "utilization": []any{}},
+		"cache":                  nil,
+		"per_node_metrics": []any{map[string]any{
+			"node_id": "node-0",
+			"metrics": map[string]any{
+				// Samples arrive unordered; the latest one is reported.
+				"cpu_usage": []any{
+					map[string]any{"timestamp": "2026-05-14T12:00:00Z", "value": 1.5},
+					map[string]any{"timestamp": "2026-05-14T12:05:00Z", "value": 3.25},
+					map[string]any{"timestamp": "2026-05-14T12:02:00Z", "value": 2.0},
+				},
+				"cpu_memory_usage_bytes": []any{},
+				"gpu_utilization": map[string]any{
+					"0": []any{map[string]any{"timestamp": "2026-05-14T12:05:00Z", "value": 0.42}},
+				},
+				"gpu_memory_usage_bytes": map[string]any{},
+				"ephemeral_storage":      map[string]any{"usage_bytes": []any{}, "utilization": []any{}},
+			},
+		}},
+	})
+
+	h.Require.NoError(h.Execute("train", "job", "metrics", "--job-id", "job-1"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "node-0")
+	h.Require.Contains(out, "3.25 cores")
+	h.Require.Contains(out, "42.0%")
+	// Series with no samples are omitted rather than shown as zero.
+	h.Require.NotContains(out, "cpu memory")
+}
+
+func Test_Train_Job_Metrics_Window(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_RUNNING"))
+	m.SetRoute("GET", trainJobPath+"/metrics", 200, map[string]any{
+		"training_job":           trainJobFixture("job-1", "TRAINING_JOB_RUNNING"),
+		"cpu_usage":              []any{},
+		"cpu_memory_usage_bytes": []any{},
+		"gpu_utilization":        map[string]any{},
+		"gpu_memory_usage_bytes": map[string]any{},
+		"ephemeral_storage":      map[string]any{"usage_bytes": []any{}, "utilization": []any{}},
+		"cache":                  nil,
+		"per_node_metrics":       []any{},
+	})
+
+	h.Require.NoError(h.Execute("train", "job", "metrics", "--job-id", "job-1", "--since", "1h"))
+	q := m.FindCall("GET", trainJobPath+"/metrics").Query()
+	h.Require.NotEmpty(q.Get("start_epoch_millis"))
+	h.Require.NotEmpty(q.Get("end_epoch_millis"))
+	h.Require.Contains(h.Stderr.String(), "No metrics reported")
+}
+
+func Test_Train_Job_Metrics_SinceWithStartRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+
+	err := h.Execute("train", "job", "metrics", "--job-id", "job-1",
+		"--since", "1h", "--start", "2026-05-14T12:00:00Z")
+	h.Require.ErrorContains(err, "--since cannot be combined with --start or --end")
+	h.Require.Empty(m.Calls())
+}
+
+func Test_Train_Job_Session_Describe(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_RUNNING"))
+	m.SetRoute("GET", trainJobPath+"/auth_codes", 200, map[string]any{
+		"auth_codes": []any{map[string]any{
+			"auth_code":  "code-1",
+			"auth_url":   "https://sessions.example.com/code-1",
+			"replica_id": "replica-0",
+			"session_id": "sess-1",
+			"expires_at": "2026-05-14T14:00:00Z",
+		}},
+	})
+
+	h.Require.NoError(h.Execute("train", "job", "session", "describe", "--job-id", "job-1"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "replica-0")
+	h.Require.Contains(out, "sess-1")
+}
+
+func Test_Train_Job_Session_Describe_None(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_RUNNING"))
+	m.SetRoute("GET", trainJobPath+"/auth_codes", 200, map[string]any{"auth_codes": []any{}})
+
+	h.Require.NoError(h.Execute("train", "job", "session", "describe", "--job-id", "job-1"))
+	h.Require.Equal("", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "No interactive sessions found.")
+}
+
+// trainArtifactTarGz builds a gzipped tar holding one file, standing in for a
+// job's uploaded code archive.
+func trainArtifactTarGz(t *testing.T, name, content string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: name, Mode: 0o644, Size: int64(len(content)), Typeflag: tar.TypeReg,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func Test_Train_Job_Download_Extracts(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
+	archive := trainArtifactTarGz(t, "train.py", "print('hi')")
+	m.SetRouteFunc("GET", "/artifact.tgz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	m.SetRoute("GET", trainJobPath+"/download", 200, map[string]any{
+		"artifact_presigned_urls": []any{m.URL + "/artifact.tgz"},
+	})
+	dir := t.TempDir()
+
+	h.Require.NoError(h.Execute("train", "job", "download", "--job-id", "job-1", "--dir", dir))
+	extracted := filepath.Join(dir, "my-project-job-1", "train.py")
+	content, err := os.ReadFile(extracted)
+	h.Require.NoError(err)
+	h.Require.Equal("print('hi')", string(content))
+	h.Require.Contains(h.Stderr.String(), extracted[:len(dir)])
+}
+
+func Test_Train_Job_Download_NoExtract(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
+	archive := trainArtifactTarGz(t, "train.py", "print('hi')")
+	m.SetRouteFunc("GET", "/artifact.tgz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	m.SetRoute("GET", trainJobPath+"/download", 200, map[string]any{
+		"artifact_presigned_urls": []any{m.URL + "/artifact.tgz"},
+	})
+	dir := t.TempDir()
+
+	h.Require.NoError(h.Execute("train", "job", "download",
+		"--job-id", "job-1", "--dir", dir, "--no-extract"))
+	written, err := os.ReadFile(filepath.Join(dir, "my-project-job-1.tgz"))
+	h.Require.NoError(err)
+	h.Require.Equal(archive, written)
+}
+
+func Test_Train_Job_Download_NoArtifacts(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
+	m.SetRoute("GET", trainJobPath+"/download", 200, map[string]any{"artifact_presigned_urls": []any{}})
+
+	err := h.Execute("train", "job", "download", "--job-id", "job-1", "--dir", t.TempDir())
+	h.Require.ErrorContains(err, "has no artifacts to download")
+}
+
+func Test_Train_Checkpoint_List(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
+	m.SetRoute("GET", trainJobPath+"/checkpoints", 200, map[string]any{
+		"training_job": trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"),
+		"checkpoints": []any{
+			map[string]any{
+				"checkpoint_id": "ckpt-old", "checkpoint_type": "full",
+				"created_at": "2026-05-14T12:00:00Z", "size_bytes": 2048,
+				"base_model": "Qwen/Qwen3-8B", "sync_status": "COMPLETE",
+				"lora_adapter_config": nil,
+			},
+			map[string]any{
+				"checkpoint_id": "ckpt-new", "checkpoint_type": "full",
+				"created_at": "2026-05-14T13:00:00Z", "size_bytes": 4096,
+				"base_model": "Qwen/Qwen3-8B", "sync_status": "SYNCING",
+				"lora_adapter_config": nil,
+			},
+		},
+	})
+
+	h.Require.NoError(h.Execute("train", "checkpoint", "list", "--job-id", "job-1"))
+	out := h.Stdout.String()
+	// Newest first by default.
+	h.Require.Less(strings.Index(out, "ckpt-new"), strings.Index(out, "ckpt-old"))
+	h.Require.Contains(out, "4.0 KiB")
+}
+
+func Test_Train_Checkpoint_List_Ascending(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
+	m.SetRoute("GET", trainJobPath+"/checkpoints", 200, map[string]any{
+		"training_job": trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"),
+		"checkpoints": []any{
+			map[string]any{
+				"checkpoint_id": "ckpt-new", "checkpoint_type": "full",
+				"created_at": "2026-05-14T13:00:00Z", "size_bytes": 4096,
+				"base_model": "Qwen/Qwen3-8B", "sync_status": "COMPLETE",
+				"lora_adapter_config": nil,
+			},
+			map[string]any{
+				"checkpoint_id": "ckpt-old", "checkpoint_type": "full",
+				"created_at": "2026-05-14T12:00:00Z", "size_bytes": 2048,
+				"base_model": "Qwen/Qwen3-8B", "sync_status": "COMPLETE",
+				"lora_adapter_config": nil,
+			},
+		},
+	})
+
+	h.Require.NoError(h.Execute("train", "checkpoint", "list", "--job-id", "job-1", "--direction", "asc"))
+	out := h.Stdout.String()
+	h.Require.Less(strings.Index(out, "ckpt-old"), strings.Index(out, "ckpt-new"))
+}
+
+func Test_Train_Checkpoint_Files_Paged(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
+	page := 0
+	m.SetRouteFunc("GET", trainJobPath+"/checkpoint_files", func(w http.ResponseWriter, r *http.Request) {
+		page++
+		w.Header().Set("Content-Type", "application/json")
+		if page == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_count":     2,
+				"next_page_token": 2,
+				"presigned_urls": []any{map[string]any{
+					"relative_file_name": "shard-1.safetensors", "size_bytes": 1024,
+					"url": "https://files.example.com/1", "node_rank": 0,
+					"last_modified": "2026-05-14T12:00:00Z",
+				}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"total_count":     2,
+			"next_page_token": nil,
+			"presigned_urls": []any{map[string]any{
+				"relative_file_name": "shard-2.safetensors", "size_bytes": 2048,
+				"url": "https://files.example.com/2", "node_rank": 1,
+				"last_modified": "2026-05-14T12:00:00Z",
+			}},
+		})
+	})
+
+	h.Require.NoError(h.Execute("train", "checkpoint", "files", "--job-id", "job-1"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "shard-1.safetensors")
+	h.Require.Contains(out, "shard-2.safetensors")
+	h.Require.Equal(2, page)
+}
+
+func Test_Train_Checkpoint_Files_JSONStreamsArray(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
+	m.SetRoute("GET", trainJobPath+"/checkpoint_files", 200, map[string]any{
+		"total_count":     1,
+		"next_page_token": nil,
+		"presigned_urls": []any{map[string]any{
+			"relative_file_name": "shard-1.safetensors", "size_bytes": 1024,
+			"url": "https://files.example.com/1", "node_rank": 0,
+			"last_modified": "2026-05-14T12:00:00Z",
+		}},
+	})
+
+	h.Require.NoError(h.Execute("train", "checkpoint", "files", "--job-id", "job-1", "--output", "json"))
+	out := h.Stdout.String()
+	// A bare array of file records, with no envelope around it.
+	h.Require.Contains(out, `"relative_file_name": "shard-1.safetensors"`)
+	h.Require.NotContains(out, "checkpoint_artifacts")
+	h.Require.Equal("[", out[:1])
+}
+
+func Test_Train_Checkpoint_Files_Empty(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
+	m.SetRoute("GET", trainJobPath+"/checkpoint_files", 200, map[string]any{
+		"total_count": 0, "next_page_token": nil, "presigned_urls": []any{},
+	})
+
+	h.Require.NoError(h.Execute("train", "checkpoint", "files", "--job-id", "job-1"))
+	h.Require.Contains(h.Stderr.String(), "No checkpoint files found.")
+}
+
+func Test_Train_Project_List(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", trainProjectsPath, 200, map[string]any{
+		"training_projects": []any{
+			map[string]any{
+				"id": "proj-old", "name": "older", "team_name": "ml",
+				"created_at": "2026-05-13T12:00:00Z", "updated_at": "2026-05-13T12:00:00Z",
+				"latest_job": nil,
+			},
+			map[string]any{
+				"id": "proj-new", "name": "newer",
+				"created_at": "2026-05-14T12:00:00Z", "updated_at": "2026-05-14T12:00:00Z",
+				"latest_job": trainJobFixture("job-1", "TRAINING_JOB_RUNNING"),
+			},
+		},
+	})
+
+	h.Require.NoError(h.Execute("train", "project", "list"))
+	out := h.Stdout.String()
+	h.Require.Less(strings.Index(out, "proj-new"), strings.Index(out, "proj-old"))
+	h.Require.Contains(out, "running")
+	h.Require.Contains(out, "ml")
+}
+
+func Test_Train_Project_List_Empty(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", trainProjectsPath, 200,
+		map[string]any{"training_projects": []any{}})
+
+	h.Require.NoError(h.Execute("train", "project", "list"))
+	h.Require.Contains(h.Stderr.String(), "No training projects found.")
+}
+
+func Test_Train_Project_Cache_Describe(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", trainProjectsPath, 200, map[string]any{
+		"training_projects": []any{map[string]any{
+			"id": "proj-1", "name": "my-project",
+			"created_at": "2026-05-14T12:00:00Z", "updated_at": "2026-05-14T12:00:00Z",
+			"latest_job": nil,
+		}},
+	})
+	m.SetRoute("GET", trainCacheSummaryPat, 200, map[string]any{
+		"project_id": "proj-1",
+		"timestamp":  "2026-05-14T12:00:00Z",
+		"file_summaries": []any{
+			map[string]any{
+				"path": "a-small.bin", "file_type": "file", "size_bytes": 1024,
+				"permissions": "rw-r--r--", "modified": "2026-05-14T12:00:00Z",
+			},
+			map[string]any{
+				"path": "z-large.bin", "file_type": "file", "size_bytes": 8192,
+				"permissions": "rw-r--r--", "modified": "2026-05-14T12:00:00Z",
+			},
+		},
+	})
+
+	h.Require.NoError(h.Execute("train", "project", "cache", "describe", "--project", "my-project"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "Total: 9.0 KiB across 2 files")
+	// Largest first by default.
+	h.Require.Less(strings.Index(out, "z-large.bin"), strings.Index(out, "a-small.bin"))
+}
+
+func Test_Train_Project_Cache_Describe_SortByPath(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", trainProjectsPath, 200, map[string]any{
+		"training_projects": []any{map[string]any{
+			"id": "proj-1", "name": "my-project",
+			"created_at": "2026-05-14T12:00:00Z", "updated_at": "2026-05-14T12:00:00Z",
+			"latest_job": nil,
+		}},
+	})
+	m.SetRoute("GET", trainCacheSummaryPat, 200, map[string]any{
+		"project_id": "proj-1",
+		"timestamp":  "2026-05-14T12:00:00Z",
+		"file_summaries": []any{
+			map[string]any{
+				"path": "z-large.bin", "file_type": "file", "size_bytes": 8192,
+				"permissions": "rw-r--r--", "modified": "2026-05-14T12:00:00Z",
+			},
+			map[string]any{
+				"path": "a-small.bin", "file_type": "file", "size_bytes": 1024,
+				"permissions": "rw-r--r--", "modified": "2026-05-14T12:00:00Z",
+			},
+		},
+	})
+
+	h.Require.NoError(h.Execute("train", "project", "cache", "describe",
+		"--project", "my-project", "--sort", "path"))
+	out := h.Stdout.String()
+	h.Require.Less(strings.Index(out, "a-small.bin"), strings.Index(out, "z-large.bin"))
+}
+
+func Test_Train_Project_Cache_Describe_UnknownProject(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", trainProjectsPath, 200, map[string]any{"training_projects": []any{}})
+
+	err := h.Execute("train", "project", "cache", "describe", "--project", "nope")
+	h.Require.ErrorContains(err, `no training project found named "nope"`)
+	h.Require.Nil(m.FindCall("GET", trainCacheSummaryPat))
+}
+
+func Test_Train_Project_Cache_Describe_ByID(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	// An ID match wins over a same-spelled name on another project.
+	m.SetRoute("GET", trainProjectsPath, 200, map[string]any{
+		"training_projects": []any{
+			map[string]any{
+				"id": "other", "name": "proj-1",
+				"created_at": "2026-05-14T12:00:00Z", "updated_at": "2026-05-14T12:00:00Z",
+				"latest_job": nil,
+			},
+			map[string]any{
+				"id": "proj-1", "name": "my-project",
+				"created_at": "2026-05-14T12:00:00Z", "updated_at": "2026-05-14T12:00:00Z",
+				"latest_job": nil,
+			},
+		},
+	})
+	m.SetRoute("GET", trainCacheSummaryPat, 200, map[string]any{
+		"project_id": "proj-1", "timestamp": "2026-05-14T12:00:00Z", "file_summaries": []any{},
+	})
+
+	h.Require.NoError(h.Execute("train", "project", "cache", "describe", "--project", "proj-1"))
+	h.Require.NotNil(m.FindCall("GET", trainCacheSummaryPat))
+}
+
+func Test_Train_Capacity_Describe(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", trainCapacityPath, 200, map[string]any{
+		"gpu_capacities": []any{map[string]any{
+			"gpu_type": "H100", "limit": 64, "baseline": 8, "usage_count": 12,
+		}},
+		"team_gpu_capacities": []any{map[string]any{
+			"team_id": "team-1", "team_name": "research",
+			"gpu_type": "H100", "limit": 32, "baseline": 4, "usage_count": 6,
+		}},
+	})
+
+	h.Require.NoError(h.Execute("train", "capacity", "describe"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "H100")
+	h.Require.Contains(out, "research")
+	h.Require.Contains(out, "TEAM")
+}
+
+func Test_Train_Capacity_Describe_NoTeams(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", trainCapacityPath, 200, map[string]any{
+		"gpu_capacities": []any{map[string]any{
+			"gpu_type": "H100", "limit": 64, "baseline": 8, "usage_count": 12,
+		}},
+	})
+
+	h.Require.NoError(h.Execute("train", "capacity", "describe"))
+	h.Require.NotContains(h.Stdout.String(), "TEAM")
+}
+
+func Test_Train_Capacity_Update(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/teams", 200, map[string]any{
+		"teams": []any{map[string]any{"id": "team-1", "name": "research"}},
+	})
+	m.SetRoute("PATCH", trainCapacityPath, 200, map[string]any{
+		"team_gpu_capacity": map[string]any{
+			"team_id": "team-1", "team_name": "research",
+			"gpu_type": "H100", "limit": 32, "baseline": 4, "usage_count": 6,
+		},
+	})
+
+	h.Require.NoError(h.Execute("train", "capacity", "update",
+		"--team", "research", "--gpu-type", "H100", "--max-gpus", "32"))
+	body := m.FindCall("PATCH", trainCapacityPath).BodyJSON(t)
+	h.Require.Equal("team-1", body["team_id"])
+	h.Require.Equal("H100", body["gpu_type"])
+	h.Require.Equal(float64(32), body["max_gpus"])
+	h.Require.Contains(h.Stderr.String(), "Set H100 limit to 32 GPUs for team research")
+}
+
+func Test_Train_Capacity_Update_NegativeRejected(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+
+	err := h.Execute("train", "capacity", "update",
+		"--team", "research", "--gpu-type", "H100", "--max-gpus", "-1")
+	h.Require.ErrorContains(err, "--max-gpus must be zero or a positive number")
+	h.Require.Empty(m.Calls())
+}
+
+func Test_Train_Job_Logs_Tail_StopsOnTerminalStatus(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_RUNNING"))
+	m.SetRoute("GET", trainJobPath+"/logs", 200, logsResponse(
+		map[string]any{"timestamp": "1", "message": "step 1", "replica": nil},
+	))
+	m.SetRoute("GET", trainJobPath, 200, map[string]any{
+		"training_job": trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"),
+		"training_project": map[string]any{
+			"id": "proj-1", "name": "my-project",
+			"created_at": "2026-05-14T12:00:00Z", "updated_at": "2026-05-14T12:00:00Z",
+			"latest_job": nil,
+		},
+	})
+	h.Context = cmd.WithSleep(h.Context, func(_ context.Context, _ time.Duration) error { return nil })
+
+	h.Require.NoError(h.Execute("train", "job", "logs", "--job-id", "job-1", "--tail"))
+	h.Require.Contains(h.Stdout.String(), "step 1")
+	h.Require.Contains(h.Stderr.String(), "completed")
+}
+
+func Test_Train_Job_Logs_Tail_StopsOnUnknownStatus(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_RUNNING"))
+	m.SetRoute("GET", trainJobPath+"/logs", 200, logsResponse(
+		map[string]any{"timestamp": "1", "message": "step 1", "replica": nil},
+	))
+	// A status this build predates is treated as terminal, so the tail ends
+	// rather than polling a job that will never produce more logs.
+	m.SetRoute("GET", trainJobPath, 200, map[string]any{
+		"training_job": trainJobFixture("job-1", "TRAINING_JOB_HIBERNATING"),
+		"training_project": map[string]any{
+			"id": "proj-1", "name": "my-project",
+			"created_at": "2026-05-14T12:00:00Z", "updated_at": "2026-05-14T12:00:00Z",
+			"latest_job": nil,
+		},
+	})
+	h.Context = cmd.WithSleep(h.Context, func(_ context.Context, _ time.Duration) error { return nil })
+
+	h.Require.NoError(h.Execute("train", "job", "logs", "--job-id", "job-1", "--tail"))
+	h.Require.Contains(h.Stderr.String(), "hibernating")
+}
+
+func Test_Train_Job_Download_MultipleArtifacts(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
+	archive := trainArtifactTarGz(t, "train.py", "print('hi')")
+	for _, path := range []string{"/artifact-1.tgz", "/artifact-2.tgz"} {
+		m.SetRouteFunc("GET", path, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(archive)
+		})
+	}
+	m.SetRoute("GET", trainJobPath+"/download", 200, map[string]any{
+		"artifact_presigned_urls": []any{m.URL + "/artifact-1.tgz", m.URL + "/artifact-2.tgz"},
+	})
+	dir := t.TempDir()
+
+	h.Require.NoError(h.Execute("train", "job", "download",
+		"--job-id", "job-1", "--dir", dir, "--no-extract"))
+	// Several artifacts are suffixed by index so they cannot overwrite each other.
+	for _, name := range []string{"my-project-job-1-1.tgz", "my-project-job-1-2.tgz"} {
+		_, err := os.Stat(filepath.Join(dir, name))
+		h.Require.NoError(err)
+	}
+}

--- a/internal/cmd/command.train_test.go
+++ b/internal/cmd/command.train_test.go
@@ -341,13 +341,13 @@ func Test_Train_Job_Session_Describe_None(t *testing.T) {
 	h.Require.Contains(h.Stderr.String(), "No interactive sessions found.")
 }
 
-// trainArtifactTarGz builds a gzipped tar holding one file, standing in for a
-// job's uploaded code archive.
-func trainArtifactTarGz(t *testing.T, name, content string) []byte {
+// trainArtifactTar builds an uncompressed tar holding one file, standing in for
+// a job's uploaded code archive. Truss packs these with tarfile "w:" and names
+// them ".tgz" by convention, so the bytes are plain tar despite the name.
+func trainArtifactTar(t *testing.T, name, content string) []byte {
 	t.Helper()
 	var buf bytes.Buffer
-	gz := gzip.NewWriter(&buf)
-	tw := tar.NewWriter(gz)
+	tw := tar.NewWriter(&buf)
 	if err := tw.WriteHeader(&tar.Header{
 		Name: name, Mode: 0o644, Size: int64(len(content)), Typeflag: tar.TypeReg,
 	}); err != nil {
@@ -359,51 +359,99 @@ func trainArtifactTarGz(t *testing.T, name, content string) []byte {
 	if err := tw.Close(); err != nil {
 		t.Fatal(err)
 	}
+	return buf.Bytes()
+}
+
+// trainArtifactTarGz is trainArtifactTar compressed, which the backend does not
+// currently produce but extraction tolerates.
+func trainArtifactTarGz(t *testing.T, name, content string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write(trainArtifactTar(t, name, content)); err != nil {
+		t.Fatal(err)
+	}
 	if err := gz.Close(); err != nil {
 		t.Fatal(err)
 	}
 	return buf.Bytes()
 }
 
+// mockTrainArtifact serves archive at /artifact.tgz and points the job's
+// download endpoint at it.
+func mockTrainArtifact(m *MockManagementAPI, archive []byte) {
+	m.SetRouteFunc("GET", "/artifact.tgz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	m.SetRoute("GET", trainJobPath+"/download", 200, map[string]any{
+		"artifact_presigned_urls": []any{m.URL + "/artifact.tgz"},
+	})
+}
+
 func Test_Train_Job_Download_Extracts(t *testing.T) {
 	h := NewCommandHarness(t)
 	m := h.MockManagementAPI()
 	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
-	archive := trainArtifactTarGz(t, "train.py", "print('hi')")
-	m.SetRouteFunc("GET", "/artifact.tgz", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(archive)
-	})
-	m.SetRoute("GET", trainJobPath+"/download", 200, map[string]any{
-		"artifact_presigned_urls": []any{m.URL + "/artifact.tgz"},
-	})
-	dir := t.TempDir()
+	mockTrainArtifact(m, trainArtifactTar(t, "train.py", "print('hi')"))
+	dir := filepath.Join(t.TempDir(), "out")
 
-	h.Require.NoError(h.Execute("train", "job", "download", "--job-id", "job-1", "--dir", dir))
-	extracted := filepath.Join(dir, "my-project-job-1", "train.py")
-	content, err := os.ReadFile(extracted)
+	h.Require.NoError(h.Execute("train", "job", "download", "--job-id", "job-1", "--out-dir", dir))
+	content, err := os.ReadFile(filepath.Join(dir, "train.py"))
 	h.Require.NoError(err)
 	h.Require.Equal("print('hi')", string(content))
-	h.Require.Contains(h.Stderr.String(), extracted[:len(dir)])
+	h.Require.Contains(h.Stderr.String(), "Extracted to "+dir)
 }
 
-func Test_Train_Job_Download_NoExtract(t *testing.T) {
+func Test_Train_Job_Download_ExtractsGzipped(t *testing.T) {
 	h := NewCommandHarness(t)
 	m := h.MockManagementAPI()
 	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
-	archive := trainArtifactTarGz(t, "train.py", "print('hi')")
-	m.SetRouteFunc("GET", "/artifact.tgz", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(archive)
-	})
-	m.SetRoute("GET", trainJobPath+"/download", 200, map[string]any{
-		"artifact_presigned_urls": []any{m.URL + "/artifact.tgz"},
-	})
-	dir := t.TempDir()
+	// Compression is detected from the bytes, so a compressed artifact extracts
+	// too even though nothing produces one today.
+	mockTrainArtifact(m, trainArtifactTarGz(t, "train.py", "print('hi')"))
+	dir := filepath.Join(t.TempDir(), "out")
+
+	h.Require.NoError(h.Execute("train", "job", "download", "--job-id", "job-1", "--out-dir", dir))
+	content, err := os.ReadFile(filepath.Join(dir, "train.py"))
+	h.Require.NoError(err)
+	h.Require.Equal("print('hi')", string(content))
+}
+
+func Test_Train_Job_Download_OutFile(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
+	archive := trainArtifactTar(t, "train.py", "print('hi')")
+	mockTrainArtifact(m, archive)
+	out := filepath.Join(t.TempDir(), "job.tar")
 
 	h.Require.NoError(h.Execute("train", "job", "download",
-		"--job-id", "job-1", "--dir", dir, "--no-extract"))
-	written, err := os.ReadFile(filepath.Join(dir, "my-project-job-1.tgz"))
+		"--job-id", "job-1", "--out-file", out, "--output", "json"))
+	written, err := os.ReadFile(out)
 	h.Require.NoError(err)
 	h.Require.Equal(archive, written)
+	h.Require.Contains(h.Stdout.String(), `"out_file"`)
+}
+
+func Test_Train_Job_Download_RequiresOutFlag(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+
+	// Matching `model deployment download`, the destination is never implied.
+	err := h.Execute("train", "job", "download", "--job-id", "job-1")
+	h.Require.ErrorContains(err, "out-dir")
+	h.Require.Empty(m.Calls())
+}
+
+func Test_Train_Job_Download_NoOverwrite(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	out := filepath.Join(t.TempDir(), "job.tar")
+	h.Require.NoError(os.WriteFile(out, []byte("existing"), 0o644))
+
+	err := h.Execute("train", "job", "download", "--job-id", "job-1", "--out-file", out)
+	h.Require.ErrorContains(err, "pass --overwrite")
+	h.Require.Empty(m.Calls())
 }
 
 func Test_Train_Job_Download_NoArtifacts(t *testing.T) {
@@ -412,7 +460,8 @@ func Test_Train_Job_Download_NoArtifacts(t *testing.T) {
 	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
 	m.SetRoute("GET", trainJobPath+"/download", 200, map[string]any{"artifact_presigned_urls": []any{}})
 
-	err := h.Execute("train", "job", "download", "--job-id", "job-1", "--dir", t.TempDir())
+	err := h.Execute("train", "job", "download",
+		"--job-id", "job-1", "--out-dir", filepath.Join(t.TempDir(), "out"))
 	h.Require.ErrorContains(err, "has no artifacts to download")
 }
 
@@ -710,6 +759,39 @@ func Test_Train_Capacity_Describe_NoTeams(t *testing.T) {
 	h.Require.NotContains(h.Stdout.String(), "TEAM")
 }
 
+func Test_Train_Capacity_Describe_TeamsWithoutOrgCapacity(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	// A team limit is enforced whether or not the org has its own capacity, so
+	// an org with none must still show the team table rather than reporting
+	// nothing configured.
+	m.SetRoute("GET", trainCapacityPath, 200, map[string]any{
+		"gpu_capacities": []any{},
+		"team_gpu_capacities": []any{map[string]any{
+			"team_id": "team-1", "team_name": "research",
+			"gpu_type": "H100", "limit": 32, "baseline": 4, "usage_count": 6,
+		}},
+	})
+
+	h.Require.NoError(h.Execute("train", "capacity", "describe"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "TEAM")
+	h.Require.Contains(out, "research")
+	h.Require.NotContains(h.Stderr.String(), "No training GPU capacity configured.")
+	// The separator between the two tables is not emitted when only one renders.
+	h.Require.False(strings.HasPrefix(out, "\n"))
+}
+
+func Test_Train_Capacity_Describe_Empty(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", trainCapacityPath, 200, map[string]any{"gpu_capacities": []any{}})
+
+	h.Require.NoError(h.Execute("train", "capacity", "describe"))
+	h.Require.Empty(h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "No training GPU capacity configured.")
+}
+
 func Test_Train_Capacity_Update(t *testing.T) {
 	h := NewCommandHarness(t)
 	m := h.MockManagementAPI()
@@ -764,6 +846,77 @@ func Test_Train_Job_Logs_Tail_StopsOnTerminalStatus(t *testing.T) {
 	h.Require.Contains(h.Stderr.String(), "completed")
 }
 
+func Test_Train_Job_Logs_Empty(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
+	m.SetRoute("GET", trainJobPath+"/logs", 200, logsResponse())
+
+	h.Require.NoError(h.Execute("train", "job", "logs", "--job-id", "job-1"))
+	h.Require.Empty(h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "No logs found.")
+}
+
+func Test_Train_Job_Logs_Tail_StopsOnTerminalStatusWithoutLogs(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_RUNNING"))
+	// A job that finished before the log window opened returns nothing, so there
+	// is no log line to trigger the status check that ends the tail.
+	m.SetRoute("GET", trainJobPath+"/logs", 200, logsResponse())
+	m.SetRoute("GET", trainJobPath, 200, map[string]any{
+		"training_job": trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"),
+		"training_project": map[string]any{
+			"id": "proj-1", "name": "my-project",
+			"created_at": "2026-05-14T12:00:00Z", "updated_at": "2026-05-14T12:00:00Z",
+			"latest_job": nil,
+		},
+	})
+	h.Context = cmd.WithSleep(h.Context, func(_ context.Context, _ time.Duration) error { return nil })
+
+	h.Require.NoError(h.Execute("train", "job", "logs", "--job-id", "job-1", "--tail"))
+	h.Require.Contains(h.Stderr.String(), "completed")
+}
+
+func Test_Train_Job_Logs_Tail_KeepsGoingWhileQueued(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_QUEUED"))
+	// A queued job has produced no logs yet, so the first-poll status check must
+	// not mistake "nothing to show" for "nothing left to show".
+	logsCalls := 0
+	m.SetRouteFunc("GET", trainJobPath+"/logs", func(w http.ResponseWriter, _ *http.Request) {
+		logsCalls++
+		payload := logsResponse()
+		if logsCalls > 1 {
+			payload = logsResponse(map[string]any{"timestamp": "1", "message": "step 1", "replica": nil})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	})
+	statusCalls := 0
+	m.SetRouteFunc("GET", trainJobPath, func(w http.ResponseWriter, _ *http.Request) {
+		statusCalls++
+		status := "TRAINING_JOB_QUEUED"
+		if statusCalls > 1 {
+			status = "TRAINING_JOB_COMPLETED"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"training_job": trainJobFixture("job-1", status),
+			"training_project": map[string]any{
+				"id": "proj-1", "name": "my-project",
+				"created_at": "2026-05-14T12:00:00Z", "updated_at": "2026-05-14T12:00:00Z",
+				"latest_job": nil,
+			},
+		})
+	})
+	h.Context = cmd.WithSleep(h.Context, func(_ context.Context, _ time.Duration) error { return nil })
+
+	h.Require.NoError(h.Execute("train", "job", "logs", "--job-id", "job-1", "--tail"))
+	h.Require.Contains(h.Stdout.String(), "step 1")
+}
+
 func Test_Train_Job_Logs_Tail_StopsOnUnknownStatus(t *testing.T) {
 	h := NewCommandHarness(t)
 	m := h.MockManagementAPI()
@@ -791,7 +944,7 @@ func Test_Train_Job_Download_MultipleArtifacts(t *testing.T) {
 	h := NewCommandHarness(t)
 	m := h.MockManagementAPI()
 	mockTrainJobSearch(m, trainJobFixture("job-1", "TRAINING_JOB_COMPLETED"))
-	archive := trainArtifactTarGz(t, "train.py", "print('hi')")
+	archive := trainArtifactTar(t, "train.py", "print('hi')")
 	for _, path := range []string{"/artifact-1.tgz", "/artifact-2.tgz"} {
 		m.SetRouteFunc("GET", path, func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write(archive)
@@ -800,41 +953,12 @@ func Test_Train_Job_Download_MultipleArtifacts(t *testing.T) {
 	m.SetRoute("GET", trainJobPath+"/download", 200, map[string]any{
 		"artifact_presigned_urls": []any{m.URL + "/artifact-1.tgz", m.URL + "/artifact-2.tgz"},
 	})
-	dir := t.TempDir()
+	out := filepath.Join(t.TempDir(), "job.tar")
 
-	h.Require.NoError(h.Execute("train", "job", "download",
-		"--job-id", "job-1", "--dir", dir, "--no-extract"))
-	// Several artifacts are suffixed by index so they cannot overwrite each other.
-	for _, name := range []string{"my-project-job-1-1.tgz", "my-project-job-1-2.tgz"} {
-		_, err := os.Stat(filepath.Join(dir, name))
-		h.Require.NoError(err)
-	}
-}
-
-func Test_Train_Job_Download_UnsafeProjectName(t *testing.T) {
-	h := NewCommandHarness(t)
-	m := h.MockManagementAPI()
-	job := trainJobFixture("job-1", "TRAINING_JOB_COMPLETED")
-	// The backend validates project names only against a reserved list, so one
-	// that would escape the download dir has to be handled here.
-	job["training_project"] = map[string]any{"id": "proj-1", "name": "../../escape"}
-	mockTrainJobSearch(m, job)
-	archive := trainArtifactTarGz(t, "train.py", "print('hi')")
-	m.SetRouteFunc("GET", "/artifact.tgz", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write(archive)
-	})
-	m.SetRoute("GET", trainJobPath+"/download", 200, map[string]any{
-		"artifact_presigned_urls": []any{m.URL + "/artifact.tgz"},
-	})
-	dir := t.TempDir()
-
-	h.Require.NoError(h.Execute("train", "job", "download",
-		"--job-id", "job-1", "--dir", dir, "--no-extract"))
-	// The separators are flattened into the file name, so the write lands in
-	// dir rather than above it.
-	entries, err := os.ReadDir(dir)
-	h.Require.NoError(err)
-	h.Require.Len(entries, 1)
-	h.Require.False(entries[0].IsDir())
-	h.Require.Equal("..-..-escape-job-1.tgz", entries[0].Name())
+	h.Require.NoError(h.Execute("train", "job", "download", "--job-id", "job-1", "--out-file", out))
+	// Only the first artifact is fetched, and the extras are called out rather
+	// than dropped silently.
+	h.Require.Contains(h.Stderr.String(), "has 2 artifacts; downloading the first")
+	h.Require.NotNil(m.FindCall("GET", "/artifact-1.tgz"))
+	h.Require.Nil(m.FindCall("GET", "/artifact-2.tgz"))
 }

--- a/internal/cmd/command.train_test.go
+++ b/internal/cmd/command.train_test.go
@@ -810,3 +810,31 @@ func Test_Train_Job_Download_MultipleArtifacts(t *testing.T) {
 		h.Require.NoError(err)
 	}
 }
+
+func Test_Train_Job_Download_UnsafeProjectName(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	job := trainJobFixture("job-1", "TRAINING_JOB_COMPLETED")
+	// The backend validates project names only against a reserved list, so one
+	// that would escape the download dir has to be handled here.
+	job["training_project"] = map[string]any{"id": "proj-1", "name": "../../escape"}
+	mockTrainJobSearch(m, job)
+	archive := trainArtifactTarGz(t, "train.py", "print('hi')")
+	m.SetRouteFunc("GET", "/artifact.tgz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	m.SetRoute("GET", trainJobPath+"/download", 200, map[string]any{
+		"artifact_presigned_urls": []any{m.URL + "/artifact.tgz"},
+	})
+	dir := t.TempDir()
+
+	h.Require.NoError(h.Execute("train", "job", "download",
+		"--job-id", "job-1", "--dir", dir, "--no-extract"))
+	// The separators are flattened into the file name, so the write lands in
+	// dir rather than above it.
+	entries, err := os.ReadDir(dir)
+	h.Require.NoError(err)
+	h.Require.Len(entries, 1)
+	h.Require.False(entries[0].IsDir())
+	h.Require.Equal("..-..-escape-job-1.tgz", entries[0].Name())
+}


### PR DESCRIPTION
## :rocket: What

Adds `baseten train`, the REST half of the training surface. Stacked on `cretz/loops-commands` in #50.

- `train capacity describe` / `update`: org and per-team GPU limits and usage.
- `train checkpoint list`: a job's synced checkpoints.
- `train checkpoint files`: presigned URLs for a job's checkpoint files, paged and streamed.
- `train job list`: jobs across every project you can see, with `--project` and `--status` filters.
- `train job describe` / `logs` / `metrics` / `stop` / `recreate` / `update` / `download`.
- `train job session describe`: interactive sessions, one per replica.
- `train project list` and `train project cache describe`.

Not included:

- `train push`, `train checkpoint deploy`, `train init`, `train workstation create`: these need a Python config file evaluated, so they delegate to truss via `uv`, which depends on https://github.com/basetenlabs/truss/pull/2603 shipping env-var auth. They follow in a second PR.
- `train job session update`: no working endpoint. The route it would use is not registered server-side, and the one that is requires a session id that only exists once a session is already running.

## :computer: How

- Users pass only `--job-id`; the owning project is resolved via `POST /v1/training_jobs/search`, which is the only lookup keyed by a bare job id.
- `--project` accepts a name or an ID, resolved against `GET /v1/training_projects`, with an ID match winning.
- Statuses are CLI-spelled (`running`) and mapped to and from `TRAINING_JOB_RUNNING` mechanically rather than through a fixed table, so a status added later works without a CLI release and renders readably. Both spellings are accepted as input. JSON output keeps the API spelling.
- `train job logs` reuses the shared log/tail flow; `train job download` reuses the existing `extractTar`.

## Differences from truss

- Job id is always required. Truss falls back to the most recently created job, which its search endpoint scopes to every project your teams can access, not to your own jobs. This matches other resources in the CLI, but we can always go back to "most recent job by default" if needed.
- `checkpoint files` prints rather than writing `<project>_<job>_checkpoints.json`, and drops the `{timestamp, job, checkpoint_artifacts}` envelope. `--output json` is the bare file array, `--output jsonl` one record per line; per-file records are unchanged.
- `job metrics` reports one snapshot instead of a continuously refreshing watcher. Same latest-sample-per-series values, broken out per node.
- `job download` keeps truss's behavior of extracting by default, with the flag spelled `--no-extract`. It writes every artifact URL rather than only the first, suffixing by index when there is more than one.

## :microscope: Testing

- Unit tests per command covering table and JSON output, empty results, ordering, filter mapping, error paths, checkpoint-file paging, tail termination on terminal and unknown statuses, and download with and without extraction.
- Manual verification against a live workspace still to do.