### PR TITLE
Add truss-delegating train and loops commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
             exit 1
           fi
 
+      # The train e2e test pushes through truss, which the CLI runs with
+      # `uv tool run`.
+      - name: Install uv
+        if: matrix.os == 'ubuntu-latest'
+        uses: astral-sh/setup-uv@v5
+
       - name: E2E test
         if: matrix.os == 'ubuntu-latest'
         env:

--- a/cmd/command.loops.go
+++ b/cmd/command.loops.go
@@ -242,6 +242,36 @@ var commandLoopsCheckpoint = Command{
 				},
 			},
 		},
+		{
+			Name:    "deploy",
+			Summary: "Deploy Loops checkpoints",
+			Description: "Deploy checkpoints saved by a Loops run as a model served by vLLM.\n\n" +
+				"Name the checkpoints with --checkpoint (which needs --run-id, since names are " +
+				"scoped to a run) or with --checkpoint-id, or pass none of them to choose " +
+				"interactively. Requests then select a checkpoint by name through the model " +
+				"parameter, so one deployment serves them all.\n\n" +
+				"Pass --config for a repeatable deploy: it is a Python file defining a " +
+				"DeployCheckpointsConfig, so it is executed rather than read.",
+			Flags: LoopsCheckpointDeployFlags{},
+			Output: &CommandOutput[TrussDelegatedResult]{
+				JSONOutputUnimportant: true,
+				TextDescription: "The new model and deployment IDs with links to the deployment's logs, " +
+					"and how to name a checkpoint in a request. With --dry-run, the generated model " +
+					"config instead.",
+				JSONDescription: "Under --output json the text output goes to stderr and stdout is an empty " +
+					"object: this command reports nothing structured yet.",
+				Examples: []CommandExample{
+					{
+						Description: "Deploy two checkpoints of a run by name.",
+						Command:     "baseten loops checkpoint deploy --run-id <run-id> --checkpoint step-50 --checkpoint step-100",
+					},
+					{
+						Description: "Deploy a checkpoint by ID, choosing the rest interactively.",
+						Command:     "baseten loops checkpoint deploy --checkpoint-id <checkpoint-id>",
+					},
+				},
+			},
+		},
 	},
 }
 
@@ -373,4 +403,16 @@ type LoopsCheckpointFilesFlags struct {
 	CommandFlags
 
 	CheckpointID string `flag:"checkpoint-id" desc:"ID of the Loops checkpoint." required:"true"`
+}
+
+// LoopsCheckpointDeployFlags configures `baseten loops checkpoint deploy`.
+type LoopsCheckpointDeployFlags struct {
+	CommandFlags
+	TrussAuthFlags
+
+	RunID        string   `flag:"run-id" desc:"Loops run whose checkpoints are deployed."`
+	Checkpoint   []string `flag:"checkpoint" desc:"Name of a checkpoint to deploy, for example 'step-50'. Requires --run-id, since names are scoped to a run. Repeatable."`
+	CheckpointID []string `flag:"checkpoint-id" desc:"ID of a checkpoint to deploy. Repeatable."`
+	Config       string   `flag:"config" desc:"Python file defining a DeployCheckpointsConfig: which checkpoints deploy and the model that serves them."`
+	DryRun       bool     `flag:"dry-run" desc:"Print the generated model config without deploying anything."`
 }

--- a/cmd/command.loops.go
+++ b/cmd/command.loops.go
@@ -333,7 +333,7 @@ type LoopsLogFlags struct {
 
 	Start time.Time     `flag:"start" desc:"Start of the log time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. Default is 30 minutes before the end. Window must be at most 7 days."`
 	End   time.Time     `flag:"end" desc:"End of the log time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. Default is now. Window must be at most 7 days."`
-	Since time.Duration `flag:"since" desc:"Shortcut for fetching logs from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
+	Since time.Duration `flag:"since" desc:"Shortcut for fetching logs from a relative time ago until now. Accepts a duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
 
 	Limit int `flag:"limit" desc:"Maximum number of log lines to return, paging backward from the end of the window. Use 0 for no limit (every log line in the window). Not applicable with --tail." default:"5000"`
 
@@ -410,9 +410,9 @@ type LoopsCheckpointDeployFlags struct {
 	CommandFlags
 	TrussAuthFlags
 
-	RunID        string   `flag:"run-id" desc:"Loops run whose checkpoints are deployed."`
-	Checkpoint   []string `flag:"checkpoint" desc:"Name of a checkpoint to deploy, for example 'step-50'. Requires --run-id, since names are scoped to a run. Repeatable."`
-	CheckpointID []string `flag:"checkpoint-id" desc:"ID of a checkpoint to deploy. Repeatable."`
-	Config       string   `flag:"config" desc:"Python file defining a DeployCheckpointsConfig: which checkpoints deploy and the model that serves them."`
+	RunID        string   `flag:"run-id" desc:"Loops run whose checkpoints are deployed. Cannot be combined with --checkpoint-id."`
+	Checkpoint   []string `flag:"checkpoint" desc:"Name of a checkpoint to deploy, for example 'step-50'. Requires --run-id, since names are scoped to a run. Cannot be combined with --checkpoint-id or --config. Repeatable."`
+	CheckpointID []string `flag:"checkpoint-id" desc:"ID of a checkpoint to deploy. Cannot be combined with --run-id, --checkpoint, or --config. Repeatable."`
+	Config       string   `flag:"config" desc:"Python file defining a DeployCheckpointsConfig: which checkpoints deploy and the model that serves them. Cannot be combined with --checkpoint or --checkpoint-id."`
 	DryRun       bool     `flag:"dry-run" desc:"Print the generated model config without deploying anything."`
 }

--- a/cmd/command.model.go
+++ b/cmd/command.model.go
@@ -247,7 +247,7 @@ type LogFlags struct {
 
 	Start time.Time     `flag:"start" desc:"Start of the log time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. Default is 30 minutes before the end. Window must be at most 7 days."`
 	End   time.Time     `flag:"end" desc:"End of the log time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. Default is now. Window must be at most 7 days."`
-	Since time.Duration `flag:"since" desc:"Shortcut for fetching logs from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
+	Since time.Duration `flag:"since" desc:"Shortcut for fetching logs from a relative time ago until now. Accepts a duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
 
 	Limit int `flag:"limit" desc:"Maximum number of log lines to return, paging backward from the end of the window. Use 0 for no limit (every log line in the window). Not applicable with --tail." default:"5000"`
 
@@ -271,7 +271,7 @@ type MetricsFlags struct {
 
 	Start time.Time     `flag:"start" desc:"Start of the metrics time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the start to one hour before the end. Window must be at most 7 days."`
 	End   time.Time     `flag:"end" desc:"End of the metrics time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. If omitted, the server defaults the end to now. Window must be at most 7 days."`
-	Since time.Duration `flag:"since" desc:"Shortcut for a window from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
+	Since time.Duration `flag:"since" desc:"Shortcut for a window from a relative time ago until now. Accepts a duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
 
 	Metric []string `flag:"metric" desc:"Name of a metric to return; see https://docs.baseten.co/observability/export-metrics/supported-metrics for the available names. May be repeated. When omitted, a default set is returned."`
 
@@ -303,7 +303,7 @@ type ModelPushFlags struct {
 	WatchHotReload   bool `flag:"watch-hot-reload" desc:"With --watch, hot-reload the running container when every change is to model code; mixed changes fall back to a cold patch."`
 	WatchNoKeepalive bool `flag:"watch-no-keepalive" desc:"With --watch, let the development deployment scale to zero while watching. By default it is kept warm by periodic pings."`
 
-	DeployTimeout string `flag:"deploy-timeout" desc:"Deployment timeout as a Go duration (e.g. 30m, 1h); allowed range 10m to 24h."`
+	DeployTimeout string `flag:"deploy-timeout" desc:"Deployment timeout as a duration (e.g. 30m, 1h); allowed range 10m to 24h."`
 
 	OverrideName            string `flag:"override-name" desc:"Override the model_name from config.yaml for this push only. The on-disk config.yaml is not modified."`
 	OverrideEnvInstanceType bool   `flag:"override-env-instance-type" desc:"Use this deployment's instance type instead of preserving the target environment's. Only meaningful when an environment is targeted."`

--- a/cmd/command.model_image.go
+++ b/cmd/command.model_image.go
@@ -101,8 +101,11 @@ type ModelImagePrepareResult struct {
 // subcommands.
 type ModelImageCommonFlags struct {
 	CommandFlags
+	// TrussFlags without credential forwarding: generating a build context runs
+	// entirely locally and calls no API.
+	TrussFlags
+
 	Dir          string `flag:"dir" desc:"Model directory." default:"."`
-	TrussVersion string `flag:"truss-version" desc:"Truss version to run via uv." default:"latest"`
 	RootUser     bool   `flag:"root-user" desc:"Run the image's container as root instead of the default non-root user."`
 	CacheMountID string `flag:"cache-mount-id" desc:"Enable a persistent apt/pip/uv build cache keyed by this id."`
 }

--- a/cmd/command.org.go
+++ b/cmd/command.org.go
@@ -425,7 +425,7 @@ type OrgSecretDeleteFlags struct {
 type AuditLogFlags struct {
 	Start time.Time     `flag:"start" desc:"Start of the time window. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. Defaults to the beginning of the audit-log history."`
 	End   time.Time     `flag:"end" desc:"End of the time window. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. Defaults to now."`
-	Since time.Duration `flag:"since" desc:"Shortcut for a window from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Mutually exclusive with --start and --end."`
+	Since time.Duration `flag:"since" desc:"Shortcut for a window from a relative time ago until now. Accepts a duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Mutually exclusive with --start and --end."`
 
 	Limit int `flag:"limit" desc:"Maximum number of entries to return, paging as needed. Use 0 for no limit (every entry in the window)." default:"20"`
 

--- a/cmd/command.train.go
+++ b/cmd/command.train.go
@@ -647,7 +647,7 @@ type TrainPushFlags struct {
 	Spot        bool   `flag:"spot" desc:"Run on interruptible spot capacity, overriding the config. Checkpointing your own progress is up to you."`
 
 	Interactive        string        `flag:"interactive" desc:"Start an interactive session on this trigger." enum:"on-startup,on-failure,on-demand"`
-	InteractiveTimeout time.Duration `flag:"interactive-timeout" desc:"How long an interactive session stays up, as a Go duration (e.g. '90m', '2h'). Rounded down to whole minutes."`
+	InteractiveTimeout time.Duration `flag:"interactive-timeout" desc:"How long an interactive session stays up, as a duration (e.g. '90m', '2h'). Rounded down to whole minutes; must be at least 1m."`
 }
 
 // TrainWorkstationCreateFlags configures `baseten train workstation create`.
@@ -702,7 +702,7 @@ type TrainLogFlags struct {
 
 	Start time.Time     `flag:"start" desc:"Start of the log time range. Accepts ISO 8601 (e.g. '2026-05-14', '2026-05-14T12:00:00', '2026-05-14T12:00:00Z'). Values without a timezone designator are interpreted in the local timezone. Default is 30 minutes before the end. Window must be at most 7 days."`
 	End   time.Time     `flag:"end" desc:"End of the log time range. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. Default is now. Window must be at most 7 days."`
-	Since time.Duration `flag:"since" desc:"Shortcut for fetching logs from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
+	Since time.Duration `flag:"since" desc:"Shortcut for fetching logs from a relative time ago until now. Accepts a duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Maximum '7d'. Mutually exclusive with --start and --end."`
 
 	Limit int `flag:"limit" desc:"Maximum number of log lines to return, paging backward from the end of the window. Use 0 for no limit (every log line in the window). Not applicable with --tail." default:"5000"`
 
@@ -720,7 +720,7 @@ type TrainJobMetricsFlags struct {
 
 	Start time.Time     `flag:"start" desc:"Start of the sample window. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone."`
 	End   time.Time     `flag:"end" desc:"End of the sample window. Accepts ISO 8601; values without a timezone designator are interpreted in the local timezone. Default is now."`
-	Since time.Duration `flag:"since" desc:"Shortcut for sampling from a relative time ago until now. Accepts a Go duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Mutually exclusive with --start and --end."`
+	Since time.Duration `flag:"since" desc:"Shortcut for sampling from a relative time ago until now. Accepts a duration (e.g. '30m', '1h30m') or '<N>d' (e.g. '3d'). Mutually exclusive with --start and --end."`
 }
 
 // TrainJobStopFlags configures `baseten train job stop`.

--- a/cmd/command.train.go
+++ b/cmd/command.train.go
@@ -13,8 +13,113 @@ var commandTrain = Command{
 	Children: []Command{
 		commandTrainCapacity,
 		commandTrainCheckpoint,
+		commandTrainInit,
 		commandTrainJob,
 		commandTrainProject,
+		commandTrainPush,
+		commandTrainWorkstation,
+	},
+}
+
+// commandTrainInit scaffolds a training project. Delegated to truss, which owns
+// the project template and the example downloads.
+var commandTrainInit = Command{
+	Name:    "init",
+	Summary: "Scaffold a training project",
+	Description: "Create a training project directory, either empty from the built-in template " +
+		"or from one of the published training examples.\n\n" +
+		"This command needs no credentials: it only writes files, and the examples are " +
+		"downloaded from a public repository.",
+	Flags: TrainInitFlags{},
+	Output: &CommandOutput[TrussDelegatedResult]{
+		JSONOutputUnimportant: true,
+		TextDescription: "A line per directory created, naming where it was written. With " +
+			"--list-examples, the available example names, one per line.",
+		JSONDescription: "Under --output json the text output goes to stderr and stdout is an empty " +
+			"object: this command reports nothing structured yet.",
+		Examples: []CommandExample{
+			{
+				Description: "Scaffold an empty training project.",
+				Command:     "baseten train init --dir ./my-training",
+			},
+			{
+				Description: "List the available examples.",
+				Command:     "baseten train init --list-examples",
+			},
+			{
+				Description: "Download two examples into the current directory.",
+				Command:     "baseten train init --example sft-lora --example grpo",
+			},
+		},
+	},
+}
+
+// commandTrainPush runs a training job from a local config. Delegated to truss,
+// which evaluates the Python config and uploads the code archive.
+var commandTrainPush = Command{
+	Name:    "push",
+	Summary: "Run a training job from a local config",
+	Description: "Create and start a training job, uploading the config file's directory as the " +
+		"job's code.\n\n" +
+		"The config is a Python file that defines the training project and its job, so it " +
+		"is executed rather than read. The flags below override what it declares.\n\n" +
+		"Returns once the job is created. Follow it with " +
+		"'baseten train job logs --job-id <id> --tail'.",
+	Flags: TrainPushFlags{},
+	Output: &CommandOutput[TrussDelegatedResult]{
+		JSONOutputUnimportant: true,
+		TextDescription: "A confirmation that the job was created, with its ID, the commands to " +
+			"follow it, and a link to it in the Baseten UI.",
+		JSONDescription: "Under --output json the text output goes to stderr and stdout is an empty " +
+			"object: this command reports nothing structured yet.",
+		Examples: []CommandExample{
+			{
+				Description: "Run a training job from a config file.",
+				Command:     "baseten train push --config ./train.py",
+			},
+			{
+				Description: "Run a named job on eight H200s over spot capacity.",
+				Command:     "baseten train push --config ./train.py --job-name sweep-3 --accelerator H200:8 --spot",
+			},
+			{
+				Description: "Run a job that opens an interactive session if it fails.",
+				Command:     "baseten train push --config ./train.py --interactive on-failure --interactive-timeout 2h",
+			},
+		},
+	},
+}
+
+// commandTrainWorkstation groups the `baseten train workstation` subcommands.
+var commandTrainWorkstation = Command{
+	Name:    "workstation",
+	Summary: "Manage SSH workstations on training infrastructure",
+	Children: []Command{
+		{
+			Name:    "create",
+			Summary: "Create an SSH workstation",
+			Description: "Create an SSH workstation: a training job that holds GPUs for an " +
+				"interactive session instead of running a training script.\n\n" +
+				"Pass --node-count for a multi-node workstation, where each node has eight GPUs " +
+				"and SLURM is set up across them. Connect once the job is running.",
+			Flags: TrainWorkstationCreateFlags{},
+			Output: &CommandOutput[TrussDelegatedResult]{
+				JSONOutputUnimportant: true,
+				TextDescription: "A confirmation that the workstation was created, with the ssh host of " +
+					"each node and the commands to view its logs or stop it.",
+				JSONDescription: "Under --output json the text output goes to stderr and stdout is an empty " +
+					"object: this command reports nothing structured yet.",
+				Examples: []CommandExample{
+					{
+						Description: "Create a single-GPU workstation.",
+						Command:     "baseten train workstation create",
+					},
+					{
+						Description: "Create a four-node workstation with checkpoint storage.",
+						Command:     "baseten train workstation create --node-count 4 --enable-checkpointing --checkpoint-volume-size 512",
+					},
+				},
+			},
+		},
 	},
 }
 
@@ -121,6 +226,39 @@ var commandTrainCheckpoint = Command{
 				JQExample: CommandExample{
 					Description: "Print just the download URLs.",
 					Command:     "baseten train checkpoint files --job-id p7qr9qv --output jsonl --jq '.url'",
+				},
+			},
+		},
+		{
+			Name:    "deploy",
+			Summary: "Deploy a training job's checkpoints",
+			Description: "Deploy a training job's LoRA checkpoints as a model served by vLLM.\n\n" +
+				"Without --config, the checkpoints and the model that serves them are chosen " +
+				"interactively. Pass --config for a repeatable deploy: it is a Python file " +
+				"defining a DeployCheckpointsConfig, so it is executed rather than read.\n\n" +
+				"The generated model config is written to disk either way, so a deploy can be " +
+				"re-run or edited by hand afterward.",
+			Flags: TrainCheckpointDeployFlags{},
+			Output: &CommandOutput[TrussDelegatedResult]{
+				JSONOutputUnimportant: true,
+				TextDescription: "The new model and deployment IDs with links to the deployment's logs, " +
+					"the path the model config was written to, and an example request naming the " +
+					"deployed checkpoints. With --dry-run, only the config path.",
+				JSONDescription: "Under --output json the text output goes to stderr and stdout is an empty " +
+					"object: this command reports nothing structured yet.",
+				Examples: []CommandExample{
+					{
+						Description: "Deploy a job's checkpoints, choosing them interactively.",
+						Command:     "baseten train checkpoint deploy --job-id p7qr9qv",
+					},
+					{
+						Description: "Deploy the checkpoints a config file names.",
+						Command:     "baseten train checkpoint deploy --config ./deploy_checkpoints.py",
+					},
+					{
+						Description: "Generate the model config without deploying.",
+						Command:     "baseten train checkpoint deploy --job-id p7qr9qv --dry-run --config-out-dir ./generated",
+					},
 				},
 			},
 		},
@@ -465,6 +603,72 @@ type TrainCheckpointListFlags struct {
 type TrainCheckpointFilesFlags struct {
 	CommandFlags
 	TrainJobRefFlags
+}
+
+// TrainCheckpointDeployFlags configures `baseten train checkpoint deploy`.
+// The job is optional here, unlike [TrainJobRefFlags], because a config file can
+// name the checkpoints on its own.
+type TrainCheckpointDeployFlags struct {
+	CommandFlags
+	TrussAuthFlags
+
+	JobID        string `flag:"job-id" desc:"Training job whose checkpoints are deployed. Required unless --config names them."`
+	Config       string `flag:"config" desc:"Python file defining a DeployCheckpointsConfig: which checkpoints deploy and the model that serves them."`
+	ConfigOutDir string `flag:"config-out-dir" desc:"Directory the generated model config is written to. Defaults to a directory under ./truss_configs."`
+	DryRun       bool   `flag:"dry-run" desc:"Write the generated model config without deploying anything."`
+}
+
+// TrainInitFlags configures `baseten train init`.
+type TrainInitFlags struct {
+	CommandFlags
+	// Scaffolding writes files and downloads public examples, so no credential
+	// is forwarded and TrussFlags is embedded rather than TrussAuthFlags.
+	TrussFlags
+
+	Dir          string   `flag:"dir" desc:"Directory to create. Defaults to ./truss-train-init for an empty project, or the current directory when examples are named."`
+	Example      []string `flag:"example" desc:"Name of a published training example to download instead of the empty template. Repeatable."`
+	ListExamples bool     `flag:"list-examples" desc:"List the available example names and exit."`
+}
+
+// TrainPushFlags configures `baseten train push`.
+type TrainPushFlags struct {
+	CommandFlags
+	TrussAuthFlags
+
+	Config string `flag:"config" desc:"Python file defining the training project and its job." required:"true"`
+
+	JobName string `flag:"job-name" desc:"Name for the training job. Defaults to a generated name."`
+	Team    string `flag:"team" desc:"Team name or ID that owns the training project."`
+
+	Accelerator string `flag:"accelerator" desc:"Accelerator type and count, for example 'H200:8'. Overrides the config."`
+	NodeCount   int    `flag:"node-count" desc:"Number of compute nodes. Overrides the config."`
+	Entrypoint  string `flag:"entrypoint" desc:"Command the job runs. Overrides the config."`
+	Priority    int    `flag:"priority" desc:"Queue priority. Higher values are dequeued first."`
+	Spot        bool   `flag:"spot" desc:"Run on interruptible spot capacity, overriding the config. Checkpointing your own progress is up to you."`
+
+	Interactive        string        `flag:"interactive" desc:"Start an interactive session on this trigger." enum:"on-startup,on-failure,on-demand"`
+	InteractiveTimeout time.Duration `flag:"interactive-timeout" desc:"How long an interactive session stays up, as a Go duration (e.g. '90m', '2h'). Rounded down to whole minutes."`
+}
+
+// TrainWorkstationCreateFlags configures `baseten train workstation create`.
+type TrainWorkstationCreateFlags struct {
+	CommandFlags
+	TrussAuthFlags
+
+	Accelerator string `flag:"accelerator" desc:"GPU accelerator type." default:"H100"`
+	GPUCount    int    `flag:"gpu-count" desc:"Number of GPUs on a single node, 1 to 8. Mutually exclusive with --node-count."`
+	NodeCount   int    `flag:"node-count" desc:"Number of eight-GPU nodes, 1 to 16. Mutually exclusive with --gpu-count."`
+	Image       string `flag:"image" desc:"Docker base image the workstation runs."`
+
+	Project string `flag:"project" desc:"Training project that owns the workstation. Defaults to 'workstation-<accelerator>'."`
+	Team    string `flag:"team" desc:"Team name or ID that owns the training project."`
+
+	Orchestrator string `flag:"orchestrator" desc:"Multi-node orchestrator set up across the nodes." enum:"slurm" default:"slurm"`
+
+	EnableCheckpointing  bool   `flag:"enable-checkpointing" desc:"Attach checkpoint storage to the workstation."`
+	CheckpointPath       string `flag:"checkpoint-path" desc:"Path inside the container where checkpoints are written."`
+	CheckpointVolumeSize int    `flag:"checkpoint-volume-size" desc:"Size of the checkpoint volume in GiB."`
+	CheckpointFromJob    string `flag:"checkpoint-from-job" desc:"Training job whose latest checkpoint the workstation starts from."`
 }
 
 // TrainJobListFlags configures `baseten train job list`.

--- a/cmd/command.truss.go
+++ b/cmd/command.truss.go
@@ -1,23 +1,70 @@
 package cmd
 
+// commandTruss forwards arbitrary arguments to the truss CLI.
 var commandTruss = Command{
-	Name:               "truss",
-	Summary:            "Run truss commands",
-	Description:        "Delegates to the truss CLI if found on PATH, otherwise shows install instructions.",
+	Name:    "truss",
+	Summary: "Run truss commands",
+	Description: "Run a truss CLI command.\n\n" +
+		"Every argument is forwarded to truss verbatim except the --truss-* flags below, " +
+		"which this CLI consumes wherever they appear. Run 'baseten truss --help' for " +
+		"truss's own help, since --help is forwarded like any other argument.\n\n" +
+		"Truss is fetched and run by 'uv tool run', so 'uv' must be on PATH. A truss " +
+		"command that imports your own Python code, such as 'chains push', needs " +
+		"--truss-executable pointing at a truss installed alongside those dependencies.\n\n" +
+		"Baseten credentials are forwarded to truss over environment variables, so it " +
+		"uses the same profile as the rest of the CLI without reading your trussrc.",
 	ArgsUsage:          "[args...]",
 	DisableFlagParsing: true,
-	Flags:              TrussFlags{},
+	Flags:              TrussPassthroughFlags{},
 	Output: &CommandOutput[JSONUndefined]{
+		JSONOutputUnimportant: true,
 		TextDescription: "Whatever the truss CLI writes to stdout/stderr, passed through verbatim. " +
-			"--output and --jq are not honored: all arguments after `truss` are forwarded to " +
-			"the underlying truss binary. The exit code is propagated from truss.",
+			"--output and --jq are not honored: every argument other than the --truss-* flags " +
+			"is forwarded to truss. The exit code is propagated from truss.",
 		Examples: []CommandExample{
 			{
 				Description: "Show truss help by passing --help to truss.",
 				Command:     "baseten truss --help",
 			},
+			{
+				Description: "Push a chain with the truss installed in the current virtualenv, which can import the chainlet's dependencies.",
+				Command:     "baseten truss --truss-executable .venv/bin/truss chains push ./my_chain.py",
+			},
+			{
+				Description: "Pin the truss version used for a push.",
+				Command:     "baseten truss --truss-version 0.18.26 push --help",
+			},
 		},
 	},
 }
 
-type TrussFlags struct{}
+// TrussDelegatedResult is the JSON output of the commands that delegate to the
+// truss CLI. It is empty: truss reports what it did as human-readable text, so
+// there is nothing structured for the CLI to pass on. Fields land here once
+// truss can report its results machine-readably.
+type TrussDelegatedResult struct{}
+
+// TrussPassthroughFlags configures `baseten truss`. It carries only the shared
+// truss flags: everything else on the command line belongs to truss. Flag
+// parsing is disabled for this command, so these are extracted from the raw
+// arguments rather than by Cobra, and CommandFlags is deliberately absent since
+// --output, --jq and friends are forwarded to truss like any other argument.
+type TrussPassthroughFlags struct {
+	TrussAuthFlags
+}
+
+// TrussFlags selects which truss the CLI runs. Embedded by every command that
+// shells out to the truss CLI.
+type TrussFlags struct {
+	TrussVersion    string `flag:"truss-version" desc:"Version of truss to fetch and run with 'uv tool run', e.g. 0.18.26. Defaults to BASETEN_TRUSS_VERSION, or the latest release. Mutually exclusive with --truss-executable." group:"truss" group-pri:"300"`
+	TrussExecutable string `flag:"truss-executable" desc:"Run this truss executable instead of fetching one with uv, e.g. a virtualenv's bin/truss. A value with no path separator is looked up on PATH, so '--truss-executable truss' runs the truss you installed. Defaults to BASETEN_TRUSS_EXECUTABLE." group:"truss" group-pri:"300"`
+}
+
+// TrussAuthFlags is [TrussFlags] plus control over credential forwarding.
+// Embedded by delegating commands that call the Baseten API through truss;
+// commands that only run truss locally embed [TrussFlags] instead.
+type TrussAuthFlags struct {
+	TrussFlags
+
+	TrussNoForwardAuth bool `flag:"truss-no-forward-auth" desc:"Do not forward this CLI's credentials to truss, leaving it to resolve a remote from your trussrc. Old truss versions ignore forwarded credentials and use the trussrc regardless." group:"truss" group-pri:"300"`
+}

--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -153,39 +153,45 @@ func (t *Transport) base() http.RoundTripper {
 }
 
 func (t *Transport) Do(req *http.Request) (*http.Response, error) {
+	token, err := t.Credential(req.Context())
+	if err != nil {
+		return nil, err
+	}
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer "+token)
+	return t.base().RoundTrip(req)
+}
+
+// Credential resolves the session's credential as a bearer token: an API key
+// verbatim, or an OAuth access token, refreshed and persisted when it has
+// expired. The backend accepts either kind under the Bearer scheme, which is
+// also the only shape the truss CLI's forwarded credential accepts.
+func (t *Transport) Credential(ctx context.Context) (string, error) {
 	if t.Session.ephemeralAPIKey != "" {
-		req = req.Clone(req.Context())
-		req.Header.Set("Authorization", "Api-Key "+t.Session.ephemeralAPIKey)
-		return t.base().RoundTrip(req)
+		return t.Session.ephemeralAPIKey, nil
 	}
 
 	if t.Session.profileName == "" {
-		return nil, fmt.Errorf("not logged in; run `baseten auth login` or set BASETEN_API_KEY")
+		return "", fmt.Errorf("not logged in; run `baseten auth login` or set BASETEN_API_KEY")
 	}
 
 	profileName := t.Session.profileName
 	profile, ok := t.Session.store.GetProfile(profileName)
 	if !ok {
-		return nil, fmt.Errorf("profile %q not found; run `baseten auth login`", profileName)
+		return "", fmt.Errorf("profile %q not found; run `baseten auth login`", profileName)
 	}
 
 	switch profile.AuthType {
 	case AuthTypeAPIKey:
-		apiKey, err := t.Session.store.GetAPIKey(profileName)
-		if err != nil {
-			return nil, err
-		}
-		req = req.Clone(req.Context())
-		req.Header.Set("Authorization", "Api-Key "+apiKey)
-		return t.base().RoundTrip(req)
+		return t.Session.store.GetAPIKey(profileName)
 
 	case AuthTypeOAuth:
 		if t.OAuthConfig == nil {
-			return nil, fmt.Errorf("OAuth credential requires OAuthConfig to be set on Transport")
+			return "", fmt.Errorf("OAuth credential requires OAuthConfig to be set on Transport")
 		}
 		cred, err := t.Session.store.GetOAuthCredential(profileName)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 		token := &oauth2.Token{
 			AccessToken:  cred.AccessToken,
@@ -193,10 +199,10 @@ func (t *Transport) Do(req *http.Request) (*http.Response, error) {
 			Expiry:       cred.Expiry,
 			TokenType:    "Bearer",
 		}
-		src := t.OAuthConfig.TokenSource(OAuthContext(req.Context(), t.base()), token)
+		src := t.OAuthConfig.TokenSource(OAuthContext(ctx, t.base()), token)
 		newToken, err := src.Token()
 		if err != nil {
-			return nil, fmt.Errorf("token expired and refresh failed: %w (run `baseten auth login` to re-authenticate)", err)
+			return "", fmt.Errorf("token expired and refresh failed: %w (run `baseten auth login` to re-authenticate)", err)
 		}
 		if newToken.AccessToken != cred.AccessToken {
 			updated := OAuthCredential{
@@ -205,14 +211,12 @@ func (t *Transport) Do(req *http.Request) (*http.Response, error) {
 				Expiry:       newToken.Expiry,
 			}
 			if err := t.Session.store.SetOAuthProfile(profileName, profile.RemoteURL, updated, false, nil); err != nil {
-				return nil, fmt.Errorf("storing refreshed credential: %w", err)
+				return "", fmt.Errorf("storing refreshed credential: %w", err)
 			}
 		}
-		req = req.Clone(req.Context())
-		req.Header.Set("Authorization", "Bearer "+newToken.AccessToken)
-		return t.base().RoundTrip(req)
+		return newToken.AccessToken, nil
 
 	default:
-		return nil, fmt.Errorf("unknown auth type %q", profile.AuthType)
+		return "", fmt.Errorf("unknown auth type %q", profile.AuthType)
 	}
 }

--- a/internal/auth/transport_test.go
+++ b/internal/auth/transport_test.go
@@ -73,7 +73,7 @@ func TestTransport_EphemeralAPIKeyWinsOverCurrentProfile(t *testing.T) {
 	resp, err := tr.Do(mustRequest(t, es.URL))
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	require.Equal(t, "Api-Key env-key", es.LastAuthHeader)
+	require.Equal(t, "Bearer env-key", es.LastAuthHeader)
 }
 
 func TestTransport_APIKeyInjected(t *testing.T) {
@@ -86,7 +86,7 @@ func TestTransport_APIKeyInjected(t *testing.T) {
 	resp, err := tr.Do(mustRequest(t, es.URL))
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	require.Equal(t, "Api-Key "+apiKeyA, es.LastAuthHeader)
+	require.Equal(t, "Bearer "+apiKeyA, es.LastAuthHeader)
 }
 
 func TestTransport_OAuthBearerInjected(t *testing.T) {

--- a/internal/cmd/command.api_test.go
+++ b/internal/cmd/command.api_test.go
@@ -77,7 +77,7 @@ func Test_API_Management_AuthHeader(t *testing.T) {
 	h, req := newAPIHarness(t, 200, map[string]any{})
 	err := h.Execute("api", "management", "models")
 	h.Require.NoError(err)
-	h.Require.Equal("Api-Key test-key", req.Headers.Get("Authorization"))
+	h.Require.Equal("Bearer test-key", req.Headers.Get("Authorization"))
 	h.Require.Regexp(`^baseten-cli/\S+ \(Go/\S+; [^)]+\)$`, req.Headers.Get("User-Agent"))
 }
 

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -273,7 +274,11 @@ func buildCommand(def cmd.Command, parentPath string, options *ExecuteOptions) *
 			c.SilenceErrors = true
 			c.SilenceUsage = true
 			fmt.Fprintln(options.Stderr, ce)
-			if ce.ExitCode() == cmd.ExitUsage {
+			// A subprocess exit code is the child's, not ours. Delegated tools
+			// like truss exit 2 for their own validation errors, which collides
+			// with ExitUsage, so only dump usage for errors that originated here.
+			var subErr *ErrSubprocess
+			if ce.ExitCode() == cmd.ExitUsage && !errors.As(runErr, &subErr) {
 				_ = c.Usage()
 			}
 			ctx.ExitWithCode(int(ce.ExitCode()))
@@ -445,7 +450,7 @@ func (v *friendlyDurationValue) Set(s string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("invalid duration %q: expected a Go duration (e.g. 30m, 1h30m) or <N>d (e.g. 3d)", s)
+	return fmt.Errorf("invalid duration %q: expected a value like 30m, 1h30m, or 3d", s)
 }
 
 // applyOneofGroups wires `oneof:"<group>"`-tagged flags as mutually exclusive

--- a/internal/cmd/command.loops.go
+++ b/internal/cmd/command.loops.go
@@ -19,6 +19,7 @@ func init() {
 	Register("loops usage", commandLoopsUsage)
 	Register("loops checkpoint list", commandLoopsCheckpointList)
 	Register("loops checkpoint files", commandLoopsCheckpointFiles)
+	Register("loops checkpoint deploy", commandLoopsCheckpointDeploy)
 }
 
 // loopsTrainerLiveStatuses are the trainer deployment statuses where the trainer
@@ -539,6 +540,25 @@ func commandLoopsCheckpointFiles(ctx *CommandContext, flags *cmd.LoopsCheckpoint
 	}
 	ctx.OutputTable(TableOutput{Headers: []string{"NAME", "SIZE", "URL"}, Rows: rows})
 	return nil
+}
+
+// commandLoopsCheckpointDeploy delegates to the truss CLI: it is the only
+// command in this surface backed by GraphQL rather than REST, and its config
+// input is a Python file only truss can evaluate.
+func commandLoopsCheckpointDeploy(ctx *CommandContext, flags *cmd.LoopsCheckpointDeployFlags) error {
+	args := []string{"loops", "checkpoints", "deploy"}
+	args = trussArg(args, "run-id", flags.RunID)
+	args = trussArg(args, "checkpoints", strings.Join(flags.Checkpoint, ","))
+	args = trussArg(args, "checkpoint-ids", strings.Join(flags.CheckpointID, ","))
+	args = trussArg(args, "config", flags.Config)
+	args = trussBoolArg(args, "dry-run", flags.DryRun)
+
+	return trussRun(ctx, trussInvocation{
+		Flags:       flags.TrussFlags,
+		Args:        args,
+		ForwardAuth: !flags.TrussNoForwardAuth,
+		JSONResult:  true,
+	})
 }
 
 // loopsApplySamplerToRow fills in a usage row's sampler half.

--- a/internal/cmd/command.loops_test.go
+++ b/internal/cmd/command.loops_test.go
@@ -969,3 +969,31 @@ func Test_Loops_Checkpoint_Files_MissingCheckpointID(t *testing.T) {
 	err := h.Execute("loops", "checkpoint", "files")
 	h.Require.ErrorContains(err, "checkpoint-id")
 }
+
+func Test_Loops_Checkpoint_Deploy_ForwardsFlags(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute("loops", "checkpoint", "deploy",
+		"--run-id", "run-1", "--checkpoint", "step-50", "--checkpoint", "step-100", "--dry-run"))
+
+	c := fake.only(t)
+	h.Require.Equal([]string{
+		"uv", "tool", "run", "truss@latest", "loops", "checkpoints", "deploy",
+		"--run-id", "run-1",
+		"--checkpoints", "step-50,step-100",
+		"--dry-run",
+	}, c.Args)
+	h.Require.Contains(c.Env, "BASETEN_TRUSS_AUTH_API_KEY=test-key")
+}
+
+func Test_Loops_Checkpoint_Deploy_CheckpointIDs(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute("loops", "checkpoint", "deploy",
+		"--checkpoint-id", "cp-1", "--checkpoint-id", "cp-2"))
+
+	h.Require.Equal([]string{
+		"uv", "tool", "run", "truss@latest", "loops", "checkpoints", "deploy",
+		"--checkpoint-ids", "cp-1,cp-2",
+	}, fake.only(t).Args)
+}

--- a/internal/cmd/command.model_image.go
+++ b/internal/cmd/command.model_image.go
@@ -23,13 +23,6 @@ func init() {
 }
 
 func commandModelImageBuild(ctx *CommandContext, flags *cmd.ModelImageBuildFlags) error {
-	if err := modelImageRequireUV(ctx); err != nil {
-		return err
-	}
-	if _, err := ctx.Execer().LookPath("docker"); err != nil {
-		return cmd.NewErrUsagef("docker not found on PATH, required to build the image")
-	}
-
 	// Everything after `--` is forwarded verbatim to `docker build`; no
 	// positional arguments are allowed before it.
 	passthrough, err := modelImageDockerPassthroughArgs(ctx)
@@ -51,7 +44,16 @@ func commandModelImageBuild(ctx *CommandContext, flags *cmd.ModelImageBuildFlags
 		return fmt.Errorf("create build dir: %w", err)
 	}
 
-	if err := modelImageBuildContext(ctx, &flags.ModelImageCommonFlags, buildDir); err != nil {
+	// The truss command is built before docker is looked up so an unusable truss
+	// is reported first, in the order the steps run.
+	contextCmd, err := modelImageBuildContextCommand(ctx, &flags.ModelImageCommonFlags, buildDir)
+	if err != nil {
+		return err
+	}
+	if _, err := ctx.Execer().LookPath("docker"); err != nil {
+		return cmd.NewErrUsagef("docker not found on PATH, required to build the image")
+	}
+	if err := modelImageExec(ctx, contextCmd); err != nil {
 		return err
 	}
 
@@ -107,13 +109,14 @@ func commandModelImageBuild(ctx *CommandContext, flags *cmd.ModelImageBuildFlags
 }
 
 func commandModelImagePrepare(ctx *CommandContext, flags *cmd.ModelImagePrepareFlags) error {
-	if err := modelImageRequireUV(ctx); err != nil {
-		return err
-	}
 	if err := os.MkdirAll(flags.BuildDir, 0o755); err != nil {
 		return fmt.Errorf("create build dir: %w", err)
 	}
-	if err := modelImageBuildContext(ctx, &flags.ModelImageCommonFlags, flags.BuildDir); err != nil {
+	contextCmd, err := modelImageBuildContextCommand(ctx, &flags.ModelImageCommonFlags, flags.BuildDir)
+	if err != nil {
+		return err
+	}
+	if err := modelImageExec(ctx, contextCmd); err != nil {
 		return err
 	}
 
@@ -133,23 +136,15 @@ func commandModelImagePrepare(ctx *CommandContext, flags *cmd.ModelImagePrepareF
 	return nil
 }
 
-// modelImageRequireUV confirms the `uv` binary, required to run the truss CLI,
-// is on PATH.
-func modelImageRequireUV(ctx *CommandContext) error {
-	if _, err := ctx.Execer().LookPath("uv"); err != nil {
-		return cmd.NewErrUsagef("uv not found on PATH, required to run truss; install from https://docs.astral.sh/uv/")
-	}
-	return nil
-}
-
-// modelImageBuildContext runs `uv tool run truss@<version> image build-context`,
+// modelImageBuildContextCommand builds the `truss image build-context` command,
 // which generates the Docker build context for the model dir into buildDir. Its
-// output is routed to stderr so our stdout stays clean for the result.
-// TRUSS_NO_UPDATE_CHECK suppresses truss's update check and its associated
-// disk/network side effects. BT_USE_NON_ROOT_USER defaults the image to a
-// non-root user (matching the backend) and is omitted when --root-user is set.
-func modelImageBuildContext(ctx *CommandContext, flags *cmd.ModelImageCommonFlags, buildDir string) error {
-	env := []string{"TRUSS_NO_UPDATE_CHECK=1"}
+// output is routed to stderr so our stdout stays clean for the result. No
+// credential is forwarded: build-context runs entirely locally.
+//
+// BT_USE_NON_ROOT_USER defaults the image to a non-root user (matching the
+// backend) and is omitted when --root-user is set.
+func modelImageBuildContextCommand(ctx *CommandContext, flags *cmd.ModelImageCommonFlags, buildDir string) (*exec.Cmd, error) {
+	var env []string
 	if !flags.RootUser {
 		env = append(env, "BT_USE_NON_ROOT_USER=true")
 	}
@@ -157,15 +152,16 @@ func modelImageBuildContext(ctx *CommandContext, flags *cmd.ModelImageCommonFlag
 		env = append(env, "TRUSS_CACHE_MOUNT_ID="+flags.CacheMountID)
 	}
 
-	c := exec.CommandContext(ctx, "uv",
-		"tool", "run", "truss@"+flags.TrussVersion,
-		"image", "build-context", buildDir, flags.Dir,
-	)
-	c.Stdin = ctx.Stdin
+	c, err := trussCommand(ctx, trussInvocation{
+		Flags: flags.TrussFlags,
+		Args:  []string{"image", "build-context", buildDir, flags.Dir},
+		Env:   env,
+	})
+	if err != nil {
+		return nil, err
+	}
 	c.Stdout = ctx.Stderr
-	c.Stderr = ctx.Stderr
-	c.Env = append(os.Environ(), env...)
-	return modelImageExec(ctx, c)
+	return c, nil
 }
 
 // modelImageExec runs c via the context's Execer, which propagates a non-zero

--- a/internal/cmd/command.train.go
+++ b/internal/cmd/command.train.go
@@ -944,6 +944,12 @@ func commandTrainProjectCacheDescribe(ctx *CommandContext, flags *cmd.TrainProje
 // refreshed by the child process, so a long tail would outlive it. The command's
 // output points at `baseten train job logs --tail` instead.
 func commandTrainPush(ctx *CommandContext, flags *cmd.TrainPushFlags) error {
+	// A sub-minute timeout truncates to zero, which trussIntArg drops as "not
+	// given": truss would silently apply its default instead of the request.
+	if d := flags.InteractiveTimeout; d != 0 && int(d.Minutes()) == 0 {
+		return cmd.NewErrUsagef("--interactive-timeout must be at least 1m")
+	}
+
 	args := []string{"train", "push", flags.Config}
 	args = trussArg(args, "job-name", flags.JobName)
 	args = trussArg(args, "team", flags.Team)

--- a/internal/cmd/command.train.go
+++ b/internal/cmd/command.train.go
@@ -16,6 +16,8 @@ func init() {
 	Register("train capacity update", commandTrainCapacityUpdate)
 	Register("train checkpoint list", commandTrainCheckpointList)
 	Register("train checkpoint files", commandTrainCheckpointFiles)
+	Register("train checkpoint deploy", commandTrainCheckpointDeploy)
+	Register("train init", commandTrainInit)
 	Register("train job list", commandTrainJobList)
 	Register("train job describe", commandTrainJobDescribe)
 	Register("train job logs", commandTrainJobLogs)
@@ -27,6 +29,8 @@ func init() {
 	Register("train job session describe", commandTrainJobSessionDescribe)
 	Register("train project list", commandTrainProjectList)
 	Register("train project cache describe", commandTrainProjectCacheDescribe)
+	Register("train push", commandTrainPush)
+	Register("train workstation create", commandTrainWorkstationCreate)
 }
 
 // trainJobStatusPrefix is the prefix every training job status carries. The CLI
@@ -309,6 +313,48 @@ func commandTrainCheckpointFiles(ctx *CommandContext, flags *cmd.TrainCheckpoint
 		Rows:    rows,
 	})
 	return nil
+}
+
+// commandTrainCheckpointDeploy delegates to the truss CLI, which is the only
+// thing that can evaluate the Python config the deploy is described by.
+func commandTrainCheckpointDeploy(ctx *CommandContext, flags *cmd.TrainCheckpointDeployFlags) error {
+	// Given neither, the job would default to the most recently created one in
+	// any project the caller's teams can reach, as likely to be a colleague's
+	// as their own.
+	if flags.JobID == "" && flags.Config == "" {
+		return cmd.NewErrUsagef("--job-id is required unless --config names the checkpoints to deploy")
+	}
+
+	args := []string{"train", "deploy_checkpoints"}
+	args = trussArg(args, "job-id", flags.JobID)
+	args = trussArg(args, "config", flags.Config)
+	args = trussArg(args, "truss-config-output-dir", flags.ConfigOutDir)
+	args = trussBoolArg(args, "dry-run", flags.DryRun)
+
+	return trussRun(ctx, trussInvocation{
+		Flags:       flags.TrussFlags,
+		Args:        args,
+		ForwardAuth: !flags.TrussNoForwardAuth,
+		JSONResult:  true,
+	})
+}
+
+// commandTrainInit delegates to the truss CLI, which owns the project template
+// and the example downloads. It calls no API, so no credential is forwarded and
+// being logged out is not an error.
+func commandTrainInit(ctx *CommandContext, flags *cmd.TrainInitFlags) error {
+	args := []string{"train", "init"}
+	if flags.ListExamples {
+		args = append(args, "--list-examples")
+	}
+	args = trussArg(args, "target-directory", flags.Dir)
+	args = trussArg(args, "examples", strings.Join(flags.Example, ","))
+
+	return trussRun(ctx, trussInvocation{
+		Flags:      flags.TrussFlags,
+		Args:       args,
+		JSONResult: true,
+	})
 }
 
 func commandTrainJobList(ctx *CommandContext, flags *cmd.TrainJobListFlags) error {
@@ -888,4 +934,60 @@ func commandTrainProjectCacheDescribe(ctx *CommandContext, flags *cmd.TrainProje
 		Rows:    rows,
 	})
 	return nil
+}
+
+// commandTrainPush delegates to the truss CLI, which is the only thing that can
+// evaluate the Python config the job is defined by, and which archives and
+// uploads the config's directory as the job's code.
+//
+// truss's --tail is deliberately not offered: the forwarded credential cannot be
+// refreshed by the child process, so a long tail would outlive it. The command's
+// output points at `baseten train job logs --tail` instead.
+func commandTrainPush(ctx *CommandContext, flags *cmd.TrainPushFlags) error {
+	args := []string{"train", "push", flags.Config}
+	args = trussArg(args, "job-name", flags.JobName)
+	args = trussArg(args, "team", flags.Team)
+	args = trussArg(args, "accelerator", flags.Accelerator)
+	args = trussIntArg(args, "node-count", flags.NodeCount)
+	args = trussArg(args, "entrypoint", flags.Entrypoint)
+	args = trussIntArg(args, "priority", flags.Priority)
+	args = trussBoolArg(args, "spot", flags.Spot)
+	// Interactive triggers are hyphenated in this CLI and underscored downstream,
+	// like every other multi-word value.
+	args = trussArg(args, "interactive", strings.ReplaceAll(flags.Interactive, "-", "_"))
+	args = trussIntArg(args, "interactive-timeout-minutes", int(flags.InteractiveTimeout.Minutes()))
+
+	return trussRun(ctx, trussInvocation{
+		Flags:       flags.TrussFlags,
+		Args:        args,
+		ForwardAuth: !flags.TrussNoForwardAuth,
+		JSONResult:  true,
+	})
+}
+
+// commandTrainWorkstationCreate delegates to the truss CLI, which builds the
+// workstation's job spec and ships the SLURM setup scripts a multi-node
+// workstation needs.
+func commandTrainWorkstationCreate(ctx *CommandContext, flags *cmd.TrainWorkstationCreateFlags) error {
+	args := []string{"train", "workstation"}
+	args = trussArg(args, "accelerator", flags.Accelerator)
+	args = trussIntArg(args, "gpu-count", flags.GPUCount)
+	args = trussIntArg(args, "node-count", flags.NodeCount)
+	args = trussArg(args, "image", flags.Image)
+	// The workstation's project is named rather than identified: it is created
+	// when no project of that name exists yet.
+	args = trussArg(args, "project-id", flags.Project)
+	args = trussArg(args, "team", flags.Team)
+	args = trussArg(args, "orchestrator", flags.Orchestrator)
+	args = trussBoolArg(args, "enable-checkpointing", flags.EnableCheckpointing)
+	args = trussArg(args, "checkpoint-path", flags.CheckpointPath)
+	args = trussIntArg(args, "checkpoint-volume-size", flags.CheckpointVolumeSize)
+	args = trussArg(args, "checkpoint-from-job", flags.CheckpointFromJob)
+
+	return trussRun(ctx, trussInvocation{
+		Flags:       flags.TrussFlags,
+		Args:        args,
+		ForwardAuth: !flags.TrussNoForwardAuth,
+		JSONResult:  true,
+	})
 }

--- a/internal/cmd/command.train_test.go
+++ b/internal/cmd/command.train_test.go
@@ -994,6 +994,16 @@ func Test_Train_Push_ForwardsFlags(t *testing.T) {
 	}, fake.only(t).Args)
 }
 
+func Test_Train_Push_RejectsSubMinuteInteractiveTimeout(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	// A sub-minute value truncates to zero minutes, which would be forwarded as
+	// nothing at all and leave truss applying its own default.
+	err := h.Execute("train", "push", "--config", "./train.py", "--interactive-timeout", "45s")
+	h.Require.ErrorContains(err, "--interactive-timeout must be at least 1m")
+	h.Require.Empty(fake.calls)
+}
+
 func Test_Train_Push_OmitsUnsetFlags(t *testing.T) {
 	h, fake := newTrussHarness(t)
 

--- a/internal/cmd/command.train_test.go
+++ b/internal/cmd/command.train_test.go
@@ -962,3 +962,133 @@ func Test_Train_Job_Download_MultipleArtifacts(t *testing.T) {
 	h.Require.NotNil(m.FindCall("GET", "/artifact-1.tgz"))
 	h.Require.Nil(m.FindCall("GET", "/artifact-2.tgz"))
 }
+
+func Test_Train_Push_ForwardsFlags(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute("train", "push",
+		"--config", "./train.py",
+		"--job-name", "sweep-3",
+		"--team", "research",
+		"--accelerator", "H200:8",
+		"--node-count", "2",
+		"--entrypoint", "./run.sh",
+		"--priority", "10",
+		"--spot",
+		"--interactive", "on-failure",
+		"--interactive-timeout", "90m",
+	))
+
+	h.Require.Equal([]string{
+		"uv", "tool", "run", "truss@latest", "train", "push", "./train.py",
+		"--job-name", "sweep-3",
+		"--team", "research",
+		"--accelerator", "H200:8",
+		"--node-count", "2",
+		"--entrypoint", "./run.sh",
+		"--priority", "10",
+		"--spot",
+		// Hyphenated here, underscored downstream, and a duration in whole minutes.
+		"--interactive", "on_failure",
+		"--interactive-timeout-minutes", "90",
+	}, fake.only(t).Args)
+}
+
+func Test_Train_Push_OmitsUnsetFlags(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute("train", "push", "--config", "./train.py"))
+
+	h.Require.Equal([]string{"uv", "tool", "run", "truss@latest", "train", "push", "./train.py"}, fake.only(t).Args)
+}
+
+func Test_Train_CheckpointDeploy_ForwardsFlags(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute("train", "checkpoint", "deploy",
+		"--job-id", "job-1", "--config-out-dir", "./generated", "--dry-run"))
+
+	h.Require.Equal([]string{
+		"uv", "tool", "run", "truss@latest", "train", "deploy_checkpoints",
+		"--job-id", "job-1",
+		"--truss-config-output-dir", "./generated",
+		"--dry-run",
+	}, fake.only(t).Args)
+}
+
+func Test_Train_CheckpointDeploy_RequiresJobOrConfig(t *testing.T) {
+	h, fake := newTrussHarness(t)
+	_ = h.Execute("train", "checkpoint", "deploy")
+	h.Require.True(h.Exited())
+	// Rejected before truss runs, so it never falls back to the latest job.
+	h.Require.Empty(fake.calls)
+	h.Require.Contains(h.Stderr.String(), "--job-id is required unless --config")
+}
+
+func Test_Train_CheckpointDeploy_ConfigWithoutJob(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute("train", "checkpoint", "deploy", "--config", "./deploy.py"))
+
+	h.Require.Equal([]string{
+		"uv", "tool", "run", "truss@latest", "train", "deploy_checkpoints", "--config", "./deploy.py",
+	}, fake.only(t).Args)
+}
+
+func Test_Train_Init_ForwardsFlagsWithoutAuth(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute("train", "init", "--dir", "./out", "--example", "sft-lora", "--example", "grpo"))
+
+	c := fake.only(t)
+	h.Require.Equal([]string{
+		"uv", "tool", "run", "truss@latest", "train", "init",
+		"--target-directory", "./out",
+		"--examples", "sft-lora,grpo",
+	}, c.Args)
+	// Scaffolding calls no API, so no credential is forwarded.
+	h.Require.NotContains(strings.Join(c.Env, " "), "BASETEN_TRUSS_AUTH_")
+}
+
+func Test_Train_Init_ListExamples(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute("train", "init", "--list-examples"))
+
+	h.Require.Equal([]string{
+		"uv", "tool", "run", "truss@latest", "train", "init", "--list-examples",
+	}, fake.only(t).Args)
+}
+
+func Test_Train_WorkstationCreate_ForwardsFlags(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute("train", "workstation", "create",
+		"--node-count", "4",
+		"--project", "my-workstation",
+		"--team", "research",
+		"--image", "myrepo/base:1",
+		"--enable-checkpointing",
+		"--checkpoint-path", "/checkpoints",
+		"--checkpoint-volume-size", "512",
+		"--checkpoint-from-job", "job-1",
+	))
+
+	c := fake.only(t)
+	h.Require.Equal([]string{
+		"uv", "tool", "run", "truss@latest", "train", "workstation",
+		// Defaulted rather than omitted, so the workstation shape is explicit.
+		"--accelerator", "H100",
+		"--node-count", "4",
+		"--image", "myrepo/base:1",
+		// The project is named, not identified, which is what truss's flag means.
+		"--project-id", "my-workstation",
+		"--team", "research",
+		"--orchestrator", "slurm",
+		"--enable-checkpointing",
+		"--checkpoint-path", "/checkpoints",
+		"--checkpoint-volume-size", "512",
+		"--checkpoint-from-job", "job-1",
+	}, c.Args)
+	h.Require.Contains(c.Env, "BASETEN_TRUSS_AUTH_API_KEY=test-key")
+}

--- a/internal/cmd/command.truss.go
+++ b/internal/cmd/command.truss.go
@@ -63,7 +63,10 @@ func trussExtractFlags(flags *cmd.TrussAuthFlags, args []string) ([]string, erro
 			switch {
 			case f.Value.Type() == "bool":
 				value = "true"
-			case i+1 < len(args):
+			// A following flag is a missing value, not the value: no truss
+			// version or executable starts with a dash, and consuming one would
+			// silently drop an argument meant for truss.
+			case i+1 < len(args) && !strings.HasPrefix(args[i+1], "-"):
 				i++
 				value = args[i]
 			default:

--- a/internal/cmd/command.truss.go
+++ b/internal/cmd/command.truss.go
@@ -1,24 +1,78 @@
 package cmd
 
 import (
-	"fmt"
-	"os/exec"
+	"reflect"
+	"strings"
 
 	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/spf13/pflag"
 )
 
 func init() {
 	Register("truss", commandTruss)
 }
 
-func commandTruss(ctx *CommandContext, flags *cmd.TrussFlags) error {
-	if _, err := ctx.Execer().LookPath("truss"); err != nil {
-		return fmt.Errorf("truss not found on PATH, install with: uv tool install truss")
+func commandTruss(ctx *CommandContext, flags *cmd.TrussPassthroughFlags) error {
+	args, err := trussExtractFlags(&flags.TrussAuthFlags, ctx.Args)
+	if err != nil {
+		return err
 	}
+	// With nothing left to forward, show this command's help rather than truss's
+	// bare usage: it is the only place the --truss-* flags are documented, since
+	// --help is forwarded to truss like any other argument.
+	if len(args) == 0 {
+		return ctx.Command.Help()
+	}
+	return trussRun(ctx, trussInvocation{
+		Flags:       flags.TrussFlags,
+		Args:        args,
+		ForwardAuth: !flags.TrussNoForwardAuth,
+	})
+}
 
-	trussCmd := exec.CommandContext(ctx, "truss", ctx.Args...)
-	trussCmd.Stdin = ctx.Stdin
-	trussCmd.Stdout = ctx.Stdout
-	trussCmd.Stderr = ctx.Stderr
-	return ctx.Execer().Exec(trussCmd)
+// trussExtractFlags pulls this CLI's own --truss-* flags out of raw arguments,
+// wherever they appear, and returns the rest untouched for forwarding to truss.
+// Flag parsing is disabled for `baseten truss`, so this stands in for Cobra:
+// pflag's unknown-flag whitelist looks like the built-in answer but consumes the
+// token after an unknown flag as its value, which would silently drop truss's
+// own arguments.
+//
+// The flag set is built from the same struct tags Cobra binds elsewhere, so the
+// names, types, and defaults cannot drift from the declared flags.
+func trussExtractFlags(flags *cmd.TrussAuthFlags, args []string) ([]string, error) {
+	fs := pflag.NewFlagSet("truss", pflag.ContinueOnError)
+	val := reflect.ValueOf(flags).Elem()
+	bindFlags(fs, val, cmd.LoadFlagsFromType(val.Type()))
+
+	var rest []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !strings.HasPrefix(arg, "--") {
+			rest = append(rest, arg)
+			continue
+		}
+		name, inline, hasInline := strings.Cut(strings.TrimPrefix(arg, "--"), "=")
+		f := fs.Lookup(name)
+		if f == nil {
+			rest = append(rest, arg)
+			continue
+		}
+
+		value := inline
+		if !hasInline {
+			switch {
+			case f.Value.Type() == "bool":
+				value = "true"
+			case i+1 < len(args):
+				i++
+				value = args[i]
+			default:
+				return nil, cmd.NewErrUsagef("flag --%s needs a value", name)
+			}
+		}
+		if err := f.Value.Set(value); err != nil {
+			return nil, cmd.NewErrUsagef("invalid value %q for --%s: %v", value, name, err)
+		}
+	}
+	return rest, nil
 }

--- a/internal/cmd/command.truss_test.go
+++ b/internal/cmd/command.truss_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +18,7 @@ import (
 type trussFakeExecer struct {
 	available map[string]bool
 	stdout    string
+	exitCode  int
 	calls     []*exec.Cmd
 }
 
@@ -43,6 +45,12 @@ func (f *trussFakeExecer) Exec(c *exec.Cmd) error {
 	if f.stdout != "" && c.Stdout != nil {
 		if _, err := fmt.Fprint(c.Stdout, f.stdout); err != nil {
 			return err
+		}
+	}
+	if f.exitCode != 0 {
+		return &cmd.ErrSubprocess{
+			Err:  errors.New("truss: bad arguments"),
+			Code: f.exitCode,
 		}
 	}
 	return nil
@@ -230,4 +238,26 @@ func Test_Truss_Delegated_TextPassesOutputThrough(t *testing.T) {
 	h.Require.NoError(h.Execute("train", "init", "--dir", "./out"))
 
 	h.Require.Equal("job created\n", h.Stdout.String())
+}
+
+func Test_Truss_ExitTwoDoesNotPrintUsage(t *testing.T) {
+	h, fake := newTrussHarness(t)
+	fake.exitCode = 2
+
+	// truss exits 2 for its own validation errors, which collides with the
+	// CLI's own usage exit code; the child's failure is not a usage error here.
+	h.Require.Error(h.Execute("truss", "no-such-command"))
+	h.Require.Equal(2, h.ExitCode)
+	h.Require.Contains(h.Stderr.String(), "truss: bad arguments")
+	h.Require.NotContains(h.Stdout.String(), "Usage:")
+	h.Require.NotContains(h.Stderr.String(), "Usage:")
+}
+
+func Test_Truss_Delegated_ExitTwoKeepsJSONStdout(t *testing.T) {
+	h, fake := newTrussHarness(t)
+	fake.exitCode = 2
+
+	h.Require.Error(h.Execute("train", "init", "--dir", "./out", "--output", "json"))
+	h.Require.Equal(2, h.ExitCode)
+	h.Require.Empty(h.Stdout.String())
 }

--- a/internal/cmd/command.truss_test.go
+++ b/internal/cmd/command.truss_test.go
@@ -116,6 +116,15 @@ func Test_Truss_FlagNeedingValueAtEnd(t *testing.T) {
 	h.Require.Contains(h.Stderr.String(), "needs a value")
 }
 
+func Test_Truss_FlagNeedingValueFollowedByFlag(t *testing.T) {
+	h, _ := newTrussHarness(t)
+	// Consuming the next flag as the value would run truss@--help and swallow
+	// the argument meant for truss.
+	_ = h.Execute("truss", "push", "--truss-version", "--help")
+	h.Require.True(h.Exited())
+	h.Require.Contains(h.Stderr.String(), "needs a value")
+}
+
 func Test_Truss_Executable(t *testing.T) {
 	h, fake := newTrussHarness(t, ".venv/bin/truss")
 
@@ -153,6 +162,16 @@ func Test_Truss_EnvExecutableDefault(t *testing.T) {
 	h.T.Setenv("BASETEN_TRUSS_EXECUTABLE", "my-truss")
 
 	h.Require.NoError(h.Execute("truss", "push"))
+
+	h.Require.Equal("/fake/my-truss", fake.only(t).Args[0])
+}
+
+func Test_Truss_FlagOverridesOtherEnvDefault(t *testing.T) {
+	h, fake := newTrussHarness(t, "my-truss")
+	h.T.Setenv("BASETEN_TRUSS_VERSION", "0.18.26")
+
+	// A stored version default must not collide with an explicit executable.
+	h.Require.NoError(h.Execute("truss", "--truss-executable", "my-truss", "push"))
 
 	h.Require.Equal("/fake/my-truss", fake.only(t).Args[0])
 }

--- a/internal/cmd/command.truss_test.go
+++ b/internal/cmd/command.truss_test.go
@@ -1,11 +1,214 @@
 package cmd_test
 
-import "testing"
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
 
-func Test_Truss_NotOnPath(t *testing.T) {
+	"github.com/basetenlabs/baseten-cli/internal/cmd"
+)
+
+// trussFakeExecer implements cmd.Execer for the commands that shell out to the
+// truss CLI, recording invocations and optionally writing simulated truss
+// output so tests can tell stdout from stderr.
+type trussFakeExecer struct {
+	available map[string]bool
+	stdout    string
+	calls     []*exec.Cmd
+}
+
+func newTrussFakeExecer(available ...string) *trussFakeExecer {
+	m := map[string]bool{}
+	for _, a := range available {
+		m[a] = true
+	}
+	return &trussFakeExecer{available: m}
+}
+
+func (f *trussFakeExecer) LookPath(name string) (string, error) {
+	if f.available[name] {
+		if filepath.IsAbs(name) {
+			return name, nil
+		}
+		return "/fake/" + name, nil
+	}
+	return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
+}
+
+func (f *trussFakeExecer) Exec(c *exec.Cmd) error {
+	f.calls = append(f.calls, c)
+	if f.stdout != "" && c.Stdout != nil {
+		if _, err := fmt.Fprint(c.Stdout, f.stdout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// only returns the single recorded invocation, failing if there is not exactly one.
+func (f *trussFakeExecer) only(t *testing.T) *exec.Cmd {
+	t.Helper()
+	if len(f.calls) != 1 {
+		t.Fatalf("expected exactly one command, got %d", len(f.calls))
+	}
+	return f.calls[0]
+}
+
+// newTrussHarness returns a harness whose truss invocations are recorded rather
+// than run, with uv available so the default resolution path works.
+func newTrussHarness(t *testing.T, available ...string) (*CommandHarness, *trussFakeExecer) {
 	h := NewCommandHarness(t)
-	h.T.Setenv("PATH", "")
-	_ = h.Execute("truss", "--help")
+	if len(available) == 0 {
+		available = []string{"uv"}
+	}
+	fake := newTrussFakeExecer(available...)
+	h.Context = cmd.WithExecer(h.Context, fake)
+	return h, fake
+}
+
+func Test_Truss_UVNotOnPath(t *testing.T) {
+	h, _ := newTrussHarness(t, "truss")
+	_ = h.Execute("truss", "push")
 	h.Require.True(h.Exited())
-	h.Require.Contains(h.Stderr.String(), "truss not found")
+	h.Require.Contains(h.Stderr.String(), "uv not found")
+}
+
+func Test_Truss_ForwardsArgsAndAuth(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute("truss", "push", "--publish", "--help"))
+
+	c := fake.only(t)
+	h.Require.Equal([]string{"uv", "tool", "run", "truss@latest", "push", "--publish", "--help"}, c.Args)
+	h.Require.Contains(c.Env, "TRUSS_NO_UPDATE_CHECK=1")
+	// The harness authenticates with BASETEN_API_KEY against BASETEN_REMOTE_URL.
+	h.Require.Contains(c.Env, "BASETEN_TRUSS_AUTH_API_KEY=test-key")
+	h.Require.Contains(c.Env, "BASETEN_TRUSS_AUTH_REMOTE_URL=http://127.0.0.1:1")
+}
+
+func Test_Truss_ExtractsOwnFlagsAnywhere(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute(
+		"truss", "push", "--truss-version", "0.18.26", "./model", "--truss-no-forward-auth", "--publish"))
+
+	c := fake.only(t)
+	// Our flags are consumed wherever they appear; everything else keeps its order.
+	h.Require.Equal([]string{"uv", "tool", "run", "truss@0.18.26", "push", "./model", "--publish"}, c.Args)
+	h.Require.NotContains(strings.Join(c.Env, " "), "BASETEN_TRUSS_AUTH_")
+}
+
+func Test_Truss_ExtractsInlineFlagValue(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute("truss", "--truss-version=0.18.26", "push"))
+
+	h.Require.Equal("truss@0.18.26", fake.only(t).Args[3])
+}
+
+func Test_Truss_FlagNeedingValueAtEnd(t *testing.T) {
+	h, _ := newTrussHarness(t)
+	_ = h.Execute("truss", "push", "--truss-version")
+	h.Require.True(h.Exited())
+	h.Require.Contains(h.Stderr.String(), "needs a value")
+}
+
+func Test_Truss_Executable(t *testing.T) {
+	h, fake := newTrussHarness(t, ".venv/bin/truss")
+
+	h.Require.NoError(h.Execute("truss", "--truss-executable", ".venv/bin/truss", "chains", "push"))
+
+	c := fake.only(t)
+	h.Require.Equal([]string{"/fake/.venv/bin/truss", "chains", "push"}, c.Args)
+}
+
+func Test_Truss_ExecutableNotFound(t *testing.T) {
+	h, _ := newTrussHarness(t)
+	_ = h.Execute("truss", "--truss-executable", "nope/truss", "push")
+	h.Require.True(h.Exited())
+	h.Require.Contains(h.Stderr.String(), `truss executable "nope/truss" not found`)
+}
+
+func Test_Truss_VersionAndExecutableMutuallyExclusive(t *testing.T) {
+	h, _ := newTrussHarness(t, "uv", "truss")
+	_ = h.Execute("truss", "--truss-version", "0.18.26", "--truss-executable", "truss", "push")
+	h.Require.True(h.Exited())
+	h.Require.Contains(h.Stderr.String(), "mutually exclusive")
+}
+
+func Test_Truss_EnvDefaultsSelectTruss(t *testing.T) {
+	h, fake := newTrussHarness(t)
+	h.T.Setenv("BASETEN_TRUSS_VERSION", "0.18.26")
+
+	h.Require.NoError(h.Execute("truss", "push"))
+
+	h.Require.Equal("truss@0.18.26", fake.only(t).Args[3])
+}
+
+func Test_Truss_EnvExecutableDefault(t *testing.T) {
+	h, fake := newTrussHarness(t, "my-truss")
+	h.T.Setenv("BASETEN_TRUSS_EXECUTABLE", "my-truss")
+
+	h.Require.NoError(h.Execute("truss", "push"))
+
+	h.Require.Equal("/fake/my-truss", fake.only(t).Args[0])
+}
+
+func Test_Truss_RejectsTrussAuthEnv(t *testing.T) {
+	for _, name := range []string{"BASETEN_TRUSS_AUTH_REMOTE_URL", "BASETEN_TRUSS_AUTH_API_KEY"} {
+		t.Run(name, func(t *testing.T) {
+			h, _ := newTrussHarness(t)
+			h.T.Setenv(name, "value")
+			_ = h.Execute("truss", "push")
+			h.Require.True(h.Exited())
+			h.Require.Contains(h.Stderr.String(), name+" is set")
+			h.Require.Contains(h.Stderr.String(), "BASETEN_API_KEY")
+		})
+	}
+}
+
+func Test_Truss_NoArgsShowsHelp(t *testing.T) {
+	h, fake := newTrussHarness(t)
+
+	h.Require.NoError(h.Execute("truss"))
+
+	// Nothing to forward, so our own help renders instead, which is the only
+	// place the --truss-* flags are documented.
+	h.Require.Empty(fake.calls)
+	h.Require.Contains(h.Stdout.String(), "--truss-version")
+}
+
+func Test_Truss_PassthroughStdoutIsVerbatim(t *testing.T) {
+	h, fake := newTrussHarness(t)
+	fake.stdout = "truss output\n"
+
+	h.Require.NoError(h.Execute("truss", "push"))
+
+	// `baseten truss` reserves nothing: truss's stdout is the command's stdout.
+	h.Require.Equal("truss output\n", h.Stdout.String())
+}
+
+func Test_Truss_Delegated_JSONReservesStdout(t *testing.T) {
+	h, fake := newTrussHarness(t)
+	fake.stdout = "job created\n"
+
+	h.Require.NoError(h.Execute("train", "init", "--dir", "./out", "--output", "json"))
+
+	// Under JSON output, stdout is the result object and truss's text moves to stderr.
+	result := map[string]any{}
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &result))
+	h.Require.Empty(result)
+	h.Require.Contains(h.Stderr.String(), "job created")
+}
+
+func Test_Truss_Delegated_TextPassesOutputThrough(t *testing.T) {
+	h, fake := newTrussHarness(t)
+	fake.stdout = "job created\n"
+
+	h.Require.NoError(h.Execute("train", "init", "--dir", "./out"))
+
+	h.Require.Equal("job created\n", h.Stdout.String())
 }

--- a/internal/cmd/truss.go
+++ b/internal/cmd/truss.go
@@ -68,13 +68,12 @@ func trussCommand(ctx *CommandContext, inv trussInvocation) (*exec.Cmd, error) {
 		}
 	}
 
-	version := inv.Flags.TrussVersion
-	if version == "" {
-		version = os.Getenv(trussVersionEnv)
-	}
-	executable := inv.Flags.TrussExecutable
-	if executable == "" {
-		executable = os.Getenv(trussExecutableEnv)
+	// Either flag suppresses both environment defaults, so a stored
+	// BASETEN_TRUSS_VERSION does not collide with an explicit
+	// --truss-executable and turn a valid invocation into a usage error.
+	version, executable := inv.Flags.TrussVersion, inv.Flags.TrussExecutable
+	if version == "" && executable == "" {
+		version, executable = os.Getenv(trussVersionEnv), os.Getenv(trussExecutableEnv)
 	}
 	if version != "" && executable != "" {
 		return nil, cmd.NewErrUsagef(

--- a/internal/cmd/truss.go
+++ b/internal/cmd/truss.go
@@ -1,0 +1,182 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/basetenlabs/baseten-cli/cmd"
+)
+
+const (
+	// trussAuthRemoteURLEnv and trussAuthAPIKeyEnv are the variables truss
+	// reads to define a remote outright, bypassing its trussrc and keyring.
+	// Together they are how the CLI hands its own credential to truss.
+	trussAuthRemoteURLEnv = "BASETEN_TRUSS_AUTH_REMOTE_URL"
+	trussAuthAPIKeyEnv    = "BASETEN_TRUSS_AUTH_API_KEY"
+
+	// trussVersionEnv and trussExecutableEnv default --truss-version and
+	// --truss-executable, so a chosen truss survives across invocations.
+	trussVersionEnv    = "BASETEN_TRUSS_VERSION"
+	trussExecutableEnv = "BASETEN_TRUSS_EXECUTABLE"
+
+	// trussDefaultVersion is the version spec handed to uv when the caller
+	// names none.
+	trussDefaultVersion = "latest"
+)
+
+// trussInvocation describes one run of the truss CLI.
+type trussInvocation struct {
+	// Flags selects which truss to run.
+	Flags cmd.TrussFlags
+	// Args are the arguments passed to truss.
+	Args []string
+	// ForwardAuth hands the CLI's resolved credential to truss over the
+	// environment. Set by commands that reach the Baseten API through truss;
+	// left false by commands that only run truss locally.
+	ForwardAuth bool
+	// Env holds extra "KEY=VALUE" entries for the child environment.
+	Env []string
+	// JSONResult reserves stdout for the command's own JSON result: under JSON
+	// output truss's output is routed to stderr and an empty result object is
+	// printed once truss succeeds. Truss reports these results as prose only,
+	// so there is nothing structured to pass on yet. Left false by
+	// `baseten truss`, whose stdout is truss's output verbatim.
+	JSONResult bool
+}
+
+// trussCommand builds the command for a truss invocation, with the caller's
+// stdio wired and the child environment prepared. Callers may retarget the
+// stdio before running it, which `baseten model image` does to keep its own
+// stdout clean.
+//
+// Truss is run by `uv tool run` unless an executable is named, since a version
+// spec resolved by uv is reproducible and recent enough to honor the forwarded
+// credential, whereas whatever is on PATH is neither.
+func trussCommand(ctx *CommandContext, inv trussInvocation) (*exec.Cmd, error) {
+	// Truss's own auth variables are the channel this CLI forwards over, so a
+	// value already in the environment would either be overwritten or, worse,
+	// silently steer truss at a different workspace. The CLI's own variables
+	// express the same intent and are forwarded from there.
+	for _, name := range []string{trussAuthRemoteURLEnv, trussAuthAPIKeyEnv} {
+		if os.Getenv(name) != "" {
+			return nil, cmd.NewErrUsagef(
+				"%s is set, which would point truss at a remote this CLI knows nothing about; "+
+					"unset it and use BASETEN_API_KEY, plus BASETEN_REMOTE_URL for a non-default remote, "+
+					"which are forwarded to truss for you", name)
+		}
+	}
+
+	version := inv.Flags.TrussVersion
+	if version == "" {
+		version = os.Getenv(trussVersionEnv)
+	}
+	executable := inv.Flags.TrussExecutable
+	if executable == "" {
+		executable = os.Getenv(trussExecutableEnv)
+	}
+	if version != "" && executable != "" {
+		return nil, cmd.NewErrUsagef(
+			"--truss-version and --truss-executable are mutually exclusive; a version selects a truss "+
+				"for uv to fetch, an executable runs one you already have (values can also come from %s and %s)",
+			trussVersionEnv, trussExecutableEnv)
+	}
+
+	var c *exec.Cmd
+	if executable != "" {
+		// LookPath resolves a bare name against PATH and, on Windows, applies
+		// PATHEXT so a path without the .exe suffix still resolves.
+		path, err := ctx.Execer().LookPath(executable)
+		if err != nil {
+			return nil, cmd.NewErrUsagef("truss executable %q not found: %v", executable, err)
+		}
+		c = exec.CommandContext(ctx, path, inv.Args...)
+	} else {
+		if _, err := ctx.Execer().LookPath("uv"); err != nil {
+			return nil, cmd.NewErrUsagef("uv not found on PATH, required to run truss; install from " +
+				"https://docs.astral.sh/uv/, or point --truss-executable at a truss you installed")
+		}
+		if version == "" {
+			version = trussDefaultVersion
+		}
+		c = exec.CommandContext(ctx, "uv", append([]string{"tool", "run", "truss@" + version}, inv.Args...)...)
+	}
+
+	// TRUSS_NO_UPDATE_CHECK suppresses truss's update check and its associated
+	// disk/network side effects.
+	env := append(os.Environ(), "TRUSS_NO_UPDATE_CHECK=1")
+	env = append(env, inv.Env...)
+	if inv.ForwardAuth {
+		transport, remote, err := ctx.AuthTransport()
+		if err != nil {
+			return nil, err
+		}
+		// Forwarded over the environment rather than written to a trussrc, and
+		// as a bearer token so the same variable carries an API key or an OAuth
+		// access token. The child cannot refresh an access token, so delegated
+		// invocations are kept short rather than tailing through truss.
+		token, err := transport.Credential(ctx)
+		if err != nil {
+			return nil, err
+		}
+		env = append(env,
+			trussAuthRemoteURLEnv+"="+remote.RemoteURL(),
+			trussAuthAPIKeyEnv+"="+token,
+		)
+	}
+	c.Env = env
+
+	c.Stdin = ctx.Stdin
+	c.Stdout = ctx.Stdout
+	c.Stderr = ctx.Stderr
+	return c, nil
+}
+
+// trussRun builds and runs a truss invocation, propagating truss's exit code
+// as an [ErrSubprocess]. The command line is logged only in verbose mode, since
+// forwarded arguments can carry values a user would not want echoed.
+func trussRun(ctx *CommandContext, inv trussInvocation) error {
+	c, err := trussCommand(ctx, inv)
+	if err != nil {
+		return err
+	}
+	if inv.JSONResult && ctx.JSON {
+		c.Stdout = ctx.Stderr
+	}
+	ctx.VerboseLogf("+ %s\n", strings.Join(c.Args, " "))
+	if err := ctx.Execer().Exec(c); err != nil {
+		return err
+	}
+	if inv.JSONResult && ctx.JSON {
+		ctx.OutputJSON(cmd.TrussDelegatedResult{})
+	}
+	return nil
+}
+
+// trussArg appends "--name value" to args when value is non-empty, the shape
+// every delegating command uses to forward an optional flag.
+func trussArg(args []string, name, value string) []string {
+	if value == "" {
+		return args
+	}
+	return append(args, "--"+name, value)
+}
+
+// trussBoolArg appends "--name" to args when set.
+func trussBoolArg(args []string, name string, set bool) []string {
+	if !set {
+		return args
+	}
+	return append(args, "--"+name)
+}
+
+// trussIntArg appends "--name value" when value is non-zero. Every integer flag
+// forwarded to truss is a count, timeout, or priority for which zero is not a
+// meaningful request, so zero means "not given" and truss applies its default.
+func trussIntArg(args []string, name string, value int) []string {
+	if value == 0 {
+		return args
+	}
+	return append(args, "--"+name, strconv.Itoa(value))
+}

--- a/internal/e2e-tests/train_test.go
+++ b/internal/e2e-tests/train_test.go
@@ -250,10 +250,12 @@ func newTrainLifecycle(t *testing.T) *trainLifecycle {
 	// checkpoint sync both come from the running pod.
 	var status string
 	require.Eventually(t, func() bool {
-		job := tr.mustDescribeJob(t)
-		status = job.CurrentStatus
+		if current := tr.mustDescribeJob(t).CurrentStatus; current != status {
+			status = current
+			t.Logf("job status: %s", status)
+		}
 		return status == "TRAINING_JOB_RUNNING"
-	}, 10*time.Minute, 5*time.Second, "job never reached running; last status %s", &status)
+	}, 10*time.Minute, 5*time.Second, "job never reached running")
 	return tr
 }
 
@@ -538,7 +540,10 @@ func (tr *trainLifecycle) Stop(t *testing.T) {
 	// Stopping is asynchronous, so the status settles a moment later.
 	var status string
 	require.Eventually(t, func() bool {
-		status = tr.mustDescribeJob(t).CurrentStatus
+		if current := tr.mustDescribeJob(t).CurrentStatus; current != status {
+			status = current
+			t.Logf("job status: %s", status)
+		}
 		return status == "TRAINING_JOB_STOPPED"
-	}, 3*time.Minute, 5*time.Second, "job never reported stopped; last status %s", &status)
+	}, 3*time.Minute, 5*time.Second, "job never reported stopped")
 }

--- a/internal/e2e-tests/train_test.go
+++ b/internal/e2e-tests/train_test.go
@@ -1,0 +1,544 @@
+//go:build e2e
+
+package e2etests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The training job is deliberately CPU-only: no accelerator means the backend
+// resolves the CPU workload-plane row and the least expensive CPU instance
+// type, so the whole lifecycle costs about what a CPU model deployment does.
+// A GPU is needed to *train* something, and this test trains nothing: it
+// checks that the CLI's train surface drives a real job end to end.
+//
+// The job writes a LoRA adapter config and then idles. Checkpoints are
+// discovered by scanning the synced prefix for checkpoint-<N>/adapter_config.json
+// and reading peft_type, base_model_name_or_path and r out of it, so that one
+// file is a complete checkpoint as far as the platform is concerned, with no
+// weights to produce or upload.
+//
+// The idle matters: the checkpoint sync sidecar loops until the job completes,
+// sleeping 30s between passes, so a job that exits right after writing its
+// checkpoint can finish before any pass picks the file up. Idling keeps the job
+// RUNNING while the assertions run, and the Stop phase ends it.
+const trainConfigTmpl = `from truss_train import definitions
+
+CHECKPOINT_DIR = "%[1]s/%[2]s"
+ADAPTER_CONFIG = "{\"peft_type\": \"LORA\", \"base_model_name_or_path\": \"%[3]s\", \"r\": %[4]d, \"lora_alpha\": 32}"
+
+training_job = definitions.TrainingJob(
+    image=definitions.Image(base_image="%[5]s"),
+    # No accelerator, so this resolves to a CPU instance type. The memory
+    # request has to cover the checkpoint sync sidecar as well as this
+    # container, since both share the instance.
+    compute=definitions.Compute(cpu_count=1, memory="%[6]s"),
+    runtime=definitions.Runtime(
+        start_commands=[
+            "mkdir -p " + CHECKPOINT_DIR
+            + " && echo '" + ADAPTER_CONFIG + "' > " + CHECKPOINT_DIR + "/adapter_config.json"
+            + " && echo %[7]s"
+            + " && sleep %[8]d"
+        ],
+        environment_variables={"%[9]s": "%[10]s"},
+        checkpointing_config=definitions.CheckpointingConfig(
+            enabled=True, checkpoint_path="%[1]s", volume_size_gib=%[11]d
+        ),
+    ),
+)
+
+training_project = definitions.TrainingProject(name="%[12]s", job=training_job)
+`
+
+// deployCheckpointsConfigTmpl is the --config for the delegated
+// `train checkpoint deploy`. Everything the deploy needs is spelled out:
+// truss prompts for any missing piece (checkpoints, model name, accelerator, HF
+// secret) and those prompts fail rather than hang without a terminal.
+//
+// Paired with --dry-run, this renders a model config and stops: the backend
+// returns before creating an oracle version, so nothing is deployed and no GPU
+// is claimed.
+const deployCheckpointsConfigTmpl = `from truss_train import definitions
+from truss.base import truss_config
+
+deploy_config = definitions.DeployCheckpointsConfig(
+    checkpoint_details=definitions.CheckpointList(
+        base_model_id="%[1]s",
+        checkpoints=[
+            definitions.LoRACheckpoint(
+                training_job_id="%[2]s",
+                checkpoint_name="%[3]s",
+                lora_details=definitions.LoRADetails(rank=%[4]d),
+            )
+        ],
+    ),
+    model_name="%[5]s",
+    runtime=definitions.DeployCheckpointsRuntime(
+        environment_variables={"HF_TOKEN": definitions.SecretReference(name="%[6]s")}
+    ),
+    compute=definitions.Compute(
+        accelerator=truss_config.AcceleratorSpec(
+            accelerator=truss_config.Accelerator.H100, count=1
+        )
+    ),
+)
+`
+
+const (
+	// trainCheckpointPath is where the checkpoint volume is mounted, and
+	// trainCheckpointName is the directory written under it. The name must match
+	// checkpoint-<N> for the backend to recognize the directory as a checkpoint.
+	trainCheckpointPath = "/mnt/ckpts"
+	trainCheckpointName = "checkpoint-1"
+
+	// trainCheckpointVolumeGiB is the checkpoint volume size. Only an upper
+	// limit is enforced, and one adapter config needs none of it.
+	trainCheckpointVolumeGiB = 10
+
+	// trainBaseModel is recorded in the adapter config and read back as the
+	// checkpoint's base model. Nothing downloads it.
+	trainBaseModel = "Qwen/Qwen3-0.6B"
+	trainLoRARank  = 16
+
+	// trainBaseImage is small enough to pull in seconds. The job's start
+	// commands run under sh, which is all the pod template requires.
+	trainBaseImage = "alpine:3.21.3"
+
+	// trainMemory covers this container plus the checkpoint sync sidecar, which
+	// requests 4Gi of its own on the same instance.
+	trainMemory = "8Gi"
+
+	// trainLogMarker is echoed by the job and asserted by the Logs phase.
+	trainLogMarker = "baseten-e2e-train-ready"
+
+	// trainEnvVarName and trainEnvVarValue prove the environment reaches the
+	// container: the marker line is echoed through the variable.
+	trainEnvVarName  = "BASETEN_E2E_TRAIN"
+	trainEnvVarValue = "ok"
+
+	// trainIdleSeconds is how long the job idles after writing its checkpoint,
+	// bounding how long the assertions have before it exits on its own. The
+	// Stop phase normally ends it well before this elapses.
+	trainIdleSeconds = 900
+)
+
+// TestE2ETrainLifecycle pushes a CPU-only training job with the delegated
+// `train push`, drives the native train surface against it, deploys its
+// checkpoint as a dry run through the delegated `train checkpoint deploy`, and
+// stops it. Skips when the e2e env vars are absent.
+func TestE2ETrainLifecycle(t *testing.T) {
+	tr := newTrainLifecycle(t)
+	t.Run("Init", tr.Init)
+	t.Run("Capacity", tr.Capacity)
+	t.Run("Project", tr.Project)
+	t.Run("Job", tr.Job)
+	t.Run("Logs", tr.Logs)
+	t.Run("Checkpoints", tr.Checkpoints)
+	t.Run("CheckpointDeployDryRun", tr.CheckpointDeployDryRun)
+	t.Run("Stop", tr.Stop)
+}
+
+// trainLifecycle holds the state shared across the lifecycle sub-tests.
+// Created by [newTrainLifecycle], which performs the push and registers
+// teardown.
+type trainLifecycle struct {
+	projectName string
+	projectID   string
+	jobName     string
+	jobID       string
+}
+
+// trainJob is the subset of a training job the assertions read.
+type trainJob struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	CurrentStatus string `json:"current_status"`
+	InstanceType  struct {
+		Name     string `json:"name"`
+		GPUCount int    `json:"gpu_count"`
+	} `json:"instance_type"`
+	TrainingProject struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"training_project"`
+}
+
+// newTrainLifecycle runs the env-gate, writes the job config, pushes it, and
+// registers cleanup. Fatals on setup failure so sub-tests can assume valid
+// state.
+func newTrainLifecycle(t *testing.T) *trainLifecycle {
+	apiKey := os.Getenv("BASETEN_E2E_TEST_API_KEY")
+	if apiKey == "" {
+		t.Skip("BASETEN_E2E_TEST_API_KEY not set")
+	}
+	remoteURL := os.Getenv("BASETEN_E2E_TEST_REMOTE_URL")
+	require.NotEmpty(t, remoteURL, "BASETEN_E2E_TEST_API_KEY is set but BASETEN_E2E_TEST_REMOTE_URL is missing")
+
+	t.Setenv("BASETEN_API_KEY", apiKey)
+	t.Setenv("BASETEN_REMOTE_URL", remoteURL)
+	t.Setenv("BASETEN_CONFIG_DIR", t.TempDir())
+
+	suffix := randomSuffix(t)
+	tr := &trainLifecycle{
+		projectName: fmt.Sprintf("cli-e2e-train-%s", suffix),
+		jobName:     fmt.Sprintf("cli-e2e-job-%s", suffix),
+	}
+
+	// The pushed archive is the config's directory, so the config sits alone in
+	// its own dir rather than beside the deploy config written later.
+	configDir := filepath.Join(t.TempDir(), "job")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	configPath := filepath.Join(configDir, "config.py")
+	require.NoError(t, os.WriteFile(configPath, []byte(fmt.Sprintf(trainConfigTmpl,
+		trainCheckpointPath, trainCheckpointName, trainBaseModel, trainLoRARank,
+		trainBaseImage, trainMemory, "$"+trainEnvVarName+" "+trainLogMarker, trainIdleSeconds,
+		trainEnvVarName, trainEnvVarValue, trainCheckpointVolumeGiB, tr.projectName,
+	)), 0o644))
+
+	// Registered before the push so a job created by a push that then failed is
+	// still stopped and its project removed.
+	t.Cleanup(func() {
+		if os.Getenv("BASETEN_E2E_KEEP_TRAIN_JOB") != "" {
+			t.Logf("BASETEN_E2E_KEEP_TRAIN_JOB set; leaving project %q in place", tr.projectName)
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if tr.jobID == "" {
+			if job := tr.findJob(t); job != nil {
+				tr.jobID, tr.projectID = job.ID, job.TrainingProject.ID
+			}
+		}
+		if tr.jobID != "" {
+			t.Logf("stopping training job %s", tr.jobID)
+			if _, errOut, err := cliCtx(t, ctx, "train", "job", "stop", "--job-id", tr.jobID, "--yes"); err != nil {
+				t.Logf("cleanup stop failed: %v\nstderr: %s", err, errOut)
+			}
+		}
+		if tr.projectID == "" {
+			return
+		}
+		// No native delete command for training projects, so go through the raw
+		// API. Leaving the project behind would accumulate one per run.
+		t.Logf("deleting training project %s (%s)", tr.projectName, tr.projectID)
+		if _, errOut, err := cliCtx(t, ctx, "api", "management",
+			"training_projects/"+tr.projectID, "-X", "DELETE"); err != nil {
+			t.Logf("cleanup project delete failed: %v\nstderr: %s", err, errOut)
+		}
+	})
+
+	// The delegated push reports nothing structured, so the job is found by
+	// listing the project it created.
+	t.Logf("pushing training job %s to project %s", tr.jobName, tr.projectName)
+	mustCLI(t, "train", "push", "--config", configPath, "--job-name", tr.jobName)
+
+	job := tr.findJob(t)
+	require.NotNil(t, job, "pushed job %q not found in project %q", tr.jobName, tr.projectName)
+	tr.jobID, tr.projectID = job.ID, job.TrainingProject.ID
+	t.Logf("pushed training job %s in project %s", tr.jobID, tr.projectID)
+
+	// The remaining phases need a container that has started: logs and
+	// checkpoint sync both come from the running pod.
+	var status string
+	require.Eventually(t, func() bool {
+		job := tr.mustDescribeJob(t)
+		status = job.CurrentStatus
+		return status == "TRAINING_JOB_RUNNING"
+	}, 10*time.Minute, 5*time.Second, "job never reached running; last status %s", &status)
+	return tr
+}
+
+// findJob returns the pushed job from the project's listing, or nil when it is
+// not there yet. Errors are not fatal so this is safe to call from cleanup.
+func (tr *trainLifecycle) findJob(t *testing.T) *trainJob {
+	t.Helper()
+	out, _, err := cli(t, "train", "job", "list", "--project", tr.projectName, "--output", "json")
+	if err != nil {
+		return nil
+	}
+	var resp struct {
+		TrainingJobs []trainJob `json:"training_jobs"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		return nil
+	}
+	for _, job := range resp.TrainingJobs {
+		if job.Name == tr.jobName {
+			return &job
+		}
+	}
+	return nil
+}
+
+// mustDescribeJob fetches the job by ID and fatals if the fetch fails.
+func (tr *trainLifecycle) mustDescribeJob(t *testing.T) trainJob {
+	t.Helper()
+	out := mustCLI(t, "train", "job", "describe", "--job-id", tr.jobID, "--output", "json")
+	var resp struct {
+		TrainingJob trainJob `json:"training_job"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+	return resp.TrainingJob
+}
+
+// Init covers the scaffolding command, which calls no API and so runs without a
+// credential.
+func (tr *trainLifecycle) Init(t *testing.T) {
+	t.Run("ListExamples", func(t *testing.T) {
+		out := mustCLI(t, "train", "init", "--list-examples")
+		require.NotEmpty(t, strings.TrimSpace(out), "no examples listed")
+	})
+
+	t.Run("EmptyProject", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "scaffold")
+		mustCLI(t, "train", "init", "--dir", dir)
+		// The template is a config the user edits plus the script it runs.
+		for _, name := range []string{"config.py", "run.sh"} {
+			_, err := os.Stat(filepath.Join(dir, name))
+			require.NoError(t, err, "%s missing from scaffold", name)
+		}
+	})
+}
+
+func (tr *trainLifecycle) Capacity(t *testing.T) {
+	out := mustCLI(t, "train", "capacity", "describe", "--output", "json")
+	var resp struct {
+		GPUCapacities []struct {
+			GPUType string `json:"gpu_type"`
+		} `json:"gpu_capacities"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+}
+
+// Project covers the project listing. `train project cache describe` is not
+// covered: it 404s unless the project has a cache-enabled job, and enabling the
+// cache would provision a cache volume and pin the project to one workload
+// plane, which is more than this test should cost.
+func (tr *trainLifecycle) Project(t *testing.T) {
+	out := mustCLI(t, "train", "project", "list", "--output", "json")
+	var resp struct {
+		TrainingProjects []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"training_projects"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+	for _, project := range resp.TrainingProjects {
+		if project.ID == tr.projectID {
+			require.Equal(t, tr.projectName, project.Name)
+			return
+		}
+	}
+	t.Fatalf("project %s (%s) missing from listing", tr.projectName, tr.projectID)
+}
+
+func (tr *trainLifecycle) Job(t *testing.T) {
+	t.Run("Describe", func(t *testing.T) {
+		job := tr.mustDescribeJob(t)
+		require.Equal(t, tr.jobID, job.ID)
+		require.Equal(t, tr.jobName, job.Name)
+		// The point of the whole test: no accelerator was requested, so the job
+		// landed on a CPU instance.
+		require.Zero(t, job.InstanceType.GPUCount, "expected a CPU instance, got %s", job.InstanceType.Name)
+	})
+
+	t.Run("ListByStatus", func(t *testing.T) {
+		out := mustCLI(t, "train", "job", "list", "--project", tr.projectName,
+			"--status", "running", "--output", "json")
+		var resp struct {
+			TrainingJobs []trainJob `json:"training_jobs"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.Len(t, resp.TrainingJobs, 1)
+		require.Equal(t, tr.jobID, resp.TrainingJobs[0].ID)
+	})
+
+	t.Run("ListByUnmatchedStatus", func(t *testing.T) {
+		out := mustCLI(t, "train", "job", "list", "--project", tr.projectName,
+			"--status", "completed", "--output", "json")
+		var resp struct {
+			TrainingJobs []trainJob `json:"training_jobs"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.Empty(t, resp.TrainingJobs)
+	})
+
+	// `train job update` is not covered: the backend only allows a priority
+	// change while a job is PENDING, waiting on capacity, which a CPU job never
+	// is.
+
+	t.Run("Metrics", func(t *testing.T) {
+		// A job this short may not have reported a sample yet, so this asserts
+		// the query works rather than what it contains.
+		out := mustCLI(t, "train", "job", "metrics", "--job-id", tr.jobID, "--since", "30m", "--output", "json")
+		require.NoError(t, json.Unmarshal([]byte(out), &struct{}{}))
+	})
+
+	t.Run("SessionDescribe", func(t *testing.T) {
+		// No interactive session was requested, so there is nothing to list.
+		out := mustCLI(t, "train", "job", "session", "describe", "--job-id", tr.jobID, "--output", "json")
+		var resp struct {
+			AuthCodes []struct {
+				SessionID string `json:"session_id"`
+			} `json:"auth_codes"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.Empty(t, resp.AuthCodes)
+	})
+}
+
+func (tr *trainLifecycle) Logs(t *testing.T) {
+	collect := func(extraArgs ...string) ([]logLine, error) {
+		args := append([]string{"train", "job", "logs", "--job-id", tr.jobID,
+			"--since", "1h", "--output", "jsonl"}, extraArgs...)
+		out, _, err := cli(t, args...)
+		if err != nil {
+			return nil, err
+		}
+		var lines []logLine
+		for _, raw := range strings.Split(strings.TrimSpace(out), "\n") {
+			if raw == "" {
+				continue
+			}
+			var ll logLine
+			require.NoError(t, json.Unmarshal([]byte(raw), &ll))
+			lines = append(lines, ll)
+		}
+		return lines, nil
+	}
+
+	// Log propagation lags the container starting, so poll until the marker the
+	// job echoed is queryable.
+	var lines []logLine
+	require.Eventually(t, func() bool {
+		got, err := collect()
+		if err != nil {
+			return false
+		}
+		lines = got
+		for _, ll := range lines {
+			if strings.Contains(ll.Message, trainLogMarker) {
+				return true
+			}
+		}
+		return false
+	}, 3*time.Minute, 5*time.Second, "marker line never appeared in job logs")
+
+	// The job echoes the marker through an environment variable it was
+	// configured with, so the line proves the environment arrived too.
+	var marker string
+	for _, ll := range lines {
+		if strings.Contains(ll.Message, trainLogMarker) {
+			marker = ll.Message
+		}
+	}
+	require.Contains(t, marker, trainEnvVarValue+" "+trainLogMarker)
+
+	t.Run("Limit", func(t *testing.T) {
+		limited, err := collect("--limit", "1")
+		require.NoError(t, err)
+		require.Len(t, limited, 1)
+	})
+}
+
+func (tr *trainLifecycle) Checkpoints(t *testing.T) {
+	type checkpoint struct {
+		CheckpointID   string  `json:"checkpoint_id"`
+		CheckpointType string  `json:"checkpoint_type"`
+		BaseModel      *string `json:"base_model"`
+		SizeBytes      int     `json:"size_bytes"`
+	}
+
+	// The sync sidecar walks the checkpoint directory every 30 seconds, and the
+	// listing reads S3 directly, so the checkpoint shows up within a pass or two
+	// of the job writing it.
+	var found checkpoint
+	require.Eventually(t, func() bool {
+		out, _, err := cli(t, "train", "checkpoint", "list", "--job-id", tr.jobID, "--output", "json")
+		if err != nil {
+			return false
+		}
+		var resp struct {
+			Checkpoints []checkpoint `json:"checkpoints"`
+		}
+		if err := json.Unmarshal([]byte(out), &resp); err != nil {
+			return false
+		}
+		for _, cp := range resp.Checkpoints {
+			if cp.CheckpointID == trainCheckpointName {
+				found = cp
+				return true
+			}
+		}
+		return false
+	}, 4*time.Minute, 10*time.Second, "checkpoint %s never appeared", trainCheckpointName)
+
+	// Type and base model are read out of the adapter config the job wrote.
+	require.Equal(t, "lora", strings.ToLower(found.CheckpointType))
+	require.NotNil(t, found.BaseModel)
+	require.Equal(t, trainBaseModel, *found.BaseModel)
+
+	t.Run("Files", func(t *testing.T) {
+		out := mustCLI(t, "train", "checkpoint", "files", "--job-id", tr.jobID, "--output", "json")
+		var files []struct {
+			RelativeFileName string `json:"relative_file_name"`
+			SizeBytes        int    `json:"size_bytes"`
+			URL              string `json:"url"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &files))
+		require.NotEmpty(t, files)
+		var names []string
+		for _, f := range files {
+			names = append(names, f.RelativeFileName)
+			require.NotEmpty(t, f.URL, "%s has no presigned URL", f.RelativeFileName)
+		}
+		require.Contains(t, strings.Join(names, "\n"), trainCheckpointName+"/adapter_config.json")
+	})
+}
+
+// CheckpointDeployDryRun exercises the delegated deploy: truss evaluates the
+// Python config, the CLI's forwarded credential authenticates the GraphQL
+// mutation behind it, and --dry-run means the backend renders the model config
+// without creating a deployment.
+func (tr *trainLifecycle) CheckpointDeployDryRun(t *testing.T) {
+	hfSecret := os.Getenv("BASETEN_E2E_TEST_HF_SECRET_NAME")
+	if hfSecret == "" {
+		hfSecret = "hf_access_token"
+	}
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "deploy_checkpoints.py")
+	require.NoError(t, os.WriteFile(configPath, []byte(fmt.Sprintf(deployCheckpointsConfigTmpl,
+		trainBaseModel, tr.jobID, trainCheckpointName, trainLoRARank,
+		tr.projectName, hfSecret,
+	)), 0o644))
+
+	outDir := filepath.Join(configDir, "generated")
+	mustCLI(t, "train", "checkpoint", "deploy", "--job-id", tr.jobID,
+		"--config", configPath, "--dry-run", "--config-out-dir", outDir)
+
+	// The generated config is what a user edits and re-pushes, so the run is
+	// only useful if it actually landed on disk.
+	entries, err := os.ReadDir(outDir)
+	require.NoError(t, err, "no config written to %s", outDir)
+	require.NotEmpty(t, entries)
+}
+
+func (tr *trainLifecycle) Stop(t *testing.T) {
+	mustCLI(t, "train", "job", "stop", "--job-id", tr.jobID, "--yes")
+
+	// Stopping is asynchronous, so the status settles a moment later.
+	var status string
+	require.Eventually(t, func() bool {
+		status = tr.mustDescribeJob(t).CurrentStatus
+		return status == "TRAINING_JOB_STOPPED"
+	}, 3*time.Minute, 5*time.Second, "job never reported stopped; last status %s", &status)
+}


### PR DESCRIPTION
## :rocket: What

New commands, each delegating to `truss` because their config is a Python file:

- `train push`: run a training job.
- `train init`: scaffold a training project.
- `train checkpoint deploy`: deploy a job's checkpoints via vLLM.
- `train workstation create`: spin up an SSH workstation.
- `loops checkpoint deploy`: deploy a Loops run's checkpoints via vLLM.
- **💥Breaking:** `baseten truss` now runs truss via `uv tool run`, not `PATH`, so uv is required; use `--truss-executable` for an installed truss. It also extracts `--truss-*` flags instead of forwarding args blindly.
- Shared `--truss-version` / `--truss-executable` / `--truss-no-forward-auth` in a `truss` help group. `model image build` / `prepare` share them, gaining `--truss-executable`, dropping their private `--truss-version`.
- Delegated commands emit `{}` under `--output json`; truss reports prose only.

## :computer: How

- Auth forwards over `BASETEN_TRUSS_AUTH_REMOTE_URL` / `BASETEN_TRUSS_AUTH_API_KEY`, never disk. Either preset is a usage error. `train init` forwards nothing.
- Forwarded as a Bearer token so it works for API keys and OAuth tokens; `auth.Transport.Do` now sends `Bearer` where it sent `Api-Key`.
- `--tail` is not forwarded: the child can't refresh an access token. Use `train job logs --tail`.
- `train checkpoint deploy` requires `--job-id` unless `--config` names checkpoints, else truss picks the newest job in any reachable project.

## :microscope: Testing

- Unit tests cover arg mapping via a fake execer.
- New `TestE2ETrainLifecycle`: CPU-only training job against a real workspace, covering `train push` and `train checkpoint deploy --dry-run`. 54s; CI gained a uv step.
- Flags checked against truss 0.18.26 help. `train workstation create` (GPUs) and `loops checkpoint deploy` (SDK-made checkpoint) untested live.