### PR TITLE
Add model-api usage command

### DIFF
--- a/cmd/command.model_api.go
+++ b/cmd/command.model_api.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "github.com/basetenlabs/baseten-go/client/managementapi"
+import (
+	"time"
+
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+)
 
 var commandModelAPI = Command{
 	Name:    "model-api",
@@ -89,6 +93,48 @@ var commandModelAPI = Command{
 				},
 			},
 		},
+		{
+			Name:    "usage",
+			Summary: "Show Model APIs token usage in time buckets",
+			Description: "Show the workspace's Model APIs token usage as contiguous time buckets, " +
+				"oldest first, broken down by the dimensions passed to --group-by.\n\n" +
+				"Buckets with no usage are included, so the series has no gaps. Usage is retained " +
+				"for 92 days; buckets older than that come back empty. Every bucket in the window " +
+				"is fetched, paging as needed, until --limit buckets are collected.\n\n" +
+				"Usage is attributed to a user when the request was authenticated with a personal " +
+				"API key or an OAuth credential. Usage from workspace or other non-user-scoped " +
+				"credentials has no user.\n\n" +
+				"For machine-readable streaming, prefer --output jsonl over --output json.",
+			Flags: ModelAPIUsageFlags{},
+			Output: &CommandOutput[managementapi.ModelApisUsageBucket]{
+				JSONArrayStreamed: true,
+				TextDescription: "Table with a time column, one column per --group-by dimension, " +
+					"then REQUESTS, INPUT, CACHED, and OUTPUT token counts, followed by an ALL " +
+					"totals row. A bucket with no usage renders as a single \"(no usage)\" row. " +
+					"When no bucket in the window has any usage, prints \"No usage in the selected " +
+					"window.\" to stderr instead of a table.",
+				JSONDescription: "One record per time bucket: its start_time, end_time, and the " +
+					"per-dimension usage totals in results.",
+				Examples: []CommandExample{
+					{
+						Description: "Show daily usage per model over the last 7 days.",
+						Command:     "baseten model-api usage",
+					},
+					{
+						Description: "Show which users drove usage over the last 3 days.",
+						Command:     "baseten model-api usage --since 3d --group-by user",
+					},
+					{
+						Description: "Break hourly usage down by user and model for one model.",
+						Command:     "baseten model-api usage --since 12h --bucket-width 1h --group-by user --group-by model --model <name>",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Stream each bucket's per-user output tokens as a JSONL stream.",
+					Command:     "baseten model-api usage --group-by user --output jsonl --jq '.results[] | {user_id, output_tokens}'",
+				},
+			},
+		},
 	},
 }
 
@@ -110,6 +156,29 @@ type ModelAPIListFlags struct {
 	CommandFlags
 
 	AddedOnly bool `flag:"added-only" desc:"Restrict to the Model APIs the workspace has added instead of the full visible catalog."`
+}
+
+// ModelAPIUsageFlags configures `baseten model-api usage`.
+type ModelAPIUsageFlags struct {
+	CommandFlags
+
+	Start time.Time     `flag:"start" desc:"Start of the range, inclusive, snapped down to its bucket start. ISO 8601, local when no timezone is given."`
+	End   time.Time     `flag:"end" desc:"End of the range, exclusive. ISO 8601, local when no timezone is given. Defaults to now."`
+	Since time.Duration `flag:"since" desc:"Window from a relative time ago until now (e.g. '30m', '3d'). Mutually exclusive with --start and --end."`
+
+	BucketWidth string   `flag:"bucket-width" desc:"Width of each time bucket. Also sets the default window: 7d for 1d, 24h for 1h, 60m for 1m." enum:"1m,1h,1d" default:"1d"`
+	GroupBy     []string `flag:"group-by" desc:"Dimension to break usage down by. May be repeated. One of: api-key, user, model. Defaults to model."`
+
+	APIKeyPrefixes []string `flag:"api-key-prefix" desc:"Only return usage for these API key prefixes. May be repeated."`
+	UserIDs        []string `flag:"user-id" desc:"Only return usage attributed to these user IDs. May be repeated."`
+	Models         []string `flag:"model" desc:"Only return usage for these models. May be repeated."`
+
+	Limit int `flag:"limit" desc:"Maximum number of time buckets, paging as needed. Rows per bucket depend on --group-by. 0 for no limit."`
+
+	// PageSize is the per-request fetch size while paging. Hidden; exists so
+	// tests can force multiple pages without a full page of buckets. Zero uses
+	// the backend's maximum for the bucket width.
+	PageSize int `flag:"page-size" hidden:"true" desc:"Time buckets fetched per backend request while paging."`
 }
 
 // ModelAPIPredictFlags configures `baseten model-api predict`.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.2.1-0.20260820160010-227e6f013b03
+	github.com/basetenlabs/baseten-go v0.2.1-0.20260825195822-1079dad30a77
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.2.1-0.20260825195822-1079dad30a77
+	github.com/basetenlabs/baseten-go v0.2.1-0.20260827190416-20e6bdc6146f
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.2.1-0.20260825195822-1079dad30a77 h1:+9v5VqKYDVDgJWvP705pgmcBvJVNop7Nu5S7Vx7mMF8=
-github.com/basetenlabs/baseten-go v0.2.1-0.20260825195822-1079dad30a77/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260827190416-20e6bdc6146f h1:YfvOeUV4O8AZ1Q1/wjTV+j8agQgktkniEsJ/lM1FxS4=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260827190416-20e6bdc6146f/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.2.1-0.20260820160010-227e6f013b03 h1:K/LeIXqHSX55e2VI2v5vnEMnY1hFqjC7F6V/arnkkik=
-github.com/basetenlabs/baseten-go v0.2.1-0.20260820160010-227e6f013b03/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260825195822-1079dad30a77 h1:+9v5VqKYDVDgJWvP705pgmcBvJVNop7Nu5S7Vx7mMF8=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260825195822-1079dad30a77/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/internal/cmd/command.loops.go
+++ b/internal/cmd/command.loops.go
@@ -193,7 +193,9 @@ func commandLoopsRunDescribe(ctx *CommandContext, flags *cmd.LoopsRunDescribeFla
 		ctx.Outputf("Owner:       %s\n", *run.User.Email)
 	}
 	ctx.Outputf("Session:     %s\n", run.SessionId)
-	ctx.Outputf("Deployment:  %s\n", run.DeploymentId)
+	if run.DeploymentId != nil {
+		ctx.Outputf("Deployment:  %s\n", *run.DeploymentId)
+	}
 	ctx.Outputf("Base URL:    %s\n", hyperlink(ctx.Stdout, run.BaseUrl))
 	ctx.Outputf("Created:     %s\n", run.CreatedAt.UTC().Format(time.RFC3339))
 	if run.Sampler != nil {
@@ -275,7 +277,10 @@ func commandLoopsRunLogs(ctx *CommandContext, flags *cmd.LoopsRunLogsFlags) erro
 		return runLogsCommand(ctx, &logFlags, fetchLogs, fetchStatus)
 	}
 
-	deploymentID := run.Run.DeploymentId
+	if run.Run.DeploymentId == nil {
+		return fmt.Errorf("Loops run %s has no deployment yet, so it has no trainer logs", flags.RunID)
+	}
+	deploymentID := *run.Run.DeploymentId
 	fetchLogs := func(q logQuery) (*managementapi.GetLogsResponse, error) {
 		direction := managementapi.SortOrder_desc
 		return cl.API().GetLoopsDeploymentsLogs(ctx, deploymentID,

--- a/internal/cmd/command.model_api_usage.go
+++ b/internal/cmd/command.model_api_usage.go
@@ -1,0 +1,368 @@
+package cmd
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+)
+
+func init() {
+	Register("model-api usage", commandModelAPIUsage)
+}
+
+// modelAPIUsageDimensions are the allowed lowercase-kebab --group-by values,
+// mapped to the snake_case backend enum by swapping '-' for '_'.
+var modelAPIUsageDimensions = []string{"api-key", "user", "model"}
+
+// modelAPIUsageDefaultDimension is pinned client-side so the column set stays
+// stable if the backend changes which dimension it defaults to.
+const modelAPIUsageDefaultDimension = managementapi.UsageDimension_model
+
+func commandModelAPIUsage(ctx *CommandContext, flags *cmd.ModelAPIUsageFlags) error {
+	api, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+
+	width := managementapi.BucketWidth(flags.BucketWidth)
+	bucket, maxPageSize := modelAPIUsageWidth(width)
+	if flags.Limit < 0 {
+		return cmd.NewErrUsagef("--limit must be zero (no limit) or a positive number")
+	}
+	// A page holds at most maxPageSize buckets; asking for more would be clamped
+	// server-side, making a full page look short and ending pagination early.
+	pageSize := flags.PageSize
+	if pageSize == 0 {
+		pageSize = maxPageSize
+	} else if pageSize < 1 || pageSize > maxPageSize {
+		return cmd.NewErrUsagef("--page-size must be between 1 and %d for --bucket-width %s", maxPageSize, width)
+	}
+
+	dims, err := modelAPIUsageGroupBy(flags.GroupBy)
+	if err != nil {
+		return err
+	}
+
+	start, end, err := modelAPIUsageWindow(ctx, flags, bucket)
+	if err != nil {
+		return err
+	}
+
+	params := managementapi.GetV1ModelApisUsageParams{
+		StartTime:   &start,
+		EndTime:     &end,
+		BucketWidth: &width,
+		GroupBy:     &dims,
+	}
+	if len(flags.APIKeyPrefixes) > 0 {
+		params.ApiKeys = &flags.APIKeyPrefixes
+	}
+	if len(flags.UserIDs) > 0 {
+		params.UserIds = &flags.UserIDs
+	}
+	if len(flags.Models) > 0 {
+		params.Models = &flags.Models
+	}
+
+	var jw *JSONArrayWriter
+	if ctx.JSON {
+		jw = ctx.NewJSONArrayWriter()
+		defer jw.Close()
+	}
+
+	table := newModelAPIUsageTable(width, dims)
+	remaining := flags.Limit
+	hitLimit := false
+buckets:
+	for {
+		params.Limit = &pageSize
+		resp, err := api.API().GetModelApisUsage(ctx, params)
+		if err != nil {
+			return fmt.Errorf("getting Model APIs usage: %w", err)
+		}
+		for i := range resp.Items {
+			if ctx.JSON {
+				jw.Write(resp.Items[i])
+			} else {
+				table.addBucket(resp.Items[i])
+			}
+			if remaining > 0 {
+				remaining--
+				if remaining == 0 {
+					// More buckets exist if this page reported another page or
+					// still had unemitted buckets of its own.
+					hitLimit = resp.Pagination.HasMore || i < len(resp.Items)-1
+					break buckets
+				}
+			}
+		}
+		if !resp.Pagination.HasMore || resp.Pagination.Cursor == nil {
+			break
+		}
+		params.Cursor = resp.Pagination.Cursor
+	}
+
+	if ctx.JSON {
+		return nil
+	}
+	// Every bucket in the window can come back empty, which is a table of
+	// nothing but gap markers. Say it instead of drawing it.
+	if table.dataRows == 0 {
+		ctx.LogLine("No usage in the selected window.")
+		return nil
+	}
+	ctx.LogLine(table.windowLine())
+	if table.sawNullUser {
+		ctx.LogLine("Rows with no user are usage from workspace or other non-user-scoped " +
+			"credentials, or from before user attribution was recorded.")
+	}
+	headers, rows, rightAligned := table.render()
+	ctx.OutputTable(TableOutput{Headers: headers, Rows: rows, RightAlignedColumns: rightAligned})
+	if hitLimit {
+		ctx.Logf("Reached the --limit of %d buckets; more exist. Increase --limit or use --limit 0 for no limit.\n", flags.Limit)
+	}
+	return nil
+}
+
+// modelAPIUsageWidth returns the duration of one bucket and the backend's
+// maximum buckets per page for a bucket width.
+func modelAPIUsageWidth(width managementapi.BucketWidth) (bucket time.Duration, maxPageSize int) {
+	switch width {
+	case managementapi.BucketWidth_1m:
+		return time.Minute, 1440
+	case managementapi.BucketWidth_1h:
+		return time.Hour, 168
+	default:
+		return 24 * time.Hour, 31
+	}
+}
+
+// modelAPIUsageGroupBy validates the --group-by values and maps them onto the
+// backend dimension enum, defaulting to a single dimension when unset.
+func modelAPIUsageGroupBy(values []string) ([]managementapi.UsageDimension, error) {
+	if len(values) == 0 {
+		return []managementapi.UsageDimension{modelAPIUsageDefaultDimension}, nil
+	}
+	dims := make([]managementapi.UsageDimension, 0, len(values))
+	for _, v := range values {
+		if !slices.Contains(modelAPIUsageDimensions, v) {
+			return nil, cmd.NewErrUsagef("invalid --group-by %q; must be one of: %s",
+				v, strings.Join(modelAPIUsageDimensions, ", "))
+		}
+		dim := managementapi.UsageDimension(strings.ReplaceAll(v, "-", "_"))
+		if !slices.Contains(dims, dim) {
+			dims = append(dims, dim)
+		}
+	}
+	return dims, nil
+}
+
+// modelAPIUsageWindow resolves the query range from --start/--end/--since. With
+// none of them set the window spans the bucket width's default bucket count,
+// matching what the endpoint returns for a single default page.
+func modelAPIUsageWindow(ctx *CommandContext, flags *cmd.ModelAPIUsageFlags, bucket time.Duration) (start, end time.Time, err error) {
+	hasStart := !flags.Start.IsZero()
+	hasEnd := !flags.End.IsZero()
+	// Use Changed rather than the zero value so an explicit --since 0 fails the
+	// positive-duration check below instead of being silently dropped.
+	hasSince := ctx.Command.Flags().Changed("since")
+	if hasSince && (hasStart || hasEnd) {
+		return start, end, cmd.NewErrUsagef("--since cannot be combined with --start or --end")
+	}
+
+	now := ctx.Now()
+	switch {
+	case hasSince:
+		if flags.Since <= 0 {
+			return start, end, cmd.NewErrUsagef("--since must be a positive duration")
+		}
+		return now.Add(-flags.Since), now, nil
+	case hasStart && hasEnd:
+		if !flags.Start.Before(flags.End) {
+			return start, end, cmd.NewErrUsagef("--start must be earlier than --end")
+		}
+		return flags.Start, flags.End, nil
+	case hasStart:
+		// --end defaults to now, so name that rather than a flag the user never
+		// passed.
+		if !flags.Start.Before(now) {
+			return start, end, cmd.NewErrUsagef("--start must be in the past when --end is omitted")
+		}
+		return flags.Start, now, nil
+	case hasEnd:
+		// start_time is required on the first page, so an --end-only window still
+		// needs a start; span the same default bucket count back from --end.
+		return flags.End.Add(-bucket * time.Duration(modelAPIUsageDefaultBuckets(bucket))), flags.End, nil
+	default:
+		return now.Add(-bucket * time.Duration(modelAPIUsageDefaultBuckets(bucket))), now, nil
+	}
+}
+
+// modelAPIUsageDefaultBuckets is the backend's default bucket count for a
+// bucket width, used to size an unspecified window.
+func modelAPIUsageDefaultBuckets(bucket time.Duration) int {
+	switch bucket {
+	case time.Minute:
+		return 60
+	case time.Hour:
+		return 24
+	default:
+		return 7
+	}
+}
+
+// windowLine summarizes the returned series on stderr. The bounds come from the
+// buckets themselves rather than the requested window, which the backend snaps
+// down to a bucket boundary.
+func (t *modelAPIUsageTable) windowLine() string {
+	names := make([]string, len(t.dims))
+	for i, d := range t.dims {
+		names[i] = string(d)
+	}
+	return fmt.Sprintf("Window: %s through %s UTC · %d buckets of %s · grouped by %s",
+		t.timestamp(t.firstStart), t.timestamp(t.lastStart), t.bucketCount, t.width,
+		strings.Join(names, ", "))
+}
+
+// modelAPIUsageTable accumulates one row per bucket-and-dimension-combination,
+// tracking column totals for the trailing ALL row.
+type modelAPIUsageTable struct {
+	width managementapi.BucketWidth
+	dims  []managementapi.UsageDimension
+	rows  [][]string
+
+	firstStart  time.Time
+	lastStart   time.Time
+	bucketCount int
+	totals      modelAPIUsageTotals
+	dataRows    int
+	sawNullUser bool
+}
+
+type modelAPIUsageTotals struct {
+	requests int64
+	input    int64
+	cached   int64
+	output   int64
+}
+
+func newModelAPIUsageTable(width managementapi.BucketWidth, dims []managementapi.UsageDimension) *modelAPIUsageTable {
+	return &modelAPIUsageTable{width: width, dims: dims}
+}
+
+// addBucket appends this bucket's result rows. An empty bucket still gets a row
+// so gaps in the series stay visible.
+func (t *modelAPIUsageTable) addBucket(b managementapi.ModelApisUsageBucket) {
+	if t.bucketCount == 0 {
+		t.firstStart = b.StartTime
+	}
+	t.lastStart = b.StartTime
+	t.bucketCount++
+
+	stamp := t.timestamp(b.StartTime)
+	if b.Results == nil || len(*b.Results) == 0 {
+		row := make([]string, 1+len(t.dims)+4)
+		row[0] = stamp
+		row[1] = "(no usage)"
+		t.rows = append(t.rows, row)
+		return
+	}
+	for _, r := range *b.Results {
+		row := make([]string, 0, 1+len(t.dims)+4)
+		row = append(row, stamp)
+		for _, d := range t.dims {
+			row = append(row, t.dimensionCell(d, r))
+		}
+		row = append(row,
+			billingGroupDigits(strconv.Itoa(r.RequestCount)),
+			billingGroupDigits(strconv.Itoa(r.InputTokens)),
+			billingGroupDigits(strconv.Itoa(r.CachedInputTokens)),
+			billingGroupDigits(strconv.Itoa(r.OutputTokens)),
+		)
+		t.rows = append(t.rows, row)
+		t.dataRows++
+		t.totals.requests += int64(r.RequestCount)
+		t.totals.input += int64(r.InputTokens)
+		t.totals.cached += int64(r.CachedInputTokens)
+		t.totals.output += int64(r.OutputTokens)
+		// Only the row's own bucket stamp repeats; blank it so a bucket's
+		// several rows read as one group.
+		stamp = ""
+	}
+}
+
+// dimensionCell renders one grouped dimension. An absent value is real data, not
+// a missing field: usage with no user attribution, for instance. The backend
+// reports absence as either null or an empty string depending on the dimension.
+func (t *modelAPIUsageTable) dimensionCell(d managementapi.UsageDimension, r managementapi.ModelApisUsageResult) string {
+	switch d {
+	case managementapi.UsageDimension_api_key:
+		return modelAPIUsageCell(r.ApiKeyPrefix)
+	case managementapi.UsageDimension_user:
+		cell := modelAPIUsageCell(r.UserId)
+		if cell == "-" {
+			t.sawNullUser = true
+		}
+		return cell
+	case managementapi.UsageDimension_model:
+		return modelAPIUsageCell(r.Model)
+	default:
+		return "-"
+	}
+}
+
+func modelAPIUsageCell(v *string) string {
+	if v == nil || *v == "" {
+		return "-"
+	}
+	return *v
+}
+
+// timestamp renders a bucket start, dropping the clock for daily buckets where
+// it is always midnight. Buckets are aligned to UTC, so rendering them in local
+// time would shift a daily bucket onto the wrong calendar date.
+func (t *modelAPIUsageTable) timestamp(start time.Time) string {
+	if t.width == managementapi.BucketWidth_1d {
+		return start.UTC().Format("2006-01-02")
+	}
+	return start.UTC().Format("2006-01-02 15:04")
+}
+
+func (t *modelAPIUsageTable) render() (headers []string, rows [][]string, rightAligned []int) {
+	timeHeader := "TIME"
+	if t.width == managementapi.BucketWidth_1d {
+		timeHeader = "DATE"
+	}
+	headers = append(headers, timeHeader)
+	for _, d := range t.dims {
+		headers = append(headers, strings.ToUpper(strings.ReplaceAll(string(d), "_", " ")))
+	}
+	headers = append(headers, "REQUESTS", "INPUT", "CACHED", "OUTPUT")
+	for col := 1 + len(t.dims); col < len(headers); col++ {
+		rightAligned = append(rightAligned, col)
+	}
+
+	rows = t.rows
+	// A totals row only earns its keep once there is more than one data row to
+	// total; with a single row it would just repeat it.
+	if t.dataRows > 1 {
+		total := make([]string, 0, len(headers))
+		total = append(total, "ALL")
+		for range t.dims {
+			total = append(total, "")
+		}
+		total = append(total,
+			billingGroupDigits(strconv.FormatInt(t.totals.requests, 10)),
+			billingGroupDigits(strconv.FormatInt(t.totals.input, 10)),
+			billingGroupDigits(strconv.FormatInt(t.totals.cached, 10)),
+			billingGroupDigits(strconv.FormatInt(t.totals.output, 10)),
+		)
+		rows = append(rows, total)
+	}
+	return headers, rows, rightAligned
+}

--- a/internal/cmd/command.model_api_usage_test.go
+++ b/internal/cmd/command.model_api_usage_test.go
@@ -1,0 +1,602 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/internal/cmd"
+)
+
+// modelAPIUsageBucket builds one time bucket. Results are passed pre-shaped so a
+// test can express partial dimensions and null attribution directly.
+func modelAPIUsageBucket(start string, results ...map[string]any) map[string]any {
+	startTime, err := time.Parse(time.RFC3339, start)
+	if err != nil {
+		panic(err)
+	}
+	items := make([]any, 0, len(results))
+	for _, r := range results {
+		items = append(items, r)
+	}
+	return map[string]any{
+		"start_time": start,
+		"end_time":   startTime.Add(24 * time.Hour).Format(time.RFC3339),
+		"results":    items,
+	}
+}
+
+func modelAPIUsageResult(dims map[string]any, requests, input, cached, output int) map[string]any {
+	r := map[string]any{
+		"request_count":         requests,
+		"input_tokens":          input,
+		"cached_input_tokens":   cached,
+		"uncached_input_tokens": input - cached,
+		"output_tokens":         output,
+	}
+	for k, v := range dims {
+		r[k] = v
+	}
+	return r
+}
+
+// modelAPIUsageCell returns whitespace-separated field col of the first output
+// line containing marker, for asserting on one column rather than the whole row
+// (a bare "-" would otherwise match the dashes in a date).
+func modelAPIUsageCell(h *CommandHarness, out, marker string, col int) string {
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.Contains(line, marker) {
+			continue
+		}
+		fields := strings.Fields(line)
+		h.Require.Greater(len(fields), col, "line %q has no field %d", line, col)
+		return fields[col]
+	}
+	h.Require.Fail("no output line contains " + marker)
+	return ""
+}
+
+func modelAPIUsageBody(buckets ...map[string]any) map[string]any {
+	items := make([]any, 0, len(buckets))
+	for _, b := range buckets {
+		items = append(items, b)
+	}
+	return map[string]any{
+		"items":      items,
+		"pagination": map[string]any{"has_more": false},
+	}
+}
+
+// modelAPIUsageTwoDays is a representative series: one bucket with two models,
+// one empty bucket, and one bucket with a single model.
+func modelAPIUsageTwoDays() map[string]any {
+	return modelAPIUsageBody(
+		modelAPIUsageBucket("2026-08-20T00:00:00Z",
+			modelAPIUsageResult(map[string]any{"model": "llama-3"}, 12, 3400, 1200, 890),
+			modelAPIUsageResult(map[string]any{"model": "kimi-k2"}, 3, 1200, 0, 45),
+		),
+		modelAPIUsageBucket("2026-08-21T00:00:00Z"),
+		modelAPIUsageBucket("2026-08-22T00:00:00Z",
+			modelAPIUsageResult(map[string]any{"model": "llama-3"}, 1, 100, 0, 10),
+		),
+	)
+}
+
+func Test_ModelApi_Usage_Table(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "DATE")
+	h.Require.Contains(out, "MODEL")
+	h.Require.Contains(out, "REQUESTS")
+	h.Require.Contains(out, "INPUT")
+	h.Require.Contains(out, "CACHED")
+	h.Require.Contains(out, "OUTPUT")
+	h.Require.Contains(out, "2026-08-20")
+	h.Require.Contains(out, "llama-3")
+	h.Require.Contains(out, "kimi-k2")
+	// Token counts carry thousands separators.
+	h.Require.Contains(out, "3,400")
+	h.Require.Contains(out, "1,200")
+	// The window summary goes to stderr so it stays out of the piped table.
+	h.Require.Contains(h.Stderr.String(), "grouped by model")
+	h.Require.NotContains(out, "grouped by model")
+}
+
+func Test_ModelApi_Usage_RepeatedBucketStampBlanked(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage"))
+	lines := strings.Split(strings.TrimSpace(h.Stdout.String()), "\n")
+	// A bucket's second row omits the date so the bucket reads as one group.
+	var llama, kimi string
+	for _, l := range lines {
+		if strings.Contains(l, "llama-3") && strings.Contains(l, "3,400") {
+			llama = l
+		}
+		if strings.Contains(l, "kimi-k2") {
+			kimi = l
+		}
+	}
+	h.Require.Contains(llama, "2026-08-20")
+	h.Require.NotContains(kimi, "2026-08-20")
+}
+
+func Test_ModelApi_Usage_GapMarkerForEmptyBucket(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage"))
+	out := h.Stdout.String()
+	// The empty middle bucket stays visible so the series reads as gapless.
+	h.Require.Contains(out, "2026-08-21")
+	h.Require.Contains(out, "(no usage)")
+}
+
+func Test_ModelApi_Usage_TotalsRow(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage"))
+	lines := strings.Split(strings.TrimSpace(h.Stdout.String()), "\n")
+	total := lines[len(lines)-1]
+	h.Require.Contains(total, "ALL")
+	// 12 + 3 + 1 requests, 3400 + 1200 + 100 input, 1200 cached, 890 + 45 + 10 output.
+	h.Require.Contains(total, "16")
+	h.Require.Contains(total, "4,700")
+	h.Require.Contains(total, "1,200")
+	h.Require.Contains(total, "945")
+}
+
+func Test_ModelApi_Usage_SingleRowHasNoTotalsRow(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageBody(
+		modelAPIUsageBucket("2026-08-22T00:00:00Z",
+			modelAPIUsageResult(map[string]any{"model": "llama-3"}, 1, 100, 0, 10),
+		),
+	))
+
+	h.Require.NoError(h.Execute("model-api", "usage"))
+	// A totals row over one data row would just repeat it.
+	h.Require.NotContains(h.Stdout.String(), "ALL")
+}
+
+func Test_ModelApi_Usage_NoUsageInWindow(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageBody(
+		modelAPIUsageBucket("2026-08-20T00:00:00Z"),
+		modelAPIUsageBucket("2026-08-21T00:00:00Z"),
+	))
+
+	h.Require.NoError(h.Execute("model-api", "usage"))
+	// Buckets came back, but all empty: say so rather than draw a table of gaps.
+	h.Require.Equal("", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "No usage in the selected window.")
+}
+
+func Test_ModelApi_Usage_NoBuckets(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageBody())
+
+	h.Require.NoError(h.Execute("model-api", "usage"))
+	h.Require.Equal("", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "No usage in the selected window.")
+}
+
+func Test_ModelApi_Usage_BucketsRenderInUTC(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageBody(
+		modelAPIUsageBucket("2026-08-20T00:00:00Z",
+			modelAPIUsageResult(map[string]any{"model": "llama-3"}, 1, 100, 0, 10),
+		),
+	))
+	// Buckets are UTC-aligned. Pin a local zone behind UTC so local rendering
+	// would visibly shift the daily bucket onto the previous calendar date.
+	// TZ alone would not do it: time.Local is resolved once per process.
+	local := time.Local
+	time.Local = time.FixedZone("test-behind-utc", -8*60*60)
+	t.Cleanup(func() { time.Local = local })
+
+	h.Require.NoError(h.Execute("model-api", "usage"))
+	h.Require.Contains(h.Stdout.String(), "2026-08-20")
+	h.Require.NotContains(h.Stdout.String(), "2026-08-19")
+	h.Require.Contains(h.Stderr.String(), "UTC")
+}
+
+func Test_ModelApi_Usage_HourlyTimeColumn(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageBody(
+		modelAPIUsageBucket("2026-08-20T13:00:00Z",
+			modelAPIUsageResult(map[string]any{"model": "llama-3"}, 1, 100, 0, 10),
+		),
+	))
+
+	h.Require.NoError(h.Execute("model-api", "usage", "--bucket-width", "1h"))
+	out := h.Stdout.String()
+	// Sub-daily buckets need the clock, and the column is headed TIME not DATE.
+	h.Require.Contains(out, "TIME")
+	h.Require.NotContains(out, "DATE")
+	h.Require.Contains(out, "2026-08-20 13:00")
+}
+
+func Test_ModelApi_Usage_DefaultsToGroupByModel(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage"))
+
+	call := m.FindCall("GET", "/v1/model_apis/usage")
+	h.Require.NotNil(call)
+	// Pinned client-side so the column set does not move if the backend changes
+	// which dimension it defaults to.
+	h.Require.Equal([]string{"model"}, call.Query()["group_by"])
+}
+
+func Test_ModelApi_Usage_GroupByKebabMapsToWireValues(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage",
+		"--group-by", "api-key", "--group-by", "user", "--group-by", "model"))
+
+	call := m.FindCall("GET", "/v1/model_apis/usage")
+	h.Require.NotNil(call)
+	h.Require.Equal([]string{"api_key", "user", "model"}, call.Query()["group_by"])
+	// Column headers follow the requested dimensions, in order.
+	out := h.Stdout.String()
+	h.Require.Contains(out, "API KEY")
+	h.Require.Contains(out, "USER")
+	h.Require.Contains(out, "MODEL")
+}
+
+func Test_ModelApi_Usage_GroupByDeduplicates(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage", "--group-by", "user", "--group-by", "user"))
+
+	call := m.FindCall("GET", "/v1/model_apis/usage")
+	h.Require.NotNil(call)
+	// A repeated dimension would otherwise duplicate the column.
+	h.Require.Equal([]string{"user"}, call.Query()["group_by"])
+}
+
+func Test_ModelApi_Usage_InvalidGroupBy(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetHandlerFallback(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("server should not be hit on validation error")
+	})
+
+	err := h.Execute("model-api", "usage", "--group-by", "service-tier")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), `invalid --group-by "service-tier"`)
+	h.Require.Contains(err.Error(), "api-key, user, model")
+}
+
+func Test_ModelApi_Usage_NullUserRendersAndIsExplained(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageBody(
+		modelAPIUsageBucket("2026-08-20T00:00:00Z",
+			modelAPIUsageResult(map[string]any{"user_id": nil}, 2, 200, 0, 20),
+			modelAPIUsageResult(map[string]any{"user_id": "usr_1"}, 5, 500, 0, 50),
+		),
+	))
+
+	h.Require.NoError(h.Execute("model-api", "usage", "--group-by", "user"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "usr_1")
+	// Unattributed usage is real data, so it gets a row of its own with the user
+	// column marked absent, plus an explanation on stderr.
+	h.Require.Equal("-", modelAPIUsageCell(h, out, "200", 1))
+	h.Require.Contains(h.Stderr.String(), "Rows with no user")
+}
+
+func Test_ModelApi_Usage_EmptyAPIKeyPrefixRendersAsAbsent(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageBody(
+		modelAPIUsageBucket("2026-08-20T00:00:00Z",
+			// Non-API-key credentials report an empty prefix rather than null.
+			modelAPIUsageResult(map[string]any{"api_key_prefix": ""}, 3, 300, 0, 30),
+		),
+	))
+
+	h.Require.NoError(h.Execute("model-api", "usage", "--group-by", "api-key"))
+	h.Require.Equal("-", modelAPIUsageCell(h, h.Stdout.String(), "300", 1))
+}
+
+func Test_ModelApi_Usage_NoUserExplanationOnlyWhenGrouped(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage"))
+	// Grouping by model alone never surfaces a user, so the note would be noise.
+	h.Require.NotContains(h.Stderr.String(), "Rows with no user")
+}
+
+func Test_ModelApi_Usage_Filters(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage",
+		"--api-key-prefix", "bsnt_abc",
+		"--api-key-prefix", "bsnt_def",
+		"--user-id", "usr_1",
+		"--model", "llama-3",
+	))
+
+	call := m.FindCall("GET", "/v1/model_apis/usage")
+	h.Require.NotNil(call)
+	q := call.Query()
+	h.Require.Equal([]string{"bsnt_abc", "bsnt_def"}, q["api_keys"])
+	h.Require.Equal([]string{"usr_1"}, q["user_ids"])
+	h.Require.Equal([]string{"llama-3"}, q["models"])
+}
+
+func Test_ModelApi_Usage_DefaultWindowPerBucketWidth(t *testing.T) {
+	now := time.Date(2026, 8, 25, 12, 30, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		width string
+		back  time.Duration
+	}{
+		{"1d", 7 * 24 * time.Hour},
+		{"1h", 24 * time.Hour},
+		{"1m", 60 * time.Minute},
+	} {
+		t.Run(tc.width, func(t *testing.T) {
+			h := NewCommandHarness(t)
+			m := h.MockManagementAPI()
+			m.SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+			h.Context = cmd.WithNow(h.Context, func() time.Time { return now })
+
+			h.Require.NoError(h.Execute("model-api", "usage", "--bucket-width", tc.width))
+
+			call := m.FindCall("GET", "/v1/model_apis/usage")
+			h.Require.NotNil(call)
+			q := call.Query()
+			// start_time is required on the first page, so an unspecified window
+			// spans the backend's default bucket count for the width.
+			h.Require.Equal(now.Add(-tc.back).Format(time.RFC3339), q.Get("start_time"))
+			h.Require.Equal(now.Format(time.RFC3339), q.Get("end_time"))
+			h.Require.Equal(tc.width, q.Get("bucket_width"))
+		})
+	}
+}
+
+func Test_ModelApi_Usage_SinceWindow(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+	now := time.Date(2026, 8, 25, 12, 30, 0, 0, time.UTC)
+	h.Context = cmd.WithNow(h.Context, func() time.Time { return now })
+
+	h.Require.NoError(h.Execute("model-api", "usage", "--since", "3h"))
+
+	call := m.FindCall("GET", "/v1/model_apis/usage")
+	h.Require.NotNil(call)
+	h.Require.Equal(now.Add(-3*time.Hour).Format(time.RFC3339), call.Query().Get("start_time"))
+	h.Require.Equal(now.Format(time.RFC3339), call.Query().Get("end_time"))
+}
+
+func Test_ModelApi_Usage_StartAndEndWindow(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage",
+		"--start", "2026-08-01T00:00:00Z", "--end", "2026-08-05T00:00:00Z"))
+
+	call := m.FindCall("GET", "/v1/model_apis/usage")
+	h.Require.NotNil(call)
+	h.Require.Equal("2026-08-01T00:00:00Z", call.Query().Get("start_time"))
+	h.Require.Equal("2026-08-05T00:00:00Z", call.Query().Get("end_time"))
+}
+
+func Test_ModelApi_Usage_EndOnlyWindowGetsDefaultSpan(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage", "--end", "2026-08-20T00:00:00Z"))
+
+	call := m.FindCall("GET", "/v1/model_apis/usage")
+	h.Require.NotNil(call)
+	// start_time is required, so --end alone still spans the default count back.
+	h.Require.Equal("2026-08-13T00:00:00Z", call.Query().Get("start_time"))
+	h.Require.Equal("2026-08-20T00:00:00Z", call.Query().Get("end_time"))
+}
+
+func Test_ModelApi_Usage_SinceWithStartIsError(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetHandlerFallback(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("server should not be hit on validation error")
+	})
+
+	err := h.Execute("model-api", "usage", "--since", "1h", "--start", "2026-08-01")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "--since cannot be combined with --start or --end")
+}
+
+func Test_ModelApi_Usage_ZeroSinceIsError(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetHandlerFallback(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("server should not be hit on validation error")
+	})
+
+	err := h.Execute("model-api", "usage", "--since", "0")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "--since must be a positive duration")
+}
+
+func Test_ModelApi_Usage_StartNotBeforeEndIsError(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetHandlerFallback(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("server should not be hit on validation error")
+	})
+
+	err := h.Execute("model-api", "usage",
+		"--start", "2026-08-05T00:00:00Z", "--end", "2026-08-01T00:00:00Z")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "--start must be earlier than --end")
+}
+
+func Test_ModelApi_Usage_FutureStartWithoutEndIsError(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetHandlerFallback(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("server should not be hit on validation error")
+	})
+	now := time.Date(2026, 8, 25, 12, 30, 0, 0, time.UTC)
+	h.Context = cmd.WithNow(h.Context, func() time.Time { return now })
+
+	err := h.Execute("model-api", "usage", "--start", "2026-09-01T00:00:00Z")
+	h.Require.Error(err)
+	// --end defaulted to now, so the message must not blame a flag the user
+	// never passed.
+	h.Require.Contains(err.Error(), "--start must be in the past when --end is omitted")
+}
+
+func Test_ModelApi_Usage_NegativeLimitIsError(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetHandlerFallback(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("server should not be hit on validation error")
+	})
+
+	err := h.Execute("model-api", "usage", "--limit", "-1")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "--limit must be zero (no limit) or a positive number")
+}
+
+func Test_ModelApi_Usage_PageSizeDefaultsToWidthMaximum(t *testing.T) {
+	for _, tc := range []struct{ width, limit string }{
+		{"1d", "31"},
+		{"1h", "168"},
+		{"1m", "1440"},
+	} {
+		t.Run(tc.width, func(t *testing.T) {
+			h := NewCommandHarness(t)
+			m := h.MockManagementAPI()
+			m.SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+			h.Require.NoError(h.Execute("model-api", "usage", "--bucket-width", tc.width))
+
+			call := m.FindCall("GET", "/v1/model_apis/usage")
+			h.Require.NotNil(call)
+			h.Require.Equal(tc.limit, call.Query().Get("limit"))
+		})
+	}
+}
+
+func Test_ModelApi_Usage_PageSizeAboveWidthMaximumIsError(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetHandlerFallback(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("server should not be hit on validation error")
+	})
+
+	// Above the width's maximum the backend would clamp, making a full page look
+	// short and ending pagination a page early.
+	err := h.Execute("model-api", "usage", "--bucket-width", "1d", "--page-size", "32")
+	h.Require.Error(err)
+	h.Require.Contains(err.Error(), "--page-size must be between 1 and 31")
+}
+
+func Test_ModelApi_Usage_PaginatesAllPages(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	// One bucket per page; the second page is reached only by following the
+	// cursor, so seeing both models proves the pager advanced.
+	m.SetRouteFunc("GET", "/v1/model_apis/usage", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []any{modelAPIUsageBucket("2026-08-20T00:00:00Z",
+					modelAPIUsageResult(map[string]any{"model": "llama-3"}, 1, 100, 0, 10))},
+				"pagination": map[string]any{"has_more": true, "cursor": "next-1"},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []any{modelAPIUsageBucket("2026-08-21T00:00:00Z",
+				modelAPIUsageResult(map[string]any{"model": "kimi-k2"}, 2, 200, 0, 20))},
+			"pagination": map[string]any{"has_more": false},
+		})
+	})
+
+	h.Require.NoError(h.Execute("model-api", "usage", "--page-size", "1"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "llama-3")
+	h.Require.Contains(out, "kimi-k2")
+
+	calls := m.Calls()
+	h.Require.Equal(2, len(calls))
+	h.Require.Equal("next-1", calls[1].Query().Get("cursor"))
+}
+
+func Test_ModelApi_Usage_LimitCapsBuckets(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage", "--limit", "1"))
+	out := h.Stdout.String()
+	// The first bucket's rows survive; later buckets are cut.
+	h.Require.Contains(out, "2026-08-20")
+	h.Require.NotContains(out, "2026-08-21")
+	h.Require.NotContains(out, "2026-08-22")
+	h.Require.Contains(h.Stderr.String(), "Reached the --limit of 1 buckets")
+}
+
+func Test_ModelApi_Usage_LimitAtExactCountHasNoNote(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage", "--limit", "3"))
+	// Exactly consumed the series, so nothing was cut off.
+	h.Require.NotContains(h.Stderr.String(), "Reached the --limit")
+}
+
+func Test_ModelApi_Usage_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage", "--output", "json"))
+	out := strings.TrimSpace(h.Stdout.String())
+	h.Require.True(strings.HasPrefix(out, "["), "JSON output should be an array")
+	h.Require.Contains(out, `"start_time"`)
+	h.Require.Contains(out, `"llama-3"`)
+	// The full result is passed through, including the field the table derives.
+	h.Require.Contains(out, `"uncached_input_tokens"`)
+}
+
+func Test_ModelApi_Usage_JSONL(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageTwoDays())
+
+	h.Require.NoError(h.Execute("model-api", "usage", "--output", "jsonl"))
+	lines := strings.Split(strings.TrimSpace(h.Stdout.String()), "\n")
+	// One record per bucket, including the empty one.
+	h.Require.Equal(3, len(lines))
+	for _, l := range lines {
+		var bucket map[string]any
+		h.Require.NoError(json.Unmarshal([]byte(l), &bucket))
+		h.Require.Contains(bucket, "start_time")
+	}
+}
+
+func Test_ModelApi_Usage_JSONEmptyIsEmptyArray(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/usage", 200, modelAPIUsageBody())
+
+	h.Require.NoError(h.Execute("model-api", "usage", "--output", "json"))
+	h.Require.Equal("[]", strings.TrimSpace(h.Stdout.String()))
+	// The text-mode notice would corrupt a JSON consumer's stream.
+	h.Require.NotContains(h.Stderr.String(), "No usage in the selected window.")
+}


### PR DESCRIPTION
## :rocket: What

- Add `baseten model-api usage`: Model APIs token usage in time buckets, grouped by api-key, user, and/or model.

Example:

```
$ baseten model-api usage --since 3d --group-by user --group-by model
Window: 2026-08-22 through 2026-08-24 UTC · 3 buckets of 1d · grouped by user, model
Rows with no user are usage from workspace or other non-user-scoped credentials, or from before user attribution was recorded.
DATE        USER        MODEL                               REQUESTS      INPUT     CACHED   OUTPUT
2026-08-22  abcdefg     deepseek-ai/DeepSeek-V4-Flash-0731     1,204    842,113    201,004  119,882
            abcdefg     moonshotai/Kimi-K3                       318    221,540     60,220   41,003
            hijklmn     deepseek-ai/DeepSeek-V4-Flash-0731        77     54,900          0   12,441
            -           zai-org/GLM-5.2                        4,102  2,914,338    880,112  512,907
2026-08-23  (no usage)
2026-08-24  abcdefg     deepseek-ai/DeepSeek-V4-Flash-0731       988    702,455    180,332   98,120
            hijklmn     moonshotai/Kimi-K3                        61     40,118      9,004    8,877
ALL                                                            6,750  4,775,464  1,330,672  793,230
```

## :computer: How

- Auto-pages the cursor endpoint; `--limit` caps time buckets, `--page-size` defaults to the bucket width's server maximum.
- `--group-by` defaults to `model` client-side so the column set does not move if the server default changes.
- Buckets render in UTC (they are UTC-aligned), with a totals row, gap markers, and a note for unattributed usage.
- Bumps baseten-go, which made `LoopsRun.deployment_id` optional.

## :microscope: Testing

- 30 unit tests covering rendering, grouping, filters, window resolution, paging, limits, and JSON/JSONL.
- Verified against the live API: three `model-api predict` calls surfaced correctly grouped by model, user, and api-key.