### PR TITLE
Emit each --tail poll batch oldest-first

### DIFF
--- a/internal/cmd/command.model_deployment_logs.go
+++ b/internal/cmd/command.model_deployment_logs.go
@@ -529,11 +529,17 @@ func tailLogs(ctx *CommandContext, opts tailLogsOptions) *TailDeploymentLogsResu
 					delete(seen, k)
 				}
 			}
+			// Every log fetcher requests direction=desc, so a poll batch
+			// arrives newest-first while batches themselves arrive
+			// chronologically. Walk each batch backward so a followed stream
+			// is ascending throughout rather than descending within a batch
+			// and ascending across them.
+			//
 			// Poll windows overlap by deploymentLogClockSkewBuffer on each
 			// side to tolerate server/client clock skew, so the same record
 			// can reappear across polls; dedup by (timestamp, message,
 			// replica).
-			for i := range resp.Logs {
+			for i := len(resp.Logs) - 1; i >= 0; i-- {
 				log := resp.Logs[i]
 				key := logDedupKey(log)
 				if _, dup := seen[key]; dup {

--- a/internal/cmd/command.model_deployment_logs_test.go
+++ b/internal/cmd/command.model_deployment_logs_test.go
@@ -572,6 +572,44 @@ func Test_Model_Deployment_Logs_TailDedupesAcrossPolls(t *testing.T) {
 	h.Require.Contains(h.Stdout.String(), "next")
 }
 
+func Test_Model_Deployment_Logs_TailEmitsOldestFirstAcrossPolls(t *testing.T) {
+	h := NewCommandHarness(t)
+	api := h.MockManagementAPI()
+	line := func(ts int) map[string]any {
+		return map[string]any{"timestamp": strconv.Itoa(ts), "message": fmt.Sprintf("log-%d", ts), "replica": nil}
+	}
+	logsCalls := 0
+	api.SetRouteFunc("GET", logsLogsPath, func(w http.ResponseWriter, _ *http.Request) {
+		logsCalls++
+		// Both polls answer newest-first, as direction=desc requires. The
+		// second re-fetches log-3 from the overlapping skew window.
+		payload := logsResponse(line(3), line(2), line(1))
+		if logsCalls > 1 {
+			payload = logsResponse(line(5), line(4), line(3))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	})
+	depCalls := 0
+	api.SetRouteFunc("GET", logsDeployPath, func(w http.ResponseWriter, _ *http.Request) {
+		depCalls++
+		status := "ACTIVE"
+		if depCalls > 1 {
+			status = "BUILD_FAILED"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(logsDeployment(status))
+	})
+
+	h.Context = cmd.WithSleep(h.Context, func(_ context.Context, _ time.Duration) error { return nil })
+	err := h.Execute("model", "deployment", "logs",
+		"--model-id", "m", "--deployment-id", "d", "--tail", "--output", "jsonl")
+	h.Require.NoError(err)
+	// Ascending within each batch and across the poll boundary, with the
+	// re-fetched log-3 deduped rather than replayed out of order.
+	h.Require.Equal([]string{"log-1", "log-2", "log-3", "log-4", "log-5"}, jsonlMessages(t, h.Stdout.String()))
+}
+
 func Test_Model_Deployment_Logs_TailJSONLStreaming(t *testing.T) {
 	h := NewCommandHarness(t)
 	api := h.MockManagementAPI()


### PR DESCRIPTION
## :rocket: What

- Fixes #56: `--tail` emitted each poll batch newest-first, so a followed stream was descending within a batch and ascending across batches.
- Affects all six `--tail` paths sharing `tailLogs`: `model deployment logs`, `model environment logs`, `loops run logs`, `train job logs`, `model push`, `model watch`.

## :computer: How

- Walk each poll's `resp.Logs` backward in `tailLogs`, since every log fetcher requests `direction=desc`.
- Non-tail output is untouched and stays newest-first.

## :microscope: Testing

- New `Test_Model_Deployment_Logs_TailEmitsOldestFirstAcrossPolls`: two newest-first polls with an overlapping line, asserting ascending order throughout and the re-fetched line deduped.
- Verified the test reproduces the reported `log-3, log-2, log-1, log-5, log-4` ordering without the fix.