### PR TITLE
Don't treat /dev/null stdin as a terminal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/zeebo/blake3 v0.2.4
 	golang.org/x/crypto v0.53.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/internal/cmd/command.auth_test.go
+++ b/internal/cmd/command.auth_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/basetenlabs/baseten-cli/internal/auth"
@@ -283,6 +284,36 @@ func Test_Auth_Login_APIKey_NoSwitchKeepsCurrent(t *testing.T) {
 	name, _, ok := configDirStore(t).CurrentProfile()
 	h.Require.True(ok)
 	h.Require.Equal("existing", name, "--no-switch must not move the current pointer")
+}
+
+// devNullStdin points the harness at /dev/null, as cron and CI do. It is a
+// character device without being a terminal, so it must take the
+// non-interactive branch rather than trying to prompt.
+func devNullStdin(t *testing.T, h *CommandHarness) {
+	f, err := os.Open(os.DevNull)
+	h.Require.NoError(err)
+	t.Cleanup(func() { _ = f.Close() })
+	h.StdinReader = f
+}
+
+func Test_Auth_Login_DevNullStdinRequiresMethodFlag(t *testing.T) {
+	h := newAuthHarness(t)
+	pointManagementAt(t, "http://127.0.0.1:1")
+	devNullStdin(t, h)
+
+	err := h.Execute("auth", "login")
+	h.Require.ErrorContains(err, "must specify --web or --with-api-key when not interactive")
+}
+
+func Test_Auth_Login_APIKey_DevNullStdinEmptyFails(t *testing.T) {
+	h := newAuthHarness(t)
+	pointManagementAt(t, "http://127.0.0.1:1")
+	devNullStdin(t, h)
+
+	// Reads stdin, hits EOF immediately, and reports the empty key rather
+	// than prompting.
+	err := h.Execute("auth", "login", "--with-api-key", "--profile", "my-laptop")
+	h.Require.ErrorContains(err, "empty")
 }
 
 func Test_Auth_Login_APIKey_EmptyFails(t *testing.T) {

--- a/internal/cmd/command.loops_test.go
+++ b/internal/cmd/command.loops_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -369,6 +370,22 @@ func Test_Loops_Run_Deactivate_NoTTY_RequiresYes(t *testing.T) {
 	m := h.MockManagementAPI()
 
 	err := h.Execute("loops", "run", "deactivate", "--run-id", "r-1")
+	h.Require.ErrorContains(err, "stdin is not a terminal")
+	h.Require.Nil(m.FindCall("POST", "/v1/loops/runs/r-1/deactivate"))
+}
+
+func Test_Loops_Run_Deactivate_DevNullStdinRequiresYes(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	// `... < /dev/null`, as cron and CI run it. /dev/null is a character
+	// device, so this has to reach the --yes guard rather than trying to
+	// prompt and dying on /dev/tty.
+	f, err := os.Open(os.DevNull)
+	h.Require.NoError(err)
+	t.Cleanup(func() { _ = f.Close() })
+	h.StdinReader = f
+
+	err = h.Execute("loops", "run", "deactivate", "--run-id", "r-1")
 	h.Require.ErrorContains(err, "stdin is not a terminal")
 	h.Require.Nil(m.FindCall("POST", "/v1/loops/runs/r-1/deactivate"))
 }

--- a/internal/cmd/command_context.go
+++ b/internal/cmd/command_context.go
@@ -24,6 +24,7 @@ import (
 	"github.com/itchyny/gojq"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2"
+	"golang.org/x/term"
 )
 
 // CommandContext is passed to run functions.
@@ -307,17 +308,16 @@ func panicOnOutputError(_ any, err error) {
 
 const oauthClientID = "baseten-cli"
 
-// IsInteractive returns true if the context's stdin is a terminal.
+// IsInteractive returns true if the context's stdin is a terminal. It asks the
+// terminal driver rather than checking for a character device, because
+// /dev/null is a character device without being a terminal, and redirecting
+// stdin from it is how cron and CI usually run.
 func (c *CommandContext) IsInteractive() bool {
 	f, ok := c.Stdin.(*os.File)
 	if !ok {
 		return false
 	}
-	fi, err := f.Stat()
-	if err != nil {
-		return false
-	}
-	return fi.Mode()&os.ModeCharDevice != 0
+	return term.IsTerminal(int(f.Fd()))
 }
 
 // ConfirmYesNo prompts the user with a yes/no question. Returns an ErrUsage

--- a/internal/cmd/command_test.go
+++ b/internal/cmd/command_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -32,6 +34,10 @@ type CommandHarness struct {
 	Stdout  bytes.Buffer
 	Stderr  bytes.Buffer
 
+	// StdinReader replaces the Stdin buffer when non-nil. Needed to reach the
+	// terminal-detection paths, which only inspect an *os.File.
+	StdinReader io.Reader
+
 	ExitCode int
 	exited   bool
 
@@ -54,9 +60,13 @@ func (h *CommandHarness) Execute(args ...string) error {
 	h.ExitCode = 0
 	h.exited = false
 	cmd.VerifyRunners()
+	var stdin io.Reader = &h.Stdin
+	if h.StdinReader != nil {
+		stdin = h.StdinReader
+	}
 	err := cmd.Execute(h.Context, cmd.ExecuteOptions{
 		Args:   args,
-		Stdin:  &h.Stdin,
+		Stdin:  stdin,
 		Stdout: &h.Stdout,
 		Stderr: &h.Stderr,
 		ExitWithCode: func(code int) {
@@ -262,4 +272,24 @@ func TestOutputEnumValidation(t *testing.T) {
 	h := NewCommandHarness(t)
 	err := h.Execute("api", "management", "--output", "invalid", "some/path")
 	h.Require.ErrorContains(err, "must be one of")
+}
+
+func TestIsInteractiveDevNullIsNotATerminal(t *testing.T) {
+	f, err := os.Open(os.DevNull)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	// /dev/null is a character device but not a terminal, and redirecting
+	// stdin from it is how cron and CI usually run.
+	require.False(t, (&cmd.CommandContext{Stdin: f}).IsInteractive())
+}
+
+func TestIsInteractiveRegularFileIsNotATerminal(t *testing.T) {
+	f, err := os.Create(filepath.Join(t.TempDir(), "stdin"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	require.False(t, (&cmd.CommandContext{Stdin: f}).IsInteractive())
+}
+
+func TestIsInteractiveNonFileIsNotATerminal(t *testing.T) {
+	require.False(t, (&cmd.CommandContext{Stdin: &bytes.Buffer{}}).IsInteractive())
 }


### PR DESCRIPTION
## :rocket: What

- Fixes #55: `/dev/null` is a character device, so `IsInteractive` reported it as a terminal.
- `... < /dev/null` slipped past `--yes` guards and died on `open /dev/tty` in cron/CI instead of printing the usage error. Also affected `auth login`, profile selection, `org secret`, and `model delete`.

## :computer: How

- Ask the terminal driver instead of checking the char-device bit.
- Promote `x/term` from indirect to direct dep; no new module.

## :microscope: Testing

- Three unit tests: `/dev/null`, a regular file, and a non-file stdin are all non-terminals.
- End-to-end `/dev/null` stdin tests for `loops run deactivate` and two `auth login` paths, hitting the usage errors rather than a prompt.
- Needed a `StdinReader` harness override: the harness stdin was a `bytes.Buffer`, so no test could reach the detection code, which is how this shipped green.
- Verified both new tests fail without the fix, the end-to-end one with the issue's exact `huh: could not open a new TTY`. CI covers windows-latest and macos-latest.