### PR TITLE
Set BASETEN_TRUSS_INVOKING_CLI on delegated truss invocations

### DIFF
--- a/internal/cmd/command.loops_test.go
+++ b/internal/cmd/command.loops_test.go
@@ -1001,6 +1001,7 @@ func Test_Loops_Checkpoint_Deploy_ForwardsFlags(t *testing.T) {
 		"--dry-run",
 	}, c.Args)
 	h.Require.Contains(c.Env, "BASETEN_TRUSS_AUTH_API_KEY=test-key")
+	h.Require.Contains(c.Env, "BASETEN_TRUSS_INVOKING_CLI=baseten")
 }
 
 func Test_Loops_Checkpoint_Deploy_CheckpointIDs(t *testing.T) {

--- a/internal/cmd/command.train_test.go
+++ b/internal/cmd/command.train_test.go
@@ -992,6 +992,7 @@ func Test_Train_Push_ForwardsFlags(t *testing.T) {
 		"--interactive", "on_failure",
 		"--interactive-timeout-minutes", "90",
 	}, fake.only(t).Args)
+	h.Require.Contains(fake.only(t).Env, "BASETEN_TRUSS_INVOKING_CLI=baseten")
 }
 
 func Test_Train_Push_RejectsSubMinuteInteractiveTimeout(t *testing.T) {
@@ -1058,6 +1059,7 @@ func Test_Train_Init_ForwardsFlagsWithoutAuth(t *testing.T) {
 	}, c.Args)
 	// Scaffolding calls no API, so no credential is forwarded.
 	h.Require.NotContains(strings.Join(c.Env, " "), "BASETEN_TRUSS_AUTH_")
+	h.Require.Contains(c.Env, "BASETEN_TRUSS_INVOKING_CLI=baseten")
 }
 
 func Test_Train_Init_ListExamples(t *testing.T) {
@@ -1101,4 +1103,5 @@ func Test_Train_WorkstationCreate_ForwardsFlags(t *testing.T) {
 		"--checkpoint-from-job", "job-1",
 	}, c.Args)
 	h.Require.Contains(c.Env, "BASETEN_TRUSS_AUTH_API_KEY=test-key")
+	h.Require.Contains(c.Env, "BASETEN_TRUSS_INVOKING_CLI=baseten")
 }

--- a/internal/cmd/command.truss_test.go
+++ b/internal/cmd/command.truss_test.go
@@ -92,9 +92,21 @@ func Test_Truss_ForwardsArgsAndAuth(t *testing.T) {
 	c := fake.only(t)
 	h.Require.Equal([]string{"uv", "tool", "run", "truss@latest", "push", "--publish", "--help"}, c.Args)
 	h.Require.Contains(c.Env, "TRUSS_NO_UPDATE_CHECK=1")
+	h.Require.Contains(c.Env, "BASETEN_TRUSS_INVOKING_CLI=baseten")
 	// The harness authenticates with BASETEN_API_KEY against BASETEN_REMOTE_URL.
 	h.Require.Contains(c.Env, "BASETEN_TRUSS_AUTH_API_KEY=test-key")
 	h.Require.Contains(c.Env, "BASETEN_TRUSS_AUTH_REMOTE_URL=http://127.0.0.1:1")
+}
+
+func Test_Truss_InvokingCLIOverridesParentEnv(t *testing.T) {
+	h, fake := newTrussHarness(t)
+	h.T.Setenv("BASETEN_TRUSS_INVOKING_CLI", "truss")
+
+	h.Require.NoError(h.Execute("truss", "push"))
+
+	c := fake.only(t)
+	h.Require.Contains(c.Env, "BASETEN_TRUSS_INVOKING_CLI=baseten")
+	h.Require.NotContains(c.Env, "BASETEN_TRUSS_INVOKING_CLI=truss")
 }
 
 func Test_Truss_ExtractsOwnFlagsAnywhere(t *testing.T) {
@@ -107,6 +119,7 @@ func Test_Truss_ExtractsOwnFlagsAnywhere(t *testing.T) {
 	// Our flags are consumed wherever they appear; everything else keeps its order.
 	h.Require.Equal([]string{"uv", "tool", "run", "truss@0.18.26", "push", "./model", "--publish"}, c.Args)
 	h.Require.NotContains(strings.Join(c.Env, " "), "BASETEN_TRUSS_AUTH_")
+	h.Require.Contains(c.Env, "BASETEN_TRUSS_INVOKING_CLI=baseten")
 }
 
 func Test_Truss_ExtractsInlineFlagValue(t *testing.T) {

--- a/internal/cmd/command.truss_test.go
+++ b/internal/cmd/command.truss_test.go
@@ -109,6 +109,17 @@ func Test_Truss_InvokingCLIOverridesParentEnv(t *testing.T) {
 	h.Require.NotContains(c.Env, "BASETEN_TRUSS_INVOKING_CLI=truss")
 }
 
+func Test_Truss_NoUpdateCheckOverridesParentEnv(t *testing.T) {
+	h, fake := newTrussHarness(t)
+	h.T.Setenv("TRUSS_NO_UPDATE_CHECK", "0")
+
+	h.Require.NoError(h.Execute("truss", "push"))
+
+	c := fake.only(t)
+	h.Require.Contains(c.Env, "TRUSS_NO_UPDATE_CHECK=1")
+	h.Require.NotContains(c.Env, "TRUSS_NO_UPDATE_CHECK=0")
+}
+
 func Test_Truss_ExtractsOwnFlagsAnywhere(t *testing.T) {
 	h, fake := newTrussHarness(t)
 

--- a/internal/cmd/truss.go
+++ b/internal/cmd/truss.go
@@ -22,6 +22,10 @@ const (
 	trussInvokingCLIEnv = "BASETEN_TRUSS_INVOKING_CLI"
 	trussInvokingCLI    = "baseten"
 
+	// trussNoUpdateCheckEnv is forced on so delegated truss skips its update
+	// check and the disk/network work that comes with it.
+	trussNoUpdateCheckEnv = "TRUSS_NO_UPDATE_CHECK"
+
 	// trussVersionEnv and trussExecutableEnv default --truss-version and
 	// --truss-executable, so a chosen truss survives across invocations.
 	trussVersionEnv    = "BASETEN_TRUSS_VERSION"
@@ -111,11 +115,11 @@ func trussCommand(ctx *CommandContext, inv trussInvocation) (*exec.Cmd, error) {
 	// TRUSS_NO_UPDATE_CHECK suppresses truss's update check and its associated
 	// disk/network side effects. BASETEN_TRUSS_INVOKING_CLI swaps truss's
 	// follow-up hints to `baseten ...` commands; see basetenlabs/baseten-cli#64.
-	// Drop any inherited copy first: Go's env lookup uses the first match.
-	env := append(os.Environ(), "TRUSS_NO_UPDATE_CHECK=1")
-	env = append(env, inv.Env...)
+	// Drop inherited copies first: Go's env lookup uses the first match.
+	env := append(os.Environ(), inv.Env...)
+	env = envWithout(env, trussNoUpdateCheckEnv)
 	env = envWithout(env, trussInvokingCLIEnv)
-	env = append(env, trussInvokingCLIEnv+"="+trussInvokingCLI)
+	env = append(env, trussNoUpdateCheckEnv+"=1", trussInvokingCLIEnv+"="+trussInvokingCLI)
 	if inv.ForwardAuth {
 		transport, remote, err := ctx.AuthTransport()
 		if err != nil {

--- a/internal/cmd/truss.go
+++ b/internal/cmd/truss.go
@@ -16,6 +16,12 @@ const (
 	trussAuthRemoteURLEnv = "BASETEN_TRUSS_AUTH_REMOTE_URL"
 	trussAuthAPIKeyEnv    = "BASETEN_TRUSS_AUTH_API_KEY"
 
+	// trussInvokingCLIEnv tells truss to print follow-up hints in this CLI's
+	// vocabulary. Set on every delegated invocation, including those that
+	// do not forward auth (train init).
+	trussInvokingCLIEnv = "BASETEN_TRUSS_INVOKING_CLI"
+	trussInvokingCLI    = "baseten"
+
 	// trussVersionEnv and trussExecutableEnv default --truss-version and
 	// --truss-executable, so a chosen truss survives across invocations.
 	trussVersionEnv    = "BASETEN_TRUSS_VERSION"
@@ -103,9 +109,13 @@ func trussCommand(ctx *CommandContext, inv trussInvocation) (*exec.Cmd, error) {
 	}
 
 	// TRUSS_NO_UPDATE_CHECK suppresses truss's update check and its associated
-	// disk/network side effects.
+	// disk/network side effects. BASETEN_TRUSS_INVOKING_CLI swaps truss's
+	// follow-up hints to `baseten ...` commands; see basetenlabs/baseten-cli#64.
+	// Drop any inherited copy first: Go's env lookup uses the first match.
 	env := append(os.Environ(), "TRUSS_NO_UPDATE_CHECK=1")
 	env = append(env, inv.Env...)
+	env = envWithout(env, trussInvokingCLIEnv)
+	env = append(env, trussInvokingCLIEnv+"="+trussInvokingCLI)
 	if inv.ForwardAuth {
 		transport, remote, err := ctx.AuthTransport()
 		if err != nil {
@@ -178,4 +188,16 @@ func trussIntArg(args []string, name string, value int) []string {
 		return args
 	}
 	return append(args, "--"+name, strconv.Itoa(value))
+}
+
+// envWithout drops entries named name, so a later append is the only match.
+func envWithout(env []string, name string) []string {
+	prefix := name + "="
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		if !strings.HasPrefix(e, prefix) {
+			out = append(out, e)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## What

Delegated commands (`train push`, `train workstation create`, `loops checkpoint deploy`, and the other truss shells) now set `BASETEN_TRUSS_INVOKING_CLI=baseten` on the child.

Truss reads that var and prints `baseten train job logs ...` instead of `truss train logs ...`. Users without a trussrc can run the hinted commands.

Companion change is [basetenlabs/truss#2636](https://github.com/basetenlabs/truss/pull/2636). This PR only sets the env var.

Closes #64.

## How

`trussCommand` already forwards `BASETEN_TRUSS_AUTH_*`. This adds `BASETEN_TRUSS_INVOKING_CLI=baseten` on every invocation, including ones that do not forward auth (`train init`).

An inherited value is stripped first so a leftover `BASETEN_TRUSS_INVOKING_CLI=truss` in the parent environment cannot win. Go's env lookup uses the first match.

## Testing

```
go test ./internal/cmd/ -count=1 -run 'Test_Truss_ForwardsArgsAndAuth|Test_Truss_InvokingCLI|Test_Truss_ExtractsOwnFlagsAnywhere|Test_Train_Push_ForwardsFlags|Test_Train_Init_ForwardsFlagsWithoutAuth|Test_Train_WorkstationCreate_ForwardsFlags|Test_Loops_Checkpoint_Deploy_ForwardsFlags'
```

Checks the var is set with and without auth forwarding, on train push / init / workstation create / loops checkpoint deploy, and that a parent `=truss` value is replaced.

No live Baseten run. The child truss is faked; we assert the env the child would have received.