### PR TITLE
Write a JSON error object to stdout when a command fails under --output json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
 - Every leaf (no `Children`) must declare an `Output` (`*CommandOutput[T]`) with `TextDescription`, at least one `Examples` entry, and a `JQExample` that includes `--jq`. Use `JSONAny` for free-shape JSON, `JSONUndefined` for raw passthrough; set `JSONArrayStreamed: true` for commands that emit a stream of records.
 - Use `ctx.Output*` for stdout, `ctx.Log*` (or `VerboseLog*` behind `--verbose`) for stderr; never mix the two. `--output` controls stdout only.
 - Return typed errors (`cmd.NewErrUsage`/`NewErrAuth`/...) so the framework maps them to the right exit code. New exit codes go in `Command.Errors` via `ErrorDescOf[*ErrFoo]()`.
+- Under `--output json`/`jsonl` the framework writes a `cmd.JSONErrorEnvelope` to stdout for a failed command, in addition to the stderr message. Call `ctx.SuppressJSONError()` before returning if the payload already written reports the failure itself.
 - Before prompting, check `ctx.IsInteractive()` and fail fast otherwise: the CLI never prompts in non-TTY contexts.
 - Internal (`internal/cmd/`): runner registered in `init()` via `Register("parent child", runner)`; path and flag type must match.
 - Parents (commands with subcommands) are not executable: no run function, no `Flags`.

--- a/README.md
+++ b/README.md
@@ -39,19 +39,19 @@ Download the [latest release](https://github.com/basetenlabs/baseten-cli/release
 PowerShell:
 
     Invoke-WebRequest `
-      https://github.com/basetenlabs/baseten-cli/releases/download/v0.3.0/baseten_0.3.0_windows_amd64.zip `
+      https://github.com/basetenlabs/baseten-cli/releases/download/v0.4.0/baseten_0.4.0_windows_amd64.zip `
       -OutFile baseten.zip; Expand-Archive -Force baseten.zip .
 
 Then move `baseten.exe` to a directory on your `PATH`.
 
 #### macOS (arm64)
 
-    curl -sL https://github.com/basetenlabs/baseten-cli/releases/download/v0.3.0/baseten_0.3.0_darwin_arm64.tar.gz \
+    curl -sL https://github.com/basetenlabs/baseten-cli/releases/download/v0.4.0/baseten_0.4.0_darwin_arm64.tar.gz \
       | sudo tar xz -C /usr/local/bin baseten
 
 #### Linux (x64)
 
-    curl -sL https://github.com/basetenlabs/baseten-cli/releases/download/v0.3.0/baseten_0.3.0_linux_amd64.tar.gz \
+    curl -sL https://github.com/basetenlabs/baseten-cli/releases/download/v0.4.0/baseten_0.4.0_linux_amd64.tar.gz \
       | sudo tar xz -C /usr/local/bin baseten
 
 </details>

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -25,10 +25,49 @@ const (
 	ExitInterrupted ExitCode = 130
 )
 
+// JSONErrorEnvelope is written to stdout when a command fails under
+// --output json or --output jsonl, on top of the plain-text message that goes
+// to stderr whatever the output format.
+//
+// It is the last JSON document on stdout: alone when the command produced no
+// payload, or after the records a streamed command emitted. Two kinds of
+// failure write none. A command whose own payload already reports the failure
+// suppresses it, so stdout stays a single document under --output json, and a
+// command that delegates to another tool leaves that tool's stdout untouched.
+type JSONErrorEnvelope struct {
+	Error JSONError `json:"error"`
+}
+
+// JSONError is the error object inside a [JSONErrorEnvelope].
+type JSONError struct {
+	// Message is the human-readable failure message, identical to the line
+	// written to stderr. For a failure originating in an API response this
+	// includes the raw response body.
+	Message string `json:"message"`
+	// Type is the name of the typed error, matching the names listed in the
+	// exit-code tables of `baseten --help-output` and each command's
+	// --help-output.
+	Type string `json:"type"`
+	// ExitCode is the process exit code, the same value the shell sees.
+	ExitCode ExitCode `json:"exit_code"`
+	// APIStatusCode is the HTTP status of the failed API response. Absent when
+	// the failure did not come from an API call.
+	APIStatusCode int `json:"api_status_code,omitempty"`
+	// APIErrorCode is the machine-readable error code from the API response
+	// body. Absent when the failure did not come from an API call, or when the
+	// response carried no code (some failures are reported by an upstream
+	// proxy whose body has only a message).
+	APIErrorCode string `json:"api_error_code,omitempty"`
+	// APIDetails is the structured, per-failure-kind payload from the API
+	// response body. Absent when the failure did not come from an API call, or
+	// when the response carried no details.
+	APIDetails map[string]any `json:"api_details,omitempty"`
+}
+
 // CommandError is implemented by typed errors a command may return. The
 // framework calls [errors.As] on the returned error to discover a
 // CommandError implementation and uses its [ExitCode] and [Meaning] to
-// classify the failure and populate the JSON error envelope.
+// classify the failure and populate the [JSONErrorEnvelope].
 //
 // Implementations should embed [CommandErrorMeta] for the underlying
 // error/unwrap plumbing and provide static [ExitCode] and [Meaning] on a
@@ -77,7 +116,7 @@ func ErrorDescOf[PT CommandError]() ErrorDesc {
 	if code == ExitSuccess {
 		panic(fmt.Sprintf("typed command error %s has ExitCode() == 0", pt.Elem().Name()))
 	}
-	return ErrorDesc{Name: pt.Elem().Name(), Code: code, Meaning: inst.Meaning()}
+	return ErrorDesc{Name: ErrorTypeName(inst), Code: code, Meaning: inst.Meaning()}
 }
 
 // ErrGeneric is the catch-all typed error for failures with no more specific
@@ -147,18 +186,44 @@ func (*ErrServer) Meaning() string    { return "Server error" }
 // NewErrServer wraps any error as an [ErrServer].
 func NewErrServer(err error) *ErrServer { return wrapErr[ErrServer](err) }
 
+// ErrInterrupted signals that the command's context was cancelled by a signal
+// (Ctrl-C / SIGTERM) rather than failing on its own. Surfaces
+// [ExitInterrupted].
+type ErrInterrupted struct{ CommandErrorMeta }
+
+func (*ErrInterrupted) ExitCode() ExitCode { return ExitInterrupted }
+func (*ErrInterrupted) Meaning() string    { return "Interrupted by signal" }
+
+// NewErrInterrupted wraps any error as an [ErrInterrupted].
+func NewErrInterrupted(err error) *ErrInterrupted { return wrapErr[ErrInterrupted](err) }
+
+// ErrorTypeName returns the name of a [CommandError]'s concrete type: the
+// value carried in [JSONError.Type], and the name listed alongside the exit
+// code in the --help-output exit-code tables.
+func ErrorTypeName(err CommandError) string {
+	t := reflect.TypeOf(err)
+	if t == nil {
+		return ""
+	}
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t.Name()
+}
+
 // hasCommandErrorMeta is the constraint on the typed-error structs that embed
 // [CommandErrorMeta], used by [wrapErr] to inject the meta into a fresh value.
 type hasCommandErrorMeta interface {
 	setCommandErrorMeta(CommandErrorMeta)
 }
 
-func (e *ErrGeneric) setCommandErrorMeta(m CommandErrorMeta)    { e.CommandErrorMeta = m }
-func (e *ErrUsage) setCommandErrorMeta(m CommandErrorMeta)      { e.CommandErrorMeta = m }
-func (e *ErrAuth) setCommandErrorMeta(m CommandErrorMeta)       { e.CommandErrorMeta = m }
-func (e *ErrNotFound) setCommandErrorMeta(m CommandErrorMeta)   { e.CommandErrorMeta = m }
-func (e *ErrValidation) setCommandErrorMeta(m CommandErrorMeta) { e.CommandErrorMeta = m }
-func (e *ErrServer) setCommandErrorMeta(m CommandErrorMeta)     { e.CommandErrorMeta = m }
+func (e *ErrGeneric) setCommandErrorMeta(m CommandErrorMeta)     { e.CommandErrorMeta = m }
+func (e *ErrUsage) setCommandErrorMeta(m CommandErrorMeta)       { e.CommandErrorMeta = m }
+func (e *ErrAuth) setCommandErrorMeta(m CommandErrorMeta)        { e.CommandErrorMeta = m }
+func (e *ErrNotFound) setCommandErrorMeta(m CommandErrorMeta)    { e.CommandErrorMeta = m }
+func (e *ErrValidation) setCommandErrorMeta(m CommandErrorMeta)  { e.CommandErrorMeta = m }
+func (e *ErrServer) setCommandErrorMeta(m CommandErrorMeta)      { e.CommandErrorMeta = m }
+func (e *ErrInterrupted) setCommandErrorMeta(m CommandErrorMeta) { e.CommandErrorMeta = m }
 
 // wrapErr is the shared constructor for typed command errors. Returns nil if
 // err is nil so callers can `return cmd.NewErrXxx(maybeNil)` without a guard.
@@ -186,6 +251,7 @@ func StandardErrors() []ErrorDesc {
 		ErrorDescOf[*ErrNotFound](),
 		ErrorDescOf[*ErrValidation](),
 		ErrorDescOf[*ErrServer](),
+		ErrorDescOf[*ErrInterrupted](),
 	}
 }
 

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -438,9 +438,10 @@ func bindFlags(flags *pflag.FlagSet, val reflect.Value, metas []cmd.CommandFlag)
 
 // outputFormatFromArgs returns the --output value read straight out of argv,
 // for the failures cobra rejects before it finishes parsing flags. Returns ""
-// when the invocation names no format, which includes a typo'd value: a bad
-// --output is reported on stderr only, since there is no telling what the
-// caller meant by it.
+// when the invocation names no format, a typo'd value included, since there
+// is no telling what the caller meant by it. --jq counts as json only if no
+// --output follows. Shorthands combined into one arg (-vojson) are not
+// recognized.
 func outputFormatFromArgs(args []string) string {
 	format := ""
 	for i, arg := range args {
@@ -451,12 +452,9 @@ func outputFormatFromArgs(args []string) string {
 			}
 		case strings.HasPrefix(arg, "--output="):
 			return strings.TrimPrefix(arg, "--output=")
-		// Shorthand with an attached value, as pflag accepts it: -o=json, -ojson.
 		case strings.HasPrefix(arg, "-o"):
 			return strings.TrimPrefix(strings.TrimPrefix(arg, "-o"), "=")
-		case arg == "--jq" || arg == "-q" || strings.HasPrefix(arg, "--jq=") || strings.HasPrefix(arg, "-q="):
-			// --jq resolves to json when the invocation sets no format of its
-			// own, so record it and keep scanning for an explicit --output.
+		case arg == "--jq" || strings.HasPrefix(arg, "--jq=") || strings.HasPrefix(arg, "-q"):
 			format = "json"
 		}
 	}

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -101,12 +101,30 @@ func Execute(ctx context.Context, options ExecuteOptions) error {
 	for _, child := range cmd.Root.Children {
 		root.AddCommand(buildCommand(child, "", &options))
 	}
-	return help.Execute(ctx, root, help.Options{
+	err := help.Execute(ctx, root, help.Options{
 		Args:    options.Args,
 		Version: Version,
 		Signals: []os.Signal{os.Interrupt, syscall.SIGTERM},
 		Tree:    cmd.Root,
 	})
+	if err == nil {
+		return nil
+	}
+
+	// The invocation was rejected before any runner ran: an unparseable flag,
+	// an unknown subcommand, or the wrong argument count. Cobra has already
+	// printed the message to stderr, but the failure never passed through a
+	// leaf's error handling, so classify it here as the usage error it is and
+	// give it the same exit code and envelope a leaf would produce.
+	ce := cmd.NewErrUsage(err)
+	format := outputFormatFromArgs(options.Args)
+	(&CommandContext{
+		Stdout:      options.Stdout,
+		JSON:        format == "json" || format == "jsonl",
+		JSONCompact: format == "jsonl",
+	}).writeJSONError(ce, err)
+	options.ExitWithCode(int(ce.ExitCode()))
+	return err
 }
 
 func buildCommand(def cmd.Command, parentPath string, options *ExecuteOptions) *cobra.Command {
@@ -265,9 +283,7 @@ func buildCommand(def cmd.Command, parentPath string, options *ExecuteOptions) *
 			// generic failure. Gated on the context, not the error's identity:
 			// only an actual interrupt should be treated this way.
 			if ctx.Err() != nil {
-				fmt.Fprintln(options.Stderr, "Canceled.")
-				ctx.ExitWithCode(int(cmd.ExitInterrupted))
-				return nil
+				runErr = cmd.NewErrInterrupted(errors.New("Canceled."))
 			}
 
 			// Render the error and set exit code.
@@ -275,12 +291,17 @@ func buildCommand(def cmd.Command, parentPath string, options *ExecuteOptions) *
 			c.SilenceErrors = true
 			c.SilenceUsage = true
 			fmt.Fprintln(options.Stderr, ce)
+			ctx.writeJSONError(ce, runErr)
 			// A subprocess exit code is the child's, not ours. Delegated tools
 			// like truss exit 2 for their own validation errors, which collides
 			// with ExitUsage, so only dump usage for errors that originated here.
 			var subErr *ErrSubprocess
 			if ce.ExitCode() == cmd.ExitUsage && !errors.As(runErr, &subErr) {
-				_ = c.Usage()
+				// Rendered through UsageString rather than Usage, which writes
+				// to cobra's out writer: that is stdout here, where the usage
+				// text would corrupt the error envelope and any payload
+				// already emitted.
+				fmt.Fprint(options.Stderr, c.UsageString())
 			}
 			ctx.ExitWithCode(int(ce.ExitCode()))
 			return nil
@@ -413,6 +434,33 @@ func bindFlags(flags *pflag.FlagSet, val reflect.Value, metas []cmd.CommandFlag)
 			}
 		}
 	}
+}
+
+// outputFormatFromArgs returns the --output value read straight out of argv,
+// for the failures cobra rejects before it finishes parsing flags. Returns ""
+// when the invocation names no format, which includes a typo'd value: a bad
+// --output is reported on stderr only, since there is no telling what the
+// caller meant by it.
+func outputFormatFromArgs(args []string) string {
+	format := ""
+	for i, arg := range args {
+		switch {
+		case arg == "--output" || arg == "-o":
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+		case strings.HasPrefix(arg, "--output="):
+			return strings.TrimPrefix(arg, "--output=")
+		// Shorthand with an attached value, as pflag accepts it: -o=json, -ojson.
+		case strings.HasPrefix(arg, "-o"):
+			return strings.TrimPrefix(strings.TrimPrefix(arg, "-o"), "=")
+		case arg == "--jq" || arg == "-q" || strings.HasPrefix(arg, "--jq=") || strings.HasPrefix(arg, "-q="):
+			// --jq resolves to json when the invocation sets no format of its
+			// own, so record it and keep scanning for an explicit --output.
+			format = "json"
+		}
+	}
+	return format
 }
 
 // optionalFlagValue binds a [cmd.OptionalFlag] to pflag. Only parsing varies by

--- a/internal/cmd/command.model_deployment_logs_test.go
+++ b/internal/cmd/command.model_deployment_logs_test.go
@@ -232,8 +232,14 @@ func Test_Model_Deployment_Logs_SingleMillisecondBurstFails(t *testing.T) {
 		"--model-id", "m", "--deployment-id", "d", "--limit", "0", "--output", "jsonl")
 	h.Require.Error(err)
 	h.Require.Contains(err.Error(), "single millisecond")
-	// The lines it could fetch were still emitted before failing.
-	h.Require.Len(jsonlMessages(t, h.Stdout.String()), 1000)
+	// The lines it could fetch were still emitted before failing, with the
+	// error envelope appended as a final record.
+	outLines := strings.Split(strings.TrimSpace(h.Stdout.String()), "\n")
+	h.Require.Len(outLines, 1001)
+	h.Require.Len(jsonlMessages(t, strings.Join(outLines[:1000], "\n")), 1000)
+	var envelope map[string]map[string]any
+	h.Require.NoError(json.Unmarshal([]byte(outLines[1000]), &envelope))
+	h.Require.Contains(envelope["error"]["message"], "single millisecond")
 }
 
 func Test_Model_Deployment_Logs_PageSizeDrivesPagination(t *testing.T) {

--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -166,6 +166,9 @@ func commandModelPush(ctx *CommandContext, flags *cmd.ModelPushFlags) error {
 	// failure; only the one-shot tail/wait paths classify the settled status.
 	if !flags.Watch && (flags.Tail || flags.Wait) &&
 		created.Deployment.Status != managementapi.DeploymentStatus_ACTIVE {
+		// The object above already carries the failed status, so it stands as
+		// the single document on stdout.
+		ctx.SuppressJSONError()
 		return fmt.Errorf("failed deployment status: %s", created.Deployment.Status)
 	}
 	return nil

--- a/internal/cmd/command.model_push_test.go
+++ b/internal/cmd/command.model_push_test.go
@@ -541,10 +541,13 @@ func Test_Model_Push_WaitFailure(t *testing.T) {
 	h.Require.NotZero(h.ExitCode)
 	h.Require.Contains(h.Stderr.String(), "did not become active (status: BUILD_FAILED)")
 
+	// The result carries the failed status, so it stands as the only document
+	// on stdout: no error envelope follows it.
 	var result map[string]any
 	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &result))
 	dep, _ := result["deployment"].(map[string]any)
 	h.Require.Equal("BUILD_FAILED", dep["status"])
+	h.Require.NotContains(result, "error")
 }
 
 // --tail without --wait stops only on terminal-failure statuses; logs go
@@ -695,7 +698,9 @@ func Test_Model_Push_Watch_ReadinessFailureNoJSON(t *testing.T) {
 	err := h.Execute("model", "push", "--dir", dir, "--watch", "--output", "json")
 	h.Require.Error(err)
 	h.Require.Contains(h.Stderr.String(), "not ready")
-	h.Require.Zero(h.Stdout.Len(), "no JSON result on a failed watch")
+	// A failed watch produces no push result, so the error envelope stands
+	// alone on stdout.
+	h.Require.Contains(decodeJSONErrorEnvelope(h.CommandHarness).Message, "not ready")
 
 	prep := h.API.FindCall("POST", "/v1/prepare_model_upload")
 	h.Require.NotNil(prep)

--- a/internal/cmd/command_context.go
+++ b/internal/cmd/command_context.go
@@ -44,9 +44,10 @@ type CommandContext struct {
 	// through the query before encoding. Leaves should not set this directly.
 	JQQuery *gojq.Query
 
-	verbose      bool
-	jqErr        error
-	strictOutput bool
+	verbose           bool
+	jqErr             error
+	strictOutput      bool
+	suppressJSONError bool
 
 	// authInfo lazily resolves the remote and auth session. Use the Remote and
 	// Session accessors; do not read its cached fields directly.
@@ -119,6 +120,42 @@ func (c *CommandContext) encodeJSON(v any) {
 		enc.SetIndent("", "  ")
 	}
 	panicOnOutputError(0, enc.Encode(v))
+}
+
+// SuppressJSONError declares that the JSON already written to stdout reports
+// the failure the command is about to return, so the framework must not
+// append an error envelope after it. Call it before returning an error from a
+// command whose payload encodes its own verdict, keeping stdout a single JSON
+// document under --output json.
+func (c *CommandContext) SuppressJSONError() {
+	c.suppressJSONError = true
+}
+
+// writeJSONError appends the error envelope for a failed command to stdout.
+// Does nothing unless the output format is json or jsonl: under text output
+// the stderr message is the whole report.
+//
+// The envelope bypasses [CommandContext.JQQuery], since a --jq expression is
+// written against the command's payload and would drop or mangle the error.
+// It is a document of its own rather than a wrapper on whatever preceded it,
+// so it ends up as the last JSON document on stdout. Streamed commands
+// terminate their array via the writer's deferred Close before this runs.
+//
+// A subprocess failure is the one failure the framework exempts on its own.
+// The exit code belongs to the child, and so does stdout: [ErrSubprocess]
+// commands hand the child's stream through untouched, and it is not
+// guaranteed to be JSON at all. A command can also opt out for itself via
+// [SuppressJSONError].
+func (c *CommandContext) writeJSONError(ce cmd.CommandError, runErr error) {
+	var subErr *ErrSubprocess
+	if !c.JSON || c.suppressJSONError || errors.As(runErr, &subErr) {
+		return
+	}
+	jsonErr := apiErrorFields(runErr)
+	jsonErr.Message = ce.Error()
+	jsonErr.Type = cmd.ErrorTypeName(ce)
+	jsonErr.ExitCode = ce.ExitCode()
+	c.encodeJSON(cmd.JSONErrorEnvelope{Error: jsonErr})
 }
 
 // NewJSONArrayWriter returns a writer that outputs a JSON array

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 
 	"github.com/basetenlabs/baseten-cli/cmd"
@@ -54,4 +55,64 @@ func knownHTTPStatus(err error) (int, bool) {
 		return irer.StatusCode, true
 	}
 	return 0, false
+}
+
+// apiErrorBody is the union of the error body shapes our APIs return. The
+// management API sends {"code", "message", "details"}, the inference API
+// sends {"error", "error_code", "detail"}, and a failure reported by an
+// upstream proxy rather than the application sends only a message field.
+// Absent fields decode to their zero value, so one struct covers all of them.
+type apiErrorBody struct {
+	Code      string         `json:"code"`
+	ErrorCode string         `json:"error_code"`
+	Details   map[string]any `json:"details"`
+}
+
+// apiErrorFields extracts the api_* fields of the JSON error envelope from a
+// recognized HTTP client error in err's chain. Returns a zero JSONError if
+// the failure did not come from an API call: the fields are omitempty, so a
+// local failure carries none of them.
+//
+// Only the status code is guaranteed. A body that isn't JSON, or that carries
+// no code or details, contributes nothing rather than failing: the message
+// already relays whatever the response said.
+func apiErrorFields(err error) cmd.JSONError {
+	status, ok := knownHTTPStatus(err)
+	if !ok {
+		return cmd.JSONError{}
+	}
+	out := cmd.JSONError{APIStatusCode: status}
+
+	// The inference API's typed error is already decoded. Everything else
+	// carries a raw body to parse.
+	var irer *inferenceapi.ResponseErrorResponse
+	if errors.As(err, &irer) {
+		if code := irer.ErrorResponse.ErrorCode; code != nil {
+			out.APIErrorCode = string(*code)
+		}
+		return out
+	}
+
+	var rawBody string
+	var mre *managementapi.ResponseError
+	var ire *inferenceapi.ResponseError
+	switch {
+	case errors.As(err, &mre):
+		rawBody = mre.Body
+	case errors.As(err, &ire):
+		rawBody = ire.Body
+	}
+	// The decode error is deliberately ignored. Unknown and absent fields are
+	// not errors, so the only failures are a body that isn't a JSON object at
+	// all or a field of an unexpected type, and both still populate whatever
+	// did decode. Anything we can't read contributes nothing, since the
+	// message already relays the response verbatim.
+	var body apiErrorBody
+	_ = json.Unmarshal([]byte(rawBody), &body)
+	out.APIErrorCode = body.Code
+	if out.APIErrorCode == "" {
+		out.APIErrorCode = body.ErrorCode
+	}
+	out.APIDetails = body.Details
+	return out
 }

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -1,0 +1,183 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/basetenlabs/baseten-cli/cmd"
+)
+
+const billingUsagePath = "/v1/billing/usage_summary"
+
+// decodeJSONErrorEnvelope decodes the error envelope a failed command writes
+// to stdout, asserting stdout holds exactly that one document.
+func decodeJSONErrorEnvelope(h *CommandHarness) cmd.JSONError {
+	h.T.Helper()
+	var envelope cmd.JSONErrorEnvelope
+	dec := json.NewDecoder(strings.NewReader(h.Stdout.String()))
+	h.Require.NoError(dec.Decode(&envelope))
+	h.Require.False(dec.More(), "expected a single JSON document on stdout")
+	return envelope.Error
+}
+
+func TestJSONErrorManagementAPIErrorCarriesCodeAndDetails(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", billingUsagePath, 409, map[string]any{
+		"code":    "CONFLICT",
+		"message": "Usage summary is being rebuilt",
+		"details": map[string]any{"retry_after_sec": 30},
+	})
+
+	h.Require.Error(h.Execute("org", "billing", "usage", "--output", "json"))
+	h.Require.Equal(int(cmd.ExitValidation), h.ExitCode)
+	// The same message goes to stderr whatever the output format.
+	h.Require.Contains(h.Stderr.String(), "Usage summary is being rebuilt")
+
+	jsonErr := decodeJSONErrorEnvelope(h)
+	h.Require.Contains(jsonErr.Message, "Usage summary is being rebuilt")
+	h.Require.Equal("ErrValidation", jsonErr.Type)
+	h.Require.Equal(cmd.ExitValidation, jsonErr.ExitCode)
+	h.Require.Equal(409, jsonErr.APIStatusCode)
+	h.Require.Equal("CONFLICT", jsonErr.APIErrorCode)
+	h.Require.Equal(map[string]any{"retry_after_sec": float64(30)}, jsonErr.APIDetails)
+}
+
+func TestJSONErrorProxyErrorCarriesStatusOnly(t *testing.T) {
+	h := NewCommandHarness(t)
+	// A failure reported by beefeater rather than the application: the body
+	// has a message under "error" and no code or details.
+	h.MockManagementAPI().SetRoute("GET", billingUsagePath, 401, map[string]any{"error": "Unauthorized"})
+
+	h.Require.Error(h.Execute("org", "billing", "usage", "--output", "json"))
+	h.Require.Equal(int(cmd.ExitAuth), h.ExitCode)
+
+	jsonErr := decodeJSONErrorEnvelope(h)
+	h.Require.Equal("ErrAuth", jsonErr.Type)
+	h.Require.Equal(401, jsonErr.APIStatusCode)
+	h.Require.Empty(jsonErr.APIErrorCode)
+	h.Require.Empty(jsonErr.APIDetails)
+}
+
+func TestJSONErrorNonJSONBodyCarriesStatusOnly(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRouteFunc("GET", billingUsagePath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(502)
+		_, _ = w.Write([]byte("<html>Bad Gateway</html>"))
+	})
+
+	h.Require.Error(h.Execute("org", "billing", "usage", "--output", "json"))
+
+	jsonErr := decodeJSONErrorEnvelope(h)
+	h.Require.Equal("ErrServer", jsonErr.Type)
+	h.Require.Equal(502, jsonErr.APIStatusCode)
+	h.Require.Empty(jsonErr.APIErrorCode)
+	h.Require.Empty(jsonErr.APIDetails)
+}
+
+func TestJSONErrorLocalFailureHasNoAPIFields(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetHandlerFallback(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatalf("server should not be hit on a flag validation error")
+	})
+
+	h.Require.Error(h.Execute("org", "billing", "usage", "--output", "json", "--since", "7d", "--start", "2026-05-01"))
+	h.Require.Equal(int(cmd.ExitUsage), h.ExitCode)
+
+	jsonErr := decodeJSONErrorEnvelope(h)
+	h.Require.Contains(jsonErr.Message, "--since cannot be combined with")
+	h.Require.Equal("ErrUsage", jsonErr.Type)
+	h.Require.Zero(jsonErr.APIStatusCode)
+	h.Require.Empty(jsonErr.APIErrorCode)
+	h.Require.Empty(jsonErr.APIDetails)
+}
+
+func TestJSONErrorTextOutputWritesNothingToStdout(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", billingUsagePath, 500, map[string]any{
+		"code": "INTERNAL_ERROR", "message": "Internal error",
+	})
+
+	h.Require.Error(h.Execute("org", "billing", "usage"))
+	h.Require.Empty(h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "Internal error")
+}
+
+func TestJSONErrorJSONLEnvelopeIsOneLine(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", billingUsagePath, 500, map[string]any{
+		"code": "INTERNAL_ERROR", "message": "Internal error",
+	})
+
+	h.Require.Error(h.Execute("org", "billing", "usage", "--output", "jsonl"))
+	h.Require.Len(strings.Split(strings.TrimSpace(h.Stdout.String()), "\n"), 1)
+	h.Require.Equal("ErrServer", decodeJSONErrorEnvelope(h).Type)
+}
+
+func TestJSONErrorBypassesJQ(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", billingUsagePath, 404, map[string]any{
+		"code": "NOT_FOUND", "message": "No usage recorded",
+	})
+
+	// --jq selects a field of the payload, which never arrived. The envelope
+	// is emitted whole rather than run through the expression.
+	h.Require.Error(h.Execute("org", "billing", "usage", "--jq", ".dedicated_usage"))
+	h.Require.Equal("ErrNotFound", decodeJSONErrorEnvelope(h).Type)
+}
+
+func TestJSONErrorUnknownFlagIsAUsageError(t *testing.T) {
+	h := NewCommandHarness(t)
+
+	h.Require.Error(h.Execute("org", "billing", "usage", "--output", "json", "--bogus"))
+	h.Require.Equal(int(cmd.ExitUsage), h.ExitCode)
+
+	jsonErr := decodeJSONErrorEnvelope(h)
+	h.Require.Contains(jsonErr.Message, "unknown flag: --bogus")
+	h.Require.Equal("ErrUsage", jsonErr.Type)
+	h.Require.Zero(jsonErr.APIStatusCode)
+}
+
+func TestJSONErrorUnknownSubcommandIsAUsageError(t *testing.T) {
+	h := NewCommandHarness(t)
+
+	h.Require.Error(h.Execute("org", "billing", "bogus", "--output", "json"))
+	h.Require.Equal(int(cmd.ExitUsage), h.ExitCode)
+	h.Require.Contains(decodeJSONErrorEnvelope(h).Message, "unknown command")
+}
+
+func TestJSONErrorBadOutputValueWritesStderrOnly(t *testing.T) {
+	h := NewCommandHarness(t)
+
+	// The format itself is what failed to parse, so there is no telling which
+	// format the caller wanted the error in.
+	h.Require.Error(h.Execute("org", "billing", "usage", "--output", "jsonnn"))
+	h.Require.Equal(int(cmd.ExitUsage), h.ExitCode)
+	h.Require.Empty(h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "must be one of")
+}
+
+func TestJSONErrorRootHelpDocumentsEnvelope(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.Require.NoError(h.Execute("--help-output"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "ErrInterrupted")
+	h.Require.Contains(out, "JSON ERRORS")
+	h.Require.Contains(out, "api_error_code")
+}
+
+// An interrupt is reported as an envelope like any other failure. Uses the
+// watch harness because a signal mid-run is the only way to reach the path.
+func TestJSONErrorInterruptIsAnEnvelope(t *testing.T) {
+	h, m, dir := newModelWatchHarness(t)
+	interruptWatchOnSync(h, m)
+
+	h.Require.Error(h.Execute("model", "watch", "--dir", dir, "--output", "json"))
+	h.Require.Equal(int(cmd.ExitInterrupted), h.ExitCode)
+
+	jsonErr := decodeJSONErrorEnvelope(h)
+	h.Require.Equal("ErrInterrupted", jsonErr.Type)
+	h.Require.Equal(cmd.ExitInterrupted, jsonErr.ExitCode)
+	h.Require.Zero(jsonErr.APIStatusCode)
+}

--- a/internal/help/output.go
+++ b/internal/help/output.go
@@ -78,6 +78,17 @@ func renderRootOutput(styles fang.Styles) string {
 	for _, e := range cmd.StandardErrors() {
 		b.WriteString(formatErrorLine(e))
 	}
+	b.WriteString(styles.Title.Render("json errors"))
+	b.WriteString("\n")
+	b.WriteString(lipgloss.NewStyle().PaddingLeft(longPad).Width(termWidth()).Render(
+		"Under --output json or jsonl, a failed command writes an object matching the schema " +
+			"below to stdout as the last JSON document there, on top of the plain message " +
+			"always written to stderr. The type field matches the names above. The api_ fields " +
+			"appear only for a failed API call. A command whose payload already reports the " +
+			"failure, or that delegates to another tool, writes none."))
+	b.WriteString("\n")
+	b.WriteString(renderCodeblock(jsonSchemaForType(reflect.TypeFor[cmd.JSONErrorEnvelope]()), styles))
+	b.WriteString("\n")
 	return b.String()
 }
 
@@ -126,17 +137,21 @@ func renderLeafJSON(def cmd.Command, styles fang.Styles) string {
 		b.WriteString("\n")
 	}
 
-	body := jsonSchemaBlock(def.Output)
+	b.WriteString(renderCodeblock(jsonSchemaBlock(def.Output), styles))
+	b.WriteString("\n")
+	return b.String()
+}
+
+// renderCodeblock renders body as a codeblock sized to its widest line, up to
+// the terminal width.
+func renderCodeblock(body string, styles fang.Styles) string {
 	padding := styles.Codeblock.Base.GetHorizontalPadding()
 	blockWidth := 0
 	for _, line := range strings.Split(body, "\n") {
 		blockWidth = max(blockWidth, lipgloss.Width(line))
 	}
 	blockWidth = min(termWidth()-padding, blockWidth+padding)
-	blockStyle := styles.Codeblock.Base.Width(blockWidth)
-	b.WriteString(blockStyle.Render(body))
-	b.WriteString("\n")
-	return b.String()
+	return styles.Codeblock.Base.Width(blockWidth).Render(body)
 }
 
 func jsonSchemaBlock(spec cmd.CommandOutputSpec) string {
@@ -150,6 +165,15 @@ func jsonSchemaBlock(spec cmd.CommandOutputSpec) string {
 		return "undefined (raw passthrough, not guaranteed JSON)"
 	}
 
+	pretty := jsonSchemaForType(typ)
+	if spec.JSONArrayStreamedBool() {
+		return "Streamed: --output json wraps records in an array, --output jsonl emits one per line.\nRecord schema:\n" + pretty
+	}
+	return pretty
+}
+
+// jsonSchemaForType renders typ as a pretty-printed JSON schema.
+func jsonSchemaForType(typ reflect.Type) string {
 	schema := (&jsonschema.Reflector{
 		Anonymous:                 true,
 		DoNotReference:            true,
@@ -165,9 +189,6 @@ func jsonSchemaBlock(spec cmd.CommandOutputSpec) string {
 	pretty, err := prettyJSONSchema(raw)
 	if err != nil {
 		return fmt.Sprintf("(schema render error: %v)", err)
-	}
-	if spec.JSONArrayStreamedBool() {
-		return "Streamed: --output json wraps records in an array, --output jsonl emits one per line.\nRecord schema:\n" + pretty
 	}
 	return pretty
 }


### PR DESCRIPTION
## :rocket: What

- Failed commands under `--output json`/`jsonl` now write a structured error to stdout, not just a message to stderr (fixes #68)
- Shape: `{"error": {"message", "type", "exit_code", "api_status_code"?, "api_error_code"?, "api_details"?}}`, the `api_*` fields only for failed API calls
- Interrupts get a real `ErrInterrupted` type, so exit code 130 is now listed in `--help-output`
- Bad flags and unknown subcommands now exit 2 (`ExitUsage`) instead of 1, and get an envelope too
- Usage text on error moves from stdout to stderr

## :computer: How

- `cmd.JSONErrorEnvelope`/`JSONError` in the public package, rendered as a schema in `baseten --help-output`
- `apiErrorFields` pulls status, code, and details off the management/inference client errors already in the chain, best-effort: unparseable bodies contribute only the status
- `message` is the error chain verbatim, so an API failure still carries the raw response body
- `ctx.SuppressJSONError()` for commands whose payload already reports the failure (`model push --wait`), keeping stdout one document under `--output json`. Subprocess passthrough (`truss`) writes no envelope either
- Pre-parse failures never reach a runner, so `Execute` classifies them and reads `--output` straight from argv
- Usage now renders via `c.UsageString()` to stderr; cobra's `Usage()` writes to the `SetOut` writer, which is stdout here

## :microscope: Testing

- New `internal/cmd/errors_test.go`: management error with code and details, proxy 401 with neither, non-JSON 502, local failure, text mode, jsonl single line, `--jq` bypass, unknown flag, unknown subcommand, bad `--output` value, interrupt, help docs
- Updated the model-push and deployment-logs tests for the new stdout shapes
