### PR TITLE
Report activate and deactivate no-ops in text output

### DIFF
--- a/cmd/command.model_deployment.go
+++ b/cmd/command.model_deployment.go
@@ -10,12 +10,16 @@ var commandModelDeployment = Command{
 	Summary: "Manage deployments of a model",
 	Children: []Command{
 		{
-			Name:        "activate",
-			Summary:     "Activate a deployment",
-			Description: "Activate a model deployment.",
-			Flags:       ModelDeploymentActivateFlags{},
+			Name:    "activate",
+			Summary: "Activate a deployment",
+			Description: "Activate a model deployment.\n\n" +
+				"Activation is idempotent: activating a deployment that is already active " +
+				"does nothing and still succeeds.",
+			Flags: ModelDeploymentActivateFlags{},
 			Output: &CommandOutput[managementapi.ActivateResponse]{
-				TextDescription: "On success, prints \"Activated deployment <id>\" to stderr; no stdout output.",
+				TextDescription: "On success, prints \"Activated deployment <id>\" to stderr, or " +
+					"\"Deployment <id> was already active; nothing to do\" when nothing changed; " +
+					"no stdout output.",
 				Examples: []CommandExample{
 					{
 						Description: "Activate a deployment.",
@@ -57,10 +61,14 @@ var commandModelDeployment = Command{
 			Summary: "Deactivate a deployment",
 			Description: "Deactivate a model deployment.\n\n" +
 				"Prompts for yes/no confirmation. Pass --yes to skip the prompt. When " +
-				"stdin is not a terminal, --yes is required.",
+				"stdin is not a terminal, --yes is required.\n\n" +
+				"Deactivation is idempotent: deactivating a deployment that is already " +
+				"inactive does nothing and still succeeds.",
 			Flags: ModelDeploymentDeactivateFlags{},
 			Output: &CommandOutput[managementapi.DeactivateResponse]{
-				TextDescription: "On success, prints \"Deactivated deployment <id>\" to stderr; no stdout output.",
+				TextDescription: "On success, prints \"Deactivated deployment <id>\" to stderr, or " +
+					"\"Deployment <id> was already inactive; nothing to do\" when nothing changed; " +
+					"no stdout output.",
 				Examples: []CommandExample{
 					{
 						Description: "Deactivate a deployment without the confirmation prompt.",

--- a/cmd/command.model_environment.go
+++ b/cmd/command.model_environment.go
@@ -8,12 +8,16 @@ var commandModelEnvironment = Command{
 	Summary: "Manage environments of a model",
 	Children: []Command{
 		{
-			Name:        "activate",
-			Summary:     "Activate the environment's active deployment",
-			Description: "Activate the deployment associated with an environment.",
-			Flags:       ModelEnvironmentActivateFlags{},
+			Name:    "activate",
+			Summary: "Activate the environment's active deployment",
+			Description: "Activate the deployment associated with an environment.\n\n" +
+				"Activation is idempotent: activating a deployment that is already active " +
+				"does nothing and still succeeds.",
+			Flags: ModelEnvironmentActivateFlags{},
 			Output: &CommandOutput[managementapi.ActivateResponse]{
-				TextDescription: "On success, prints \"Activated environment <name>\" to stderr; no stdout output.",
+				TextDescription: "On success, prints \"Activated environment <name>\" to stderr, or " +
+					"\"Environment <name> was already active; nothing to do\" when nothing changed; " +
+					"no stdout output.",
 				Examples: []CommandExample{
 					{
 						Description: "Activate the deployment associated with an environment.",
@@ -31,10 +35,14 @@ var commandModelEnvironment = Command{
 			Summary: "Deactivate the environment's active deployment",
 			Description: "Deactivate the deployment associated with an environment.\n\n" +
 				"Prompts for yes/no confirmation. Pass --yes to skip the prompt. When " +
-				"stdin is not a terminal, --yes is required.",
+				"stdin is not a terminal, --yes is required.\n\n" +
+				"Deactivation is idempotent: deactivating a deployment that is already " +
+				"inactive does nothing and still succeeds.",
 			Flags: ModelEnvironmentDeactivateFlags{},
 			Output: &CommandOutput[managementapi.DeactivateResponse]{
-				TextDescription: "On success, prints \"Deactivated environment <name>\" to stderr; no stdout output.",
+				TextDescription: "On success, prints \"Deactivated environment <name>\" to stderr, or " +
+					"\"Environment <name> was already inactive; nothing to do\" when nothing changed; " +
+					"no stdout output.",
 				Examples: []CommandExample{
 					{
 						Description: "Deactivate an environment without the confirmation prompt.",

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.2.1-0.20260902122144-e30c99eda507
+	github.com/basetenlabs/baseten-go v0.2.1-0.20260903212600-17ee138bad80
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.2.1-0.20260902122144-e30c99eda507 h1:W7dihWVy4BvX5vlI5ge8pMZl1DXOs0Ybz7wqcSGbMc8=
-github.com/basetenlabs/baseten-go v0.2.1-0.20260902122144-e30c99eda507/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260903212600-17ee138bad80 h1:xRPWgZxDxuDQ6yWLx76LHtAw8hR//JdSFPzn8YajxDA=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260903212600-17ee138bad80/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/internal/cmd/command.model_deployment.go
+++ b/internal/cmd/command.model_deployment.go
@@ -259,7 +259,11 @@ func commandModelDeploymentActivate(ctx *CommandContext, flags *cmd.ModelDeploym
 		ctx.OutputJSON(resp)
 		return nil
 	}
-	ctx.Logf("Activated deployment %s\n", ref.DeploymentID)
+	if resp.NoOp != nil && *resp.NoOp {
+		ctx.Logf("Deployment %s was already active; nothing to do\n", ref.DeploymentID)
+	} else {
+		ctx.Logf("Activated deployment %s\n", ref.DeploymentID)
+	}
 	return nil
 }
 
@@ -288,7 +292,11 @@ func commandModelDeploymentDeactivate(ctx *CommandContext, flags *cmd.ModelDeplo
 		ctx.OutputJSON(resp)
 		return nil
 	}
-	ctx.Logf("Deactivated deployment %s\n", ref.DeploymentID)
+	if resp.NoOp != nil && *resp.NoOp {
+		ctx.Logf("Deployment %s was already inactive; nothing to do\n", ref.DeploymentID)
+	} else {
+		ctx.Logf("Deactivated deployment %s\n", ref.DeploymentID)
+	}
 	return nil
 }
 

--- a/internal/cmd/command.model_deployment_test.go
+++ b/internal/cmd/command.model_deployment_test.go
@@ -169,6 +169,17 @@ func Test_Model_Deployment_Activate(t *testing.T) {
 	h.Require.Contains(h.Stderr.String(), "Activated deployment d-1")
 }
 
+func Test_Model_Deployment_Activate_NoOp(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", "/v1/models/m-1/deployments/d-1/activate", 200,
+		map[string]any{"success": true, "no_op": true})
+
+	h.Require.NoError(h.Execute("model", "deployment", "activate",
+		"--model-id", "m-1", "--deployment-id", "d-1"))
+	h.Require.Contains(h.Stderr.String(), "Deployment d-1 was already active; nothing to do")
+}
+
 func Test_Model_Deployment_Deactivate_Yes(t *testing.T) {
 	h := NewCommandHarness(t)
 	m := h.MockManagementAPI()
@@ -179,6 +190,17 @@ func Test_Model_Deployment_Deactivate_Yes(t *testing.T) {
 		"--model-id", "m-1", "--deployment-id", "d-1", "--yes"))
 	h.Require.NotNil(m.FindCall("POST", "/v1/models/m-1/deployments/d-1/deactivate"))
 	h.Require.Contains(h.Stderr.String(), "Deactivated deployment d-1")
+}
+
+func Test_Model_Deployment_Deactivate_NoOp(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", "/v1/models/m-1/deployments/d-1/deactivate", 200,
+		map[string]any{"success": true, "no_op": true})
+
+	h.Require.NoError(h.Execute("model", "deployment", "deactivate",
+		"--model-id", "m-1", "--deployment-id", "d-1", "--yes"))
+	h.Require.Contains(h.Stderr.String(), "Deployment d-1 was already inactive; nothing to do")
 }
 
 func Test_Model_Deployment_Deactivate_NoTTY_RequiresYes(t *testing.T) {

--- a/internal/cmd/command.model_environment.go
+++ b/internal/cmd/command.model_environment.go
@@ -180,7 +180,11 @@ func commandModelEnvironmentActivate(ctx *CommandContext, flags *cmd.ModelEnviro
 		ctx.OutputJSON(resp)
 		return nil
 	}
-	ctx.Logf("Activated environment %s\n", flags.Environment)
+	if resp.NoOp != nil && *resp.NoOp {
+		ctx.Logf("Environment %s was already active; nothing to do\n", flags.Environment)
+	} else {
+		ctx.Logf("Activated environment %s\n", flags.Environment)
+	}
 	return nil
 }
 
@@ -209,7 +213,11 @@ func commandModelEnvironmentDeactivate(ctx *CommandContext, flags *cmd.ModelEnvi
 		ctx.OutputJSON(resp)
 		return nil
 	}
-	ctx.Logf("Deactivated environment %s\n", flags.Environment)
+	if resp.NoOp != nil && *resp.NoOp {
+		ctx.Logf("Environment %s was already inactive; nothing to do\n", flags.Environment)
+	} else {
+		ctx.Logf("Deactivated environment %s\n", flags.Environment)
+	}
 	return nil
 }
 

--- a/internal/cmd/command.model_environment_test.go
+++ b/internal/cmd/command.model_environment_test.go
@@ -133,6 +133,17 @@ func Test_Model_Environment_Activate(t *testing.T) {
 	h.Require.Contains(h.Stderr.String(), "Activated environment production")
 }
 
+func Test_Model_Environment_Activate_NoOp(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", "/v1/models/m-1/environments/production/activate", 200,
+		map[string]any{"success": true, "no_op": true})
+
+	h.Require.NoError(h.Execute("model", "environment", "activate",
+		"--model-id", "m-1", "--environment", "production"))
+	h.Require.Contains(h.Stderr.String(), "Environment production was already active; nothing to do")
+}
+
 func Test_Model_Environment_Deactivate_Yes(t *testing.T) {
 	h := NewCommandHarness(t)
 	m := h.MockManagementAPI()
@@ -143,6 +154,17 @@ func Test_Model_Environment_Deactivate_Yes(t *testing.T) {
 		"--model-id", "m-1", "--environment", "production", "--yes"))
 	h.Require.NotNil(m.FindCall("POST", "/v1/models/m-1/environments/production/deactivate"))
 	h.Require.Contains(h.Stderr.String(), "Deactivated environment production")
+}
+
+func Test_Model_Environment_Deactivate_NoOp(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("POST", "/v1/models/m-1/environments/production/deactivate", 200,
+		map[string]any{"success": true, "no_op": true})
+
+	h.Require.NoError(h.Execute("model", "environment", "deactivate",
+		"--model-id", "m-1", "--environment", "production", "--yes"))
+	h.Require.Contains(h.Stderr.String(), "Environment production was already inactive; nothing to do")
 }
 
 func Test_Model_Environment_Deactivate_NoTTY_RequiresYes(t *testing.T) {

--- a/internal/e2e-tests/model_test.go
+++ b/internal/e2e-tests/model_test.go
@@ -30,6 +30,7 @@ func TestE2EModelLifecycle(t *testing.T) {
 	t.Run("APIInference", l.APIInference)
 	t.Run("Model", l.Model)
 	t.Run("Deployment", l.Deployment)
+	t.Run("Activate", l.Activate)
 	t.Run("Logs", l.Logs)
 	t.Run("Environment", l.Environment)
 	t.Run("ModelPredict", l.ModelPredict)
@@ -294,6 +295,32 @@ func (l *lifecycle) Deployment(t *testing.T) {
 		st, err := os.Stat(outFile)
 		require.NoError(t, err)
 		require.Greater(t, st.Size(), int64(0), "downloaded tar should be non-empty")
+	})
+}
+
+// Activate checks that activating a deployment is idempotent. The push in
+// newLifecycle left this deployment active, so every activate here is the
+// already-active case: the server reports no_op and the CLI says so rather than
+// claiming it activated anything.
+func (l *lifecycle) Activate(t *testing.T) {
+	t.Run("JSON", func(t *testing.T) {
+		out := mustCLI(t, "model", "deployment", "activate",
+			"--model-id", l.modelID, "--deployment-id", l.initialDeploymentID, "--output", "json")
+		var resp struct {
+			Success bool `json:"success"`
+			NoOp    bool `json:"no_op"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &resp))
+		require.True(t, resp.Success, "activating an active deployment should still succeed")
+		require.True(t, resp.NoOp, "activating an active deployment should be a no-op")
+	})
+
+	t.Run("Text", func(t *testing.T) {
+		out, errOut, err := cli(t, "model", "deployment", "activate",
+			"--model-id", l.modelID, "--deployment-id", l.initialDeploymentID)
+		require.NoError(t, err, "stderr: %s", errOut)
+		require.Empty(t, out, "activate writes nothing to stdout in text mode")
+		require.Contains(t, errOut, fmt.Sprintf("Deployment %s was already active", l.initialDeploymentID))
 	})
 }
 


### PR DESCRIPTION
## :rocket: What

- Text output now says "was already active/inactive; nothing to do" when activate/deactivate was a no-op, for both deployments and environments
- Help text documents that (de)activation is idempotent

Pending https://github.com/basetenlabs/baseten-go/pull/37 and need to update go.mod after that merges

## :computer: How

- Branch on the new `no_op` response field in the four activate/deactivate handlers; JSON output unchanged

## :microscope: Testing

- Unit tests for the four no-op paths
- New e2e `Activate` phase asserting an activate against the already-active deployment returns `success: true, no_op: true` and prints the no-op line