### PR TITLE
Use per-region invoke URLs for regional deployments

### DIFF
--- a/cmd/command.model_deployment.go
+++ b/cmd/command.model_deployment.go
@@ -161,7 +161,8 @@ var commandModelDeployment = Command{
 			Flags:       ModelDeploymentDescribeFlags{},
 			Output: &CommandOutput[managementapi.Deployment]{
 				TextDescription: "Field-per-line summary: ID, Name, Model, Environment (optional), " +
-					"Status, Instance (optional), Replicas, Invoke URL, Logs URL, Created, " +
+					"Status, Instance (optional), Region (only when the deployment is pinned to " +
+					"a region), Replicas, Invoke URL, Logs URL, Created, " +
 					"Backpressure, and an indented Autoscaling block covering every setting " +
 					"'update-autoscaling' can change. Settings that are unset or inherited " +
 					"show as '-'.",
@@ -184,7 +185,9 @@ var commandModelDeployment = Command{
 			Flags:       ModelDeploymentListFlags{},
 			Output: &CommandOutput[managementapi.Deployments]{
 				TextDescription: "Table with columns: ID, NAME, ENVIRONMENT, STATUS, INSTANCE, " +
-					"REPLICAS, CREATED. When no deployments exist, prints \"No deployments found.\" to stderr.",
+					"REGION (only when a deployment is pinned to a region, where unpinned ones " +
+					"read as global), REPLICAS, CREATED. When no deployments exist, prints " +
+					"\"No deployments found.\" to stderr.",
 				Examples: []CommandExample{
 					{
 						Description: "List all deployments of a model.",

--- a/internal/cmd/command.model_deployment.go
+++ b/internal/cmd/command.model_deployment.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -102,6 +103,11 @@ func commandModelDeploymentList(ctx *CommandContext, flags *cmd.ModelDeploymentL
 		ctx.LogLine("No deployments found.")
 		return nil
 	}
+	// Pinning a region is opt-in, so the column stays out until some deployment
+	// carries one, and the unpinned ones then read as global beside it.
+	showRegion := slices.ContainsFunc(resp.Deployments, func(d managementapi.Deployment) bool {
+		return d.Region != nil
+	})
 	rows := make([][]string, 0, len(resp.Deployments))
 	for _, d := range resp.Deployments {
 		env := ""
@@ -112,20 +118,26 @@ func commandModelDeploymentList(ctx *CommandContext, flags *cmd.ModelDeploymentL
 		if d.InstanceTypeName != nil {
 			instance = *d.InstanceTypeName
 		}
-		rows = append(rows, []string{
-			d.Id,
-			d.Name,
-			env,
-			string(d.Status),
-			instance,
+		row := []string{d.Id, d.Name, env, string(d.Status), instance}
+		if showRegion {
+			if d.Region != nil {
+				row = append(row, d.Region.Slug)
+			} else {
+				row = append(row, "global")
+			}
+		}
+		row = append(row,
 			fmt.Sprintf("%d", d.ActiveReplicaCount),
 			d.CreatedAt.UTC().Format(time.RFC3339),
-		})
+		)
+		rows = append(rows, row)
 	}
-	ctx.OutputTable(TableOutput{
-		Headers: []string{"ID", "NAME", "ENVIRONMENT", "STATUS", "INSTANCE", "REPLICAS", "CREATED"},
-		Rows:    rows,
-	})
+	headers := []string{"ID", "NAME", "ENVIRONMENT", "STATUS", "INSTANCE"}
+	if showRegion {
+		headers = append(headers, "REGION")
+	}
+	headers = append(headers, "REPLICAS", "CREATED")
+	ctx.OutputTable(TableOutput{Headers: headers, Rows: rows})
 	return nil
 }
 
@@ -161,8 +173,14 @@ func commandModelDeploymentDescribe(ctx *CommandContext, flags *cmd.ModelDeploym
 	if dep.InstanceTypeName != nil {
 		ctx.Outputf("Instance:     %s\n", *dep.InstanceTypeName)
 	}
+	regionSlug := ""
+	if dep.Region != nil {
+		regionSlug = dep.Region.Slug
+		ctx.Outputf("Region:       %s\n", regionSlug)
+	}
 	ctx.Outputf("Replicas:     %d\n", dep.ActiveReplicaCount)
-	ctx.Outputf("Invoke URL:   %s\n", hyperlink(ctx.Stdout, remote.PredictURL(dep.ModelId, dep.Id, dep.IsDevelopment)))
+	ctx.Outputf("Invoke URL:   %s\n", hyperlink(ctx.Stdout,
+		remote.PredictURL(dep.ModelId, dep.Id, dep.IsDevelopment, regionSlug)))
 	ctx.Outputf("Logs URL:     %s\n", hyperlink(ctx.Stdout, remote.LogsURL(dep.ModelId, dep.Id)))
 	ctx.Outputf("Created:      %s\n", dep.CreatedAt.UTC().Format(time.RFC3339))
 	ctx.Outputf("Backpressure: %s\n", backpressurePolicyText(dep.RequestBackpressureSettings.Policy))

--- a/internal/cmd/command.model_deployment_test.go
+++ b/internal/cmd/command.model_deployment_test.go
@@ -85,6 +85,64 @@ func Test_Model_Deployment_Describe(t *testing.T) {
 	h.Require.Contains(out, "ACTIVE")
 }
 
+// The region column is absent until a deployment is pinned to a region, so an
+// unpinned model's list is unchanged.
+func Test_Model_Deployment_List_NoRegionColumn(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/models/m-1/deployments", 200,
+		map[string]any{"deployments": []any{depFixture("d-1", "first", "production", "ACTIVE")}})
+
+	h.Require.NoError(h.Execute("model", "deployment", "list", "--model-id", "m-1"))
+	h.Require.NotContains(h.Stdout.String(), "REGION")
+}
+
+// One pinned deployment brings the column in for every row, where the unpinned
+// ones read as global.
+func Test_Model_Deployment_List_Region(t *testing.T) {
+	h := NewCommandHarness(t)
+	pinned := depFixture("d-1", "first", "production", "ACTIVE")
+	pinned["region"] = map[string]any{"slug": "us", "display_name": "United States"}
+	h.MockManagementAPI().SetRoute("GET", "/v1/models/m-1/deployments", 200,
+		map[string]any{"deployments": []any{pinned, depFixture("d-2", "second", "", "ACTIVE")}})
+
+	h.Require.NoError(h.Execute("model", "deployment", "list", "--model-id", "m-1"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "REGION")
+	h.Require.Contains(out, "us")
+	h.Require.Contains(out, "global")
+}
+
+// A pinned deployment is served by its per-region host, not the model's plain
+// host, so describe has to report the regional invoke URL.
+func Test_Model_Deployment_Describe_Region(t *testing.T) {
+	h := NewCommandHarness(t)
+	dep := depFixture("d-1", "first", "production", "ACTIVE")
+	dep["region"] = map[string]any{"slug": "us", "display_name": "United States"}
+	h.MockManagementAPI().SetRoute("GET", "/v1/models/m-1/deployments/d-1", 200, dep)
+
+	h.Require.NoError(h.Execute("model", "deployment", "describe",
+		"--model-id", "m-1", "--deployment-id", "d-1"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "Region:       us")
+	h.Require.Contains(out, "model-m-1-region-us.")
+	h.Require.Contains(out, "/deployment/d-1/predict")
+}
+
+// An unpinned deployment keeps the plain host, and describe omits the region
+// line rather than claiming the deployment is placed anywhere in particular.
+func Test_Model_Deployment_Describe_NoRegion(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/models/m-1/deployments/d-1", 200,
+		depFixture("d-1", "first", "production", "ACTIVE"))
+
+	h.Require.NoError(h.Execute("model", "deployment", "describe",
+		"--model-id", "m-1", "--deployment-id", "d-1"))
+	out := h.Stdout.String()
+	h.Require.NotContains(out, "Region:")
+	h.Require.NotContains(out, "-region-")
+	h.Require.Contains(out, "model-m-1.")
+}
+
 func Test_Model_Deployment_Describe_MissingDeploymentID(t *testing.T) {
 	h := NewCommandHarness(t)
 	err := h.Execute("model", "deployment", "describe", "--model-id", "m-1")

--- a/internal/cmd/command.model_environment.go
+++ b/internal/cmd/command.model_environment.go
@@ -90,7 +90,12 @@ func commandModelEnvironmentDescribe(ctx *CommandContext, flags *cmd.ModelEnviro
 	if env.CandidateDeployment != nil {
 		ctx.Outputf("Candidate Deployment: %s\n", env.CandidateDeployment.Id)
 	}
-	ctx.Outputf("Invoke URL:          %s\n", hyperlink(ctx.Stdout, remote.EnvironmentPredictURL(env.ModelId, env.Name)))
+	regionSlug := ""
+	if env.CurrentDeployment != nil && env.CurrentDeployment.Region != nil {
+		regionSlug = env.CurrentDeployment.Region.Slug
+	}
+	ctx.Outputf("Invoke URL:          %s\n", hyperlink(ctx.Stdout,
+		remote.EnvironmentPredictURL(env.ModelId, env.Name, regionSlug)))
 	if env.CurrentDeployment != nil {
 		ctx.Outputf("Logs URL:            %s\n", hyperlink(ctx.Stdout, remote.LogsURL(env.ModelId, env.CurrentDeployment.Id)))
 	}

--- a/internal/cmd/command.model_environment_test.go
+++ b/internal/cmd/command.model_environment_test.go
@@ -70,6 +70,23 @@ func Test_Model_Environment_Describe(t *testing.T) {
 	h.Require.Contains(out, "ACTIVE")
 }
 
+// Promoting a regional deployment into an environment leaves it on its
+// per-region host, so the environment's invoke URL follows the region of its
+// current deployment.
+func Test_Model_Environment_Describe_Region(t *testing.T) {
+	h := NewCommandHarness(t)
+	env := envFixture("production", "d-1", "ACTIVE")
+	dep, _ := env["current_deployment"].(map[string]any)
+	dep["region"] = map[string]any{"slug": "us", "display_name": "United States"}
+	h.MockManagementAPI().SetRoute("GET", "/v1/models/m-1/environments/production", 200, env)
+
+	h.Require.NoError(h.Execute("model", "environment", "describe",
+		"--model-id", "m-1", "--environment", "production"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "model-m-1-region-us.")
+	h.Require.Contains(out, "/environments/production/predict")
+}
+
 // Describe is the only way to read these settings back, since the update
 // commands deliberately have no per-setting describe of their own.
 func Test_Model_Environment_Describe_ShowsSettings(t *testing.T) {

--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -115,7 +115,12 @@ func commandModelPush(ctx *CommandContext, flags *cmd.ModelPushFlags) error {
 	if err != nil {
 		return err
 	}
-	predictURL := remote.PredictURL(created.Model.Id, created.Deployment.Id, created.Deployment.IsDevelopment)
+	regionSlug := ""
+	if created.Deployment.Region != nil {
+		regionSlug = created.Deployment.Region.Slug
+	}
+	predictURL := remote.PredictURL(
+		created.Model.Id, created.Deployment.Id, created.Deployment.IsDevelopment, regionSlug)
 	logsURL := remote.LogsURL(created.Model.Id, created.Deployment.Id)
 
 	// In JSON mode the human-readable output goes to stderr so stdout carries

--- a/internal/cmd/command.model_push_test.go
+++ b/internal/cmd/command.model_push_test.go
@@ -660,6 +660,29 @@ func Test_Model_Push_Develop_SetsIsDevelopment(t *testing.T) {
 	h.Require.Equal(true, dep["is_development"])
 }
 
+// A push into a region reports the per-region invoke URL, since the plain host
+// resolves to the model's default workload plane rather than the pinned one.
+func Test_Model_Push_Region(t *testing.T) {
+	h := newModelPushHarness(t)
+	h.API.SetRoute("POST", "/v1/models", 200, map[string]any{
+		"model": map[string]any{
+			"id": "model-123", "name": "test-model", "created_at": "2026-01-01T00:00:00Z",
+			"deployments_count": 1, "instance_type_name": "1x2",
+		},
+		"deployment": map[string]any{
+			"id": "deploy-456", "model_id": "model-123", "name": "v1",
+			"created": "2026-01-01T00:00:00Z", "updated": "2026-01-01T00:00:00Z",
+			"is_development": false, "status": "BUILDING",
+			"region": map[string]any{"slug": "us", "display_name": "United States"},
+		},
+	})
+
+	dir := h.WriteModelDir(modelPushMinimalConfig)
+	h.Require.NoError(h.Execute("model", "push", "--dir", dir, "--region", "us"))
+
+	h.Require.Contains(h.Stdout.String(), "model-model-123-region-us.")
+}
+
 func Test_Model_Push_WatchValidation(t *testing.T) {
 	t.Run("watch_and_environment", func(t *testing.T) {
 		h := newModelPushHarness(t)

--- a/internal/cmd/remote.go
+++ b/internal/cmd/remote.go
@@ -130,9 +130,22 @@ func (r *Remote) InferenceHostHeader(modelID, chainID, environment string) (stri
 	return host, true, nil
 }
 
+// modelInvokeBaseURL returns the base URL a model's deployments are invoked
+// through. A deployment pinned to a region is served by a per-region host,
+// which resolves to the workload plane the pinned replicas run in; the
+// model's plain host resolves to its default plane and so does not reach
+// them. regionSlug is empty for an unpinned deployment.
+func (r *Remote) modelInvokeBaseURL(modelID, regionSlug string) string {
+	host := "model-" + modelID
+	if regionSlug != "" {
+		host += "-region-" + regionSlug
+	}
+	return r.scheme + "://" + host + "." + r.managementAPIHost
+}
+
 // PredictURL returns the user-facing predict URL printed in push output.
-func (r *Remote) PredictURL(modelID, deploymentID string, isDraft bool) string {
-	base := r.scheme + "://model-" + modelID + "." + r.managementAPIHost
+func (r *Remote) PredictURL(modelID, deploymentID string, isDraft bool, regionSlug string) string {
+	base := r.modelInvokeBaseURL(modelID, regionSlug)
 	if isDraft {
 		return base + "/development/predict"
 	}
@@ -141,8 +154,11 @@ func (r *Remote) PredictURL(modelID, deploymentID string, isDraft bool) string {
 
 // EnvironmentPredictURL returns the user-facing predict URL for a model
 // environment, whose stable name selects the live deployment via the path.
-func (r *Remote) EnvironmentPredictURL(modelID, environment string) string {
-	return r.scheme + "://model-" + modelID + "." + r.managementAPIHost + "/environments/" + environment + "/predict"
+// regionSlug is the region of the environment's current deployment, since an
+// environment holding a regional deployment is invoked through that
+// deployment's per-region host.
+func (r *Remote) EnvironmentPredictURL(modelID, environment, regionSlug string) string {
+	return r.modelInvokeBaseURL(modelID, regionSlug) + "/environments/" + environment + "/predict"
 }
 
 // LogsURL returns the user-facing logs URL printed in push output.


### PR DESCRIPTION
## :rocket: What

- Regional deployments now report their per-region invoke URL
- `model deployment list` and `describe` show region

## :computer: How

- `PredictURL`/`EnvironmentPredictURL` take a region slug and emit the `-region-<slug>` host label, matching the backend's regional FQDN
- Callers read the slug off the deployment already in the response: `model push`, `model deployment describe`, and `model environment describe` (via `current_deployment`)
- `list` adds a REGION column only when some deployment is pinned, unpinned rows reading `global`; `describe` prints `Region:` when pinned

## :microscope: Testing

- Unit tests for both URL shapes across push, deployment describe, and environment describe, plus the column appearing and staying away