### PR TITLE
Sort model-api list table like the UI and show RELEASED instead of ADDED

### DIFF
--- a/cmd/command.model_api.go
+++ b/cmd/command.model_api.go
@@ -38,7 +38,7 @@ var commandModelAPI = Command{
 				"Pass --added-only to restrict to just the Model APIs the workspace has added.",
 			Flags: ModelAPIListFlags{},
 			Output: &CommandOutput[ModelAPIList]{
-				TextDescription: "Table with columns: NAME, CONTEXT, $/1M IN, $/1M OUT, ADDED. " +
+				TextDescription: "Table with columns: NAME, CONTEXT, $/1M IN, $/1M OUT, RELEASED. " +
 					"When no Model APIs match, prints \"No Model APIs found.\" to stderr.",
 				Examples: []CommandExample{
 					{

--- a/internal/cmd/command.model_api.go
+++ b/internal/cmd/command.model_api.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -51,21 +53,50 @@ func commandModelAPIList(ctx *CommandContext, flags *cmd.ModelAPIListFlags) erro
 		ctx.LogLine("No Model APIs found.")
 		return nil
 	}
+
+	// Order the table the way the workspace Model APIs page does: the Model APIs
+	// the workspace has used come first, most recently used first, then ones
+	// added but never used, then the rest of the catalog by newest release. This
+	// is presentation only, so JSON output above stays in backend order.
+	tier := func(m managementapi.ModelAPI) int {
+		switch {
+		case m.OrgDetails == nil:
+			return 2
+		case m.OrgDetails.LastUsedAt == nil:
+			return 1
+		default:
+			return 0
+		}
+	}
+	slices.SortStableFunc(items, func(a, b managementapi.ModelAPI) int {
+		if c := cmp.Compare(tier(a), tier(b)); c != 0 {
+			return c
+		}
+		// Only the used tier carries a last-used timestamp; the other two fall
+		// through to release date.
+		if a.OrgDetails != nil && a.OrgDetails.LastUsedAt != nil {
+			if c := b.OrgDetails.LastUsedAt.Compare(*a.OrgDetails.LastUsedAt); c != 0 {
+				return c
+			}
+		}
+		// ReleaseDate is a YYYY-MM-DD string, so reversed lexical order is newest first.
+		if c := cmp.Compare(b.ReleaseDate, a.ReleaseDate); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
+
 	rows := make([][]string, 0, len(items))
 	for _, m := range items {
-		added := ""
-		if m.OrgDetails != nil {
-			added = "yes"
-		}
 		rows = append(rows, []string{
 			m.Name, fmt.Sprintf("%d", m.ContextLength),
 			modelAPICurrencyString(m.CostPerMillionInputTokens),
 			modelAPICurrencyString(m.CostPerMillionOutputTokens),
-			added,
+			m.ReleaseDate,
 		})
 	}
 	ctx.OutputTable(TableOutput{
-		Headers:             []string{"NAME", "CONTEXT", "$/1M IN", "$/1M OUT", "ADDED"},
+		Headers:             []string{"NAME", "CONTEXT", "$/1M IN", "$/1M OUT", "RELEASED"},
 		Rows:                rows,
 		RightAlignedColumns: []int{1, 2, 3},
 	})
@@ -103,7 +134,7 @@ func commandModelAPIDescribe(ctx *CommandContext, flags *cmd.ModelAPIDescribeFla
 		ctx.Outputf("Rate Limits:     %s\n", modelAPIRateLimitsString(m.RateLimits))
 	}
 	if m.OrgDetails != nil {
-		ctx.Outputf("Added:           %s\n", m.OrgDetails.AddedAt.UTC().Format(time.RFC3339))
+		ctx.Outputf("First Used:      %s\n", m.OrgDetails.AddedAt.UTC().Format(time.RFC3339))
 		if m.OrgDetails.LastUsedAt != nil {
 			ctx.Outputf("Last Used:       %s\n", m.OrgDetails.LastUsedAt.UTC().Format(time.RFC3339))
 		}

--- a/internal/cmd/command.model_api_test.go
+++ b/internal/cmd/command.model_api_test.go
@@ -3,6 +3,7 @@ package cmd_test
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -44,13 +45,69 @@ func Test_ModelApi_List_Rows(t *testing.T) {
 	h.Require.Contains(out, "CONTEXT")
 	h.Require.Contains(out, "$/1M IN")
 	h.Require.Contains(out, "$/1M OUT")
+	h.Require.Contains(out, "RELEASED")
 	h.Require.Contains(out, "llama-3")
 	h.Require.Contains(out, "8192")
 	h.Require.Contains(out, "0.5")
 	h.Require.Contains(out, "1.5")
+	h.Require.Contains(out, "2025-01-01")
 	// Display name and family were dropped from the list table.
 	h.Require.NotContains(out, "DISPLAY NAME")
 	h.Require.NotContains(out, "Llama 3")
+	// The added flag column was replaced by RELEASED.
+	h.Require.NotContains(out, "ADDED")
+}
+
+func Test_ModelApi_List_SortsUsedThenAddedThenCatalog(t *testing.T) {
+	usedNewest := modelAPIFixture("used-newest", "Used Newest", "fam")
+	usedNewest["org_details"] = map[string]any{
+		"added_at": "2025-01-01T00:00:00Z", "last_used_at": "2026-05-01T00:00:00Z",
+	}
+	usedOlder := modelAPIFixture("used-older", "Used Older", "fam")
+	usedOlder["org_details"] = map[string]any{
+		"added_at": "2025-01-01T00:00:00Z", "last_used_at": "2026-01-01T00:00:00Z",
+	}
+	addedUnused := modelAPIFixture("added-never-used", "Added Never Used", "fam")
+	addedUnused["org_details"] = map[string]any{"added_at": "2025-01-01T00:00:00Z"}
+	catalogNew := modelAPIFixture("catalog-new", "Catalog New", "fam")
+	catalogNew["release_date"] = "2026-03-01"
+	catalogOld := modelAPIFixture("catalog-old", "Catalog Old", "fam")
+	catalogOld["release_date"] = "2024-03-01"
+
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis", 200, map[string]any{
+		"items":      []any{catalogOld, addedUnused, catalogNew, usedOlder, usedNewest},
+		"pagination": map[string]any{"has_more": false},
+	})
+
+	h.Require.NoError(h.Execute("model-api", "list"))
+	out := h.Stdout.String()
+	want := []string{"used-newest", "used-older", "added-never-used", "catalog-new", "catalog-old"}
+	positions := make([]int, len(want))
+	for i, name := range want {
+		positions[i] = strings.Index(out, name)
+		h.Require.NotEqual(-1, positions[i], "%s missing from table", name)
+	}
+	h.Require.IsIncreasing(positions)
+}
+
+func Test_ModelApi_List_JSONKeepsBackendOrder(t *testing.T) {
+	usedNewest := modelAPIFixture("used-newest", "Used Newest", "fam")
+	usedNewest["org_details"] = map[string]any{
+		"added_at": "2025-01-01T00:00:00Z", "last_used_at": "2026-05-01T00:00:00Z",
+	}
+	catalogOld := modelAPIFixture("catalog-old", "Catalog Old", "fam")
+
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis", 200, map[string]any{
+		"items":      []any{catalogOld, usedNewest},
+		"pagination": map[string]any{"has_more": false},
+	})
+
+	// Sorting is presentation only, so JSON stays in the order the backend sent.
+	h.Require.NoError(h.Execute("model-api", "list", "--output", "json"))
+	out := h.Stdout.String()
+	h.Require.Less(strings.Index(out, "catalog-old"), strings.Index(out, "used-newest"))
 }
 
 func Test_ModelApi_List_JSON(t *testing.T) {
@@ -130,6 +187,23 @@ func Test_ModelApi_Describe_Text(t *testing.T) {
 	h.Require.Contains(out, "8192")
 	h.Require.Contains(out, "$0.5 / 1M tokens")
 	h.Require.Contains(out, "100 per minute (requests)")
+}
+
+func Test_ModelApi_Describe_TextOrgDetails(t *testing.T) {
+	h := NewCommandHarness(t)
+	fixture := modelAPIFixture("llama-3", "Llama 3", "llama")
+	fixture["org_details"] = map[string]any{
+		"added_at": "2025-02-03T04:05:06Z", "last_used_at": "2026-02-03T04:05:06Z",
+	}
+	h.MockManagementAPI().SetRoute("GET", "/v1/model_apis/llama-3", 200, fixture)
+
+	h.Require.NoError(h.Execute("model-api", "describe", "--model", "llama-3"))
+	out := h.Stdout.String()
+	// added_at is when the workspace first invoked the Model API, so it reads as
+	// first use rather than an explicit add.
+	h.Require.Contains(out, "First Used:      2025-02-03T04:05:06Z")
+	h.Require.Contains(out, "Last Used:       2026-02-03T04:05:06Z")
+	h.Require.NotContains(out, "Added:")
 }
 
 func Test_ModelApi_Describe_JSON(t *testing.T) {


### PR DESCRIPTION
## :rocket: What

- `model-api list` now orders the table like the workspace Model APIs page: used first (most recently used first), then added-but-never-used, then the rest of the catalog by newest release.
- `ADDED` column replaced with `RELEASED`; `describe` renames `Added:` to `First Used:`.

## :computer: How

- Sort the aggregated list client-side, after the JSON branch, so `--output json` keeps backend order.
- `added_at` is set lazily during inference authz, so it reads as first use rather than an explicit add.

## :microscope: Testing

- New unit tests for the sort tiers, JSON keeping backend order, and the `First Used:` label.
- Verified against a real workspace; table renders at 82 columns.