### PR TITLE
Wrap long examples, fix --output parse on error, lots of help hints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 - Files: `command.<name>.go` where `<name>` is the top-level subcommand (`command.api.go` covers all `api` subcommands); split only when a group grows large.
 - Public (`cmd/`): a `Command` struct plus a flags struct embedding `CommandFlags`. Declare flags via struct tags (`flag`, `short`, `desc`, `default`, `enum`, `required`).
 - Every leaf (no `Children`) must declare an `Output` (`*CommandOutput[T]`) with `TextDescription`, at least one `Examples` entry, and a `JQExample` that includes `--jq`. Use `JSONAny` for free-shape JSON, `JSONUndefined` for raw passthrough; set `JSONArrayStreamed: true` for commands that emit a stream of records.
+- An example that does not fit help's width is rejected at build time. Split it into `CommandLines` (instead of `Command`) at argument boundaries, never inside a quoted argument; help adds the trailing `\` and the indent.
 - Use `ctx.Output*` for stdout, `ctx.Log*` (or `VerboseLog*` behind `--verbose`) for stderr; never mix the two. `--output` controls stdout only.
 - Return typed errors (`cmd.NewErrUsage`/`NewErrAuth`/...) so the framework maps them to the right exit code. New exit codes go in `Command.Errors` via `ErrorDescOf[*ErrFoo]()`.
 - Under `--output json`/`jsonl` the framework writes a `cmd.JSONErrorEnvelope` to stdout for a failed command, in addition to the stderr message. Call `ctx.SuppressJSONError()` before returning if the payload already written reports the failure itself.

--- a/cmd/command.loops.go
+++ b/cmd/command.loops.go
@@ -215,7 +215,10 @@ var commandLoopsCheckpoint = Command{
 				},
 				JQExample: CommandExample{
 					Description: "Print the deployable checkpoint names.",
-					Command:     "baseten loops checkpoint list --run-id <run-id> --jq '.checkpoints[] | select(.target != \"trainer\") | .checkpoint_id'",
+					CommandLines: []string{
+						"baseten loops checkpoint list --run-id <run-id>",
+						"--jq '.checkpoints[] | select(.target != \"trainer\") | .checkpoint_id'",
+					},
 				},
 			},
 		},
@@ -285,10 +288,10 @@ type LoopsRunRefFlags struct {
 type LoopsRunCreateFlags struct {
 	CommandFlags
 
-	BaseModel string `flag:"base-model" desc:"HuggingFace ID of the base model to fine-tune (for example 'Qwen/Qwen3-8B')." required:"true"`
+	BaseModel string `flag:"base-model" desc:"HuggingFace ID of the base model to fine-tune (for example 'Qwen/Qwen3-8B'). Supported models are listed at https://docs.baseten.co/loops/supported-models." required:"true"`
 	Name      string `flag:"name" desc:"Display name for the run. Defaults to the base model."`
 	Replicas  int    `flag:"replicas" desc:"Number of data-parallel trainer replicas. The trainer deployment runs this many copies of the model's preset node group, so --replicas 4 on a 4-node preset provisions 16 nodes. Defaults to 1."`
-	Team      string `flag:"team" desc:"Team name or ID that owns the run's infrastructure. Defaults to the organization's default team."`
+	Team      string `flag:"team" desc:"Team name or ID that owns the run's infrastructure. Defaults to the organization's default team. Run 'baseten org team list' to see teams."`
 }
 
 // LoopsRunListFlags configures `baseten loops run list`.
@@ -402,7 +405,7 @@ type LoopsCheckpointListFlags struct {
 type LoopsCheckpointFilesFlags struct {
 	CommandFlags
 
-	CheckpointID string `flag:"checkpoint-id" desc:"ID of the Loops checkpoint." required:"true"`
+	CheckpointID string `flag:"checkpoint-id" desc:"ID of the Loops checkpoint. Run 'baseten loops checkpoint list' to see checkpoints." required:"true"`
 }
 
 // LoopsCheckpointDeployFlags configures `baseten loops checkpoint deploy`.
@@ -412,7 +415,7 @@ type LoopsCheckpointDeployFlags struct {
 
 	RunID        string   `flag:"run-id" desc:"Loops run whose checkpoints are deployed. Cannot be combined with --checkpoint-id."`
 	Checkpoint   []string `flag:"checkpoint" desc:"Name of a checkpoint to deploy, for example 'step-50'. Requires --run-id, since names are scoped to a run. Cannot be combined with --checkpoint-id or --config. Repeatable."`
-	CheckpointID []string `flag:"checkpoint-id" desc:"ID of a checkpoint to deploy. Cannot be combined with --run-id, --checkpoint, or --config. Repeatable."`
-	Config       string   `flag:"config" desc:"Python file defining a DeployCheckpointsConfig: which checkpoints deploy and the model that serves them. Cannot be combined with --checkpoint or --checkpoint-id."`
+	CheckpointID []string `flag:"checkpoint-id" desc:"ID of a checkpoint to deploy. Cannot be combined with --run-id, --checkpoint, or --config. Repeatable. Run 'baseten loops checkpoint list' to see checkpoints."`
+	Config       string   `flag:"config" desc:"Python file defining a DeployCheckpointsConfig: which checkpoints deploy and the model that serves them. Cannot be combined with --checkpoint or --checkpoint-id. The type is documented at https://docs.baseten.co/reference/sdk/training#deploycheckpointsconfig."`
 	DryRun       bool     `flag:"dry-run" desc:"Print the generated model config without deploying anything."`
 }

--- a/cmd/command.model.go
+++ b/cmd/command.model.go
@@ -312,7 +312,7 @@ type ModelPushFlags struct {
 
 	DryRun bool `flag:"dry-run" desc:"Validate the push and request upload credentials without uploading or creating anything."`
 
-	Environment    string `flag:"environment" desc:"Stable environment to push to."`
+	Environment    string `flag:"environment" desc:"Stable environment to push to. Run 'baseten model environment list' to see a model's environments."`
 	DeploymentName string `flag:"deployment-name" desc:"Human-readable name for the new deployment."`
 	Region         string `flag:"region" desc:"Slug of the region to deploy the model in. Defaults to a region Baseten selects."`
 
@@ -374,12 +374,12 @@ type ModelPredictFlags struct {
 	CommandFlags
 	ModelRefFlags
 
-	Environment    string `flag:"environment" desc:"Environment to target (e.g. production, development). Defaults to production. Mutually exclusive with --deployment-id, --deployment-name, and --regional."`
+	Environment    string `flag:"environment" desc:"Environment to target (e.g. production, development). Defaults to production. Mutually exclusive with --deployment-id, --deployment-name, and --regional. Run 'baseten model environment list' to see a model's environments."`
 	DeploymentID   string `flag:"deployment-id" desc:"Specific deployment to target. Mutually exclusive with --environment, --deployment-name, and --regional."`
 	DeploymentName string `flag:"deployment-name" desc:"Name of the deployment to target. Mutually exclusive with --environment, --deployment-id, and --regional."`
 	Regional       string `flag:"regional" desc:"Regional environment name; routes via the regional hostname. Mutually exclusive with --environment, --deployment-id, and --deployment-name."`
 
-	Data string `flag:"data" desc:"Inline JSON request body." oneof:"predict-input"`
+	Data string `flag:"data" desc:"Inline JSON request body. The shape is the deployed model's own input schema; see https://docs.baseten.co/inference/calling-your-model." oneof:"predict-input"`
 	File string `flag:"file" desc:"Path to a JSON file containing the request body. Use '-' for stdin." oneof:"predict-input"`
 
 	Websocket bool `flag:"websocket" desc:"Use the WebSocket predict endpoint. Sends the body as one frame, reads one frame back, then closes. Not for multi-message or back-and-forth sessions."`

--- a/cmd/command.model_api.go
+++ b/cmd/command.model_api.go
@@ -84,7 +84,10 @@ var commandModelAPI = Command{
 					},
 					{
 						Description: "Send a full OpenAI-shaped body and stream it as JSONL.",
-						Command:     `baseten model-api predict --model <name> --data '{"model":"<name>","messages":[{"role":"user","content":"hi"}],"stream":true}' --output jsonl`,
+						CommandLines: []string{
+							`baseten model-api predict --model <name>`,
+							`--data '{"model":"<name>","messages":[{"role":"user","content":"hi"}],"stream":true}' --output jsonl`,
+						},
 					},
 				},
 				JQExample: CommandExample{
@@ -189,6 +192,6 @@ type ModelAPIPredictFlags struct {
 	Model string `flag:"model" desc:"Name of the Model API. Required with --content, where it sets the request's model." `
 
 	Content string `flag:"content" desc:"Single user message; builds an OpenAI chat-completions request and prints the assistant's reply. Only valid for OpenAI chat URLs and requires --model." oneof:"predict-input"`
-	Data    string `flag:"data" desc:"Inline request body, sent verbatim." oneof:"predict-input"`
+	Data    string `flag:"data" desc:"Inline request body, sent verbatim. The accepted shapes are documented at https://docs.baseten.co/inference/model-apis/overview." oneof:"predict-input"`
 	File    string `flag:"file" desc:"Path to a file containing the request body, sent verbatim. Use '-' for stdin." oneof:"predict-input"`
 }

--- a/cmd/command.model_deployment.go
+++ b/cmd/command.model_deployment.go
@@ -106,7 +106,10 @@ var commandModelDeployment = Command{
 				},
 				JQExample: CommandExample{
 					Description: "Print just the destination path.",
-					Command:     "baseten model deployment download --model-id <model-id> --deployment-id <deployment-id> --out-file model.tar --jq '.out_file'",
+					CommandLines: []string{
+						"baseten model deployment download --model-id <model-id> --deployment-id <deployment-id>",
+						"--out-file model.tar --jq '.out_file'",
+					},
 				},
 			},
 		},
@@ -130,7 +133,10 @@ var commandModelDeployment = Command{
 					},
 					{
 						Description: "Promote to a non-production environment using the deployment's own instance type.",
-						Command:     "baseten model deployment promote --model-id <model-id> --deployment-id <deployment-id> --environment staging --override-env-instance-type --yes",
+						CommandLines: []string{
+							"baseten model deployment promote --model-id <model-id> --deployment-id <deployment-id>",
+							"--environment staging --override-env-instance-type --yes",
+						},
 					},
 				},
 				JQExample: CommandExample{
@@ -233,7 +239,10 @@ var commandModelDeployment = Command{
 				},
 				JQExample: CommandExample{
 					Description: "Stream just the log messages as a JSONL stream.",
-					Command:     "baseten model deployment logs --model-id <model-id> --deployment-id <deployment-id> --output jsonl --jq '.message'",
+					CommandLines: []string{
+						"baseten model deployment logs --model-id <model-id> --deployment-id <deployment-id>",
+						"--output jsonl --jq '.message'",
+					},
 				},
 			},
 		},
@@ -260,7 +269,11 @@ var commandModelDeployment = Command{
 					},
 					{
 						Description: "Summarize request volume and latency over the last hour.",
-						Command:     "baseten model deployment metrics --model-id <model-id> --deployment-id <deployment-id> --mode summary --since 1h --metric baseten_inference_requests_total --metric baseten_end_to_end_response_time_seconds",
+						CommandLines: []string{
+							"baseten model deployment metrics --model-id <model-id> --deployment-id <deployment-id>",
+							"--mode summary --since 1h --metric baseten_inference_requests_total",
+							"--metric baseten_end_to_end_response_time_seconds",
+						},
 					},
 					{
 						Description: "Plot a series over the last 6 hours.",
@@ -269,7 +282,10 @@ var commandModelDeployment = Command{
 				},
 				JQExample: CommandExample{
 					Description: "Print the metric names returned.",
-					Command:     "baseten model deployment metrics --model-id <model-id> --deployment-id <deployment-id> --jq '.metric_descriptors[].name'",
+					CommandLines: []string{
+						"baseten model deployment metrics --model-id <model-id> --deployment-id <deployment-id>",
+						"--jq '.metric_descriptors[].name'",
+					},
 				},
 			},
 		},
@@ -291,7 +307,10 @@ var commandModelDeployment = Command{
 				},
 				JQExample: CommandExample{
 					Description: "Print the deployment's new name.",
-					Command:     "baseten model deployment rename --model-id <model-id> --deployment-id <deployment-id> --new-name canary --jq '.name'",
+					CommandLines: []string{
+						"baseten model deployment rename --model-id <model-id> --deployment-id <deployment-id>",
+						"--new-name canary --jq '.name'",
+					},
 				},
 			},
 		},
@@ -302,23 +321,34 @@ var commandModelDeployment = Command{
 				"Only the flags you pass are changed; every other setting is left alone. " +
 				"Changes are applied asynchronously, so the response reports whether the " +
 				"request was accepted rather than the settled state.\n\n" +
-				"Run 'baseten model deployment describe' to see the current values.",
+				"Run 'baseten model deployment describe' to see the current values. How the " +
+				"settings drive scaling is documented at " +
+				"https://docs.baseten.co/deployment/autoscaling/overview.",
 			Flags: ModelDeploymentUpdateAutoscalingFlags{},
 			Output: &CommandOutput[managementapi.UpdateAutoscalingSettingsResponse]{
 				TextDescription: "The status of the request followed by the server's message.",
 				Examples: []CommandExample{
 					{
 						Description: "Raise a deployment's replica bounds.",
-						Command:     "baseten model deployment update-autoscaling --model-id <model-id> --deployment-id <deployment-id> --min-replica 2 --max-replica 10",
+						CommandLines: []string{
+							"baseten model deployment update-autoscaling --model-id <model-id> --deployment-id <deployment-id>",
+							"--min-replica 2 --max-replica 10",
+						},
 					},
 					{
 						Description: "Shorten the scale-down delay, leaving every other setting unchanged.",
-						Command:     "baseten model deployment update-autoscaling --model-id <model-id> --deployment-id <deployment-id> --scale-down-delay 60",
+						CommandLines: []string{
+							"baseten model deployment update-autoscaling --model-id <model-id> --deployment-id <deployment-id>",
+							"--scale-down-delay 60",
+						},
 					},
 				},
 				JQExample: CommandExample{
 					Description: "Print just the status.",
-					Command:     "baseten model deployment update-autoscaling --model-id <model-id> --deployment-id <deployment-id> --min-replica 2 --jq '.status'",
+					CommandLines: []string{
+						"baseten model deployment update-autoscaling --model-id <model-id> --deployment-id <deployment-id>",
+						"--min-replica 2 --jq '.status'",
+					},
 				},
 			},
 		},
@@ -334,16 +364,25 @@ var commandModelDeployment = Command{
 				Examples: []CommandExample{
 					{
 						Description: "Reject requests once the queue is full.",
-						Command:     "baseten model deployment update-request-backpressure --model-id <model-id> --deployment-id <deployment-id> --policy reject-on-full",
+						CommandLines: []string{
+							"baseten model deployment update-request-backpressure --model-id <model-id>",
+							"--deployment-id <deployment-id> --policy reject-on-full",
+						},
 					},
 					{
 						Description: "Clear the policy.",
-						Command:     "baseten model deployment update-request-backpressure --model-id <model-id> --deployment-id <deployment-id> --policy null",
+						CommandLines: []string{
+							"baseten model deployment update-request-backpressure --model-id <model-id>",
+							"--deployment-id <deployment-id> --policy null",
+						},
 					},
 				},
 				JQExample: CommandExample{
 					Description: "Print the resulting policy.",
-					Command:     "baseten model deployment update-request-backpressure --model-id <model-id> --deployment-id <deployment-id> --policy reject-on-full --jq '.policy'",
+					CommandLines: []string{
+						"baseten model deployment update-request-backpressure --model-id <model-id>",
+						"--deployment-id <deployment-id> --policy reject-on-full --jq '.policy'",
+					},
 				},
 			},
 		},

--- a/cmd/command.model_deployment_replica.go
+++ b/cmd/command.model_deployment_replica.go
@@ -21,12 +21,18 @@ var commandModelDeploymentReplica = Command{
 				Examples: []CommandExample{
 					{
 						Description: "Terminate a replica without the confirmation prompt.",
-						Command:     "baseten model deployment replica terminate --model-id <model-id> --deployment-id <deployment-id> --replica-id <replica-id> --yes",
+						CommandLines: []string{
+							"baseten model deployment replica terminate --model-id <model-id>",
+							"--deployment-id <deployment-id> --replica-id <replica-id> --yes",
+						},
 					},
 				},
 				JQExample: CommandExample{
 					Description: "Print just the success flag.",
-					Command:     "baseten model deployment replica terminate --model-id <model-id> --deployment-id <deployment-id> --replica-id <replica-id> --yes --jq '.success'",
+					CommandLines: []string{
+						"baseten model deployment replica terminate --model-id <model-id>",
+						"--deployment-id <deployment-id> --replica-id <replica-id> --yes --jq '.success'",
+					},
 				},
 			},
 		},

--- a/cmd/command.model_environment.go
+++ b/cmd/command.model_environment.go
@@ -153,7 +153,11 @@ var commandModelEnvironment = Command{
 					},
 					{
 						Description: "Summarize request volume and latency over the last hour.",
-						Command:     "baseten model environment metrics --model-id <model-id> --environment production --mode summary --since 1h --metric baseten_inference_requests_total --metric baseten_end_to_end_response_time_seconds",
+						CommandLines: []string{
+							"baseten model environment metrics --model-id <model-id> --environment production",
+							"--mode summary --since 1h --metric baseten_inference_requests_total",
+							"--metric baseten_end_to_end_response_time_seconds",
+						},
 					},
 					{
 						Description: "Plot a series over the last 6 hours.",
@@ -162,7 +166,10 @@ var commandModelEnvironment = Command{
 				},
 				JQExample: CommandExample{
 					Description: "Print the metric names returned.",
-					Command:     "baseten model environment metrics --model-id <model-id> --environment production --jq '.metric_descriptors[].name'",
+					CommandLines: []string{
+						"baseten model environment metrics --model-id <model-id> --environment production",
+						"--jq '.metric_descriptors[].name'",
+					},
 				},
 			},
 		},
@@ -172,19 +179,27 @@ var commandModelEnvironment = Command{
 			Description: "Update an environment's autoscaling settings, which apply to whichever " +
 				"deployment currently serves it.\n\n" +
 				"Only the flags you pass are changed; every other setting is left alone.\n\n" +
-				"Run 'baseten model environment describe' to see the current values.",
+				"Run 'baseten model environment describe' to see the current values. How the " +
+				"settings drive scaling is documented at " +
+				"https://docs.baseten.co/deployment/autoscaling/overview.",
 			Flags: ModelEnvironmentUpdateAutoscalingFlags{},
 			Output: &CommandOutput[managementapi.UpdateEnvironmentResponse]{
 				TextDescription: "On success, prints \"Updated autoscaling settings for environment <name>\" to stderr; no stdout output.",
 				Examples: []CommandExample{
 					{
 						Description: "Raise the production environment's replica bounds.",
-						Command:     "baseten model environment update-autoscaling --model-id <model-id> --environment production --min-replica 2 --max-replica 10",
+						CommandLines: []string{
+							"baseten model environment update-autoscaling --model-id <model-id> --environment production",
+							"--min-replica 2 --max-replica 10",
+						},
 					},
 				},
 				JQExample: CommandExample{
 					Description: "Print the environment's resulting minimum replica count.",
-					Command:     "baseten model environment update-autoscaling --model-id <model-id> --environment production --min-replica 2 --jq '.environment.autoscaling_settings.min_replica'",
+					CommandLines: []string{
+						"baseten model environment update-autoscaling --model-id <model-id> --environment production",
+						"--min-replica 2 --jq '.environment.autoscaling_settings.min_replica'",
+					},
 				},
 			},
 		},
@@ -203,7 +218,10 @@ var commandModelEnvironment = Command{
 				Examples: []CommandExample{
 					{
 						Description: "Turn on rolling deploys and scale the outgoing deployment to zero.",
-						Command:     "baseten model environment update-promotion --model-id <model-id> --environment production --rolling-deploy true --promotion-cleanup-strategy scale-to-zero",
+						CommandLines: []string{
+							"baseten model environment update-promotion --model-id <model-id> --environment production",
+							"--rolling-deploy true --promotion-cleanup-strategy scale-to-zero",
+						},
 					},
 					{
 						Description: "Slow the rollout by lowering the surge percentage.",
@@ -212,7 +230,11 @@ var commandModelEnvironment = Command{
 				},
 				JQExample: CommandExample{
 					Description: "Print the resulting cleanup strategy.",
-					Command:     "baseten model environment update-promotion --model-id <model-id> --environment production --rolling-deploy true --jq '.environment.promotion_settings.promotion_cleanup_strategy'",
+					CommandLines: []string{
+						"baseten model environment update-promotion --model-id <model-id> --environment production",
+						"--rolling-deploy true",
+						"--jq '.environment.promotion_settings.promotion_cleanup_strategy'",
+					},
 				},
 			},
 		},
@@ -228,16 +250,26 @@ var commandModelEnvironment = Command{
 				Examples: []CommandExample{
 					{
 						Description: "Reject requests once the queue is full.",
-						Command:     "baseten model environment update-request-backpressure --model-id <model-id> --environment production --policy reject-on-full",
+						CommandLines: []string{
+							"baseten model environment update-request-backpressure --model-id <model-id>",
+							"--environment production --policy reject-on-full",
+						},
 					},
 					{
 						Description: "Clear the policy.",
-						Command:     "baseten model environment update-request-backpressure --model-id <model-id> --environment production --policy null",
+						CommandLines: []string{
+							"baseten model environment update-request-backpressure --model-id <model-id>",
+							"--environment production --policy null",
+						},
 					},
 				},
 				JQExample: CommandExample{
 					Description: "Print the resulting policy.",
-					Command:     "baseten model environment update-request-backpressure --model-id <model-id> --environment production --policy reject-on-full --jq '.environment.request_backpressure_settings.policy'",
+					CommandLines: []string{
+						"baseten model environment update-request-backpressure --model-id <model-id>",
+						"--environment production --policy reject-on-full",
+						"--jq '.environment.request_backpressure_settings.policy'",
+					},
 				},
 			},
 		},
@@ -286,7 +318,7 @@ type ModelEnvironmentUpdatePromotionFlags struct {
 // Embedded by commands that act on a specific environment.
 type ModelEnvironmentFlags struct {
 	ModelRefFlags
-	Environment string `flag:"environment" desc:"Name of the environment (e.g. production)." required:"true"`
+	Environment string `flag:"environment" desc:"Name of the environment (e.g. production). Run 'baseten model environment list' to see a model's environments." required:"true"`
 }
 
 // ModelEnvironmentListFlags configures `baseten model environment list`.

--- a/cmd/command.model_environment_autoscaling_schedule.go
+++ b/cmd/command.model_environment_autoscaling_schedule.go
@@ -27,23 +27,38 @@ var commandModelEnvironmentAutoscalingSchedule = Command{
 				"timezone is shared by the whole collection and has no default. Afterwards it " +
 				"is optional and must match the existing one; use 'update-settings' to change " +
 				"it for every schedule at once.\n\n" +
-				"Run 'baseten model environment describe' to see the current values.",
+				"Run 'baseten model environment describe' to see the current values. Scheduled " +
+				"scaling is documented at https://docs.baseten.co/deployment/autoscaling/schedules.",
 			Flags: ModelEnvironmentAutoscalingScheduleCreateFlags{},
 			Output: &CommandOutput[managementapi.UpdateEnvironmentResponse]{
 				TextDescription: "On success, prints \"Created autoscaling schedule <name>\" to stderr; no stdout output.",
 				Examples: []CommandExample{
 					{
 						Description: "Scale up on weekday mornings.",
-						Command:     "baseten model environment autoscaling-schedule create --model-id <model-id> --environment production --name weekday-peak --cadence daily --weekdays monday,tuesday,wednesday,thursday,friday --start-hour 8 --start-minute 0 --end-hour 18 --end-minute 0 --timezone America/New_York --min-replica 4 --max-replica 20",
+						CommandLines: []string{
+							"baseten model environment autoscaling-schedule create --model-id <model-id> --environment production",
+							"--name weekday-peak --cadence daily --weekdays monday,tuesday,wednesday,thursday,friday",
+							"--start-hour 8 --start-minute 0 --end-hour 18 --end-minute 0 --timezone America/New_York",
+							"--min-replica 4 --max-replica 20",
+						},
 					},
 					{
 						Description: "Scale up for a one-off launch window.",
-						Command:     "baseten model environment autoscaling-schedule create --model-id <model-id> --environment production --name launch --cadence one-time --start-at 2026-09-01T08:00 --end-at 2026-09-01T20:00 --timezone America/New_York --min-replica 10 --max-replica 50",
+						CommandLines: []string{
+							"baseten model environment autoscaling-schedule create --model-id <model-id> --environment production",
+							"--name launch --cadence one-time --start-at 2026-09-01T08:00 --end-at 2026-09-01T20:00",
+							"--timezone America/New_York --min-replica 10 --max-replica 50",
+						},
 					},
 				},
 				JQExample: CommandExample{
 					Description: "Print the ids of every schedule after the create.",
-					Command:     "baseten model environment autoscaling-schedule create --model-id <model-id> --environment production --name weekday-peak --cadence daily --weekdays monday --start-minute 0 --end-minute 0 --timezone UTC --min-replica 1 --max-replica 2 --jq '.environment.autoscaling_schedules.schedules[].id'",
+					CommandLines: []string{
+						"baseten model environment autoscaling-schedule create --model-id <model-id> --environment production",
+						"--name weekday-peak --cadence daily --weekdays monday --start-minute 0 --end-minute 0",
+						"--timezone UTC --min-replica 1 --max-replica 2",
+						"--jq '.environment.autoscaling_schedules.schedules[].id'",
+					},
 				},
 			},
 		},
@@ -59,16 +74,25 @@ var commandModelEnvironmentAutoscalingSchedule = Command{
 				Examples: []CommandExample{
 					{
 						Description: "Delete a schedule by id.",
-						Command:     "baseten model environment autoscaling-schedule delete --model-id <model-id> --environment production --schedule-id <schedule-id>",
+						CommandLines: []string{
+							"baseten model environment autoscaling-schedule delete --model-id <model-id> --environment production",
+							"--schedule-id <schedule-id>",
+						},
 					},
 					{
 						Description: "Delete a schedule by name.",
-						Command:     "baseten model environment autoscaling-schedule delete --model-id <model-id> --environment production --schedule-name weekday-peak",
+						CommandLines: []string{
+							"baseten model environment autoscaling-schedule delete --model-id <model-id> --environment production",
+							"--schedule-name weekday-peak",
+						},
 					},
 				},
 				JQExample: CommandExample{
 					Description: "Print the ids that remain.",
-					Command:     "baseten model environment autoscaling-schedule delete --model-id <model-id> --environment production --schedule-id <schedule-id> --jq '.environment.autoscaling_schedules.schedules[].id'",
+					CommandLines: []string{
+						"baseten model environment autoscaling-schedule delete --model-id <model-id> --environment production",
+						"--schedule-id <schedule-id> --jq '.environment.autoscaling_schedules.schedules[].id'",
+					},
 				},
 			},
 		},
@@ -89,7 +113,10 @@ var commandModelEnvironmentAutoscalingSchedule = Command{
 				},
 				JQExample: CommandExample{
 					Description: "Print each schedule's id and name.",
-					Command:     "baseten model environment autoscaling-schedule list --model-id <model-id> --environment production --jq '.schedules[] | \"\\(.id) \\(.name)\"'",
+					CommandLines: []string{
+						"baseten model environment autoscaling-schedule list --model-id <model-id> --environment production",
+						"--jq '.schedules[] | \"\\(.id) \\(.name)\"'",
+					},
 				},
 			},
 		},
@@ -112,20 +139,34 @@ var commandModelEnvironmentAutoscalingSchedule = Command{
 				Examples: []CommandExample{
 					{
 						Description: "Raise a schedule's replica floor.",
-						Command:     "baseten model environment autoscaling-schedule update --model-id <model-id> --environment production --schedule-id <schedule-id> --min-replica 6",
+						CommandLines: []string{
+							"baseten model environment autoscaling-schedule update --model-id <model-id> --environment production",
+							"--schedule-id <schedule-id> --min-replica 6",
+						},
 					},
 					{
 						Description: "Turn a schedule off without deleting it, naming it instead of using its id.",
-						Command:     "baseten model environment autoscaling-schedule update --model-id <model-id> --environment production --schedule-name weekday-peak --enabled false",
+						CommandLines: []string{
+							"baseten model environment autoscaling-schedule update --model-id <model-id> --environment production",
+							"--schedule-name weekday-peak --enabled false",
+						},
 					},
 					{
 						Description: "Convert a recurring schedule into a one-time one.",
-						Command:     "baseten model environment autoscaling-schedule update --model-id <model-id> --environment production --schedule-name weekday-peak --cadence one-time --start-at 2026-09-01T08:00 --end-at 2026-09-01T20:00",
+						CommandLines: []string{
+							"baseten model environment autoscaling-schedule update --model-id <model-id> --environment production",
+							"--schedule-name weekday-peak --cadence one-time",
+							"--start-at 2026-09-01T08:00 --end-at 2026-09-01T20:00",
+						},
 					},
 				},
 				JQExample: CommandExample{
 					Description: "Print the resulting schedule names.",
-					Command:     "baseten model environment autoscaling-schedule update --model-id <model-id> --environment production --schedule-id <schedule-id> --min-replica 6 --jq '.environment.autoscaling_schedules.schedules[].name'",
+					CommandLines: []string{
+						"baseten model environment autoscaling-schedule update --model-id <model-id> --environment production",
+						"--schedule-id <schedule-id> --min-replica 6",
+						"--jq '.environment.autoscaling_schedules.schedules[].name'",
+					},
 				},
 			},
 		},
@@ -145,12 +186,19 @@ var commandModelEnvironmentAutoscalingSchedule = Command{
 				Examples: []CommandExample{
 					{
 						Description: "Move every schedule to a new timezone.",
-						Command:     "baseten model environment autoscaling-schedule update-settings --model-id <model-id> --environment production --timezone Europe/Berlin",
+						CommandLines: []string{
+							"baseten model environment autoscaling-schedule update-settings --model-id <model-id>",
+							"--environment production --timezone Europe/Berlin",
+						},
 					},
 				},
 				JQExample: CommandExample{
 					Description: "Print the resulting timezone.",
-					Command:     "baseten model environment autoscaling-schedule update-settings --model-id <model-id> --environment production --timezone Europe/Berlin --jq '.environment.autoscaling_schedules.timezone'",
+					CommandLines: []string{
+						"baseten model environment autoscaling-schedule update-settings --model-id <model-id>",
+						"--environment production --timezone Europe/Berlin",
+						"--jq '.environment.autoscaling_schedules.timezone'",
+					},
 				},
 			},
 		},

--- a/cmd/command.org.go
+++ b/cmd/command.org.go
@@ -402,7 +402,7 @@ type OrgAPIKeyCreateFlags struct {
 	Type     string   `flag:"type" desc:"API key category." required:"true" enum:"personal,workspace-export-metrics,workspace-invoke,workspace-manage-all,workspace-manage-api-keys"`
 	Name     string   `flag:"name" desc:"Optional human-readable name for the key."`
 	ModelIDs []string `flag:"model-id" desc:"Restrict the key to a specific model. May be repeated. Only valid with --type workspace-export-metrics or workspace-invoke."`
-	Team     string   `flag:"team" desc:"Team name or ID to create the key in. Defaults to the organization's default team."`
+	Team     string   `flag:"team" desc:"Team name or ID to create the key in. Defaults to the organization's default team. Run 'baseten org team list' to see teams."`
 }
 
 type OrgAPIKeyDeleteFlags struct {
@@ -431,14 +431,14 @@ type OrgSecretSetFlags struct {
 
 	Name  string `flag:"name" desc:"Name of the secret." required:"true"`
 	Value string `flag:"value" desc:"Secret value. Discouraged: leaks into shell history and process list. Prefer stdin or prompt."`
-	Team  string `flag:"team" desc:"Team name or ID the secret belongs to. Defaults to the organization's default team."`
+	Team  string `flag:"team" desc:"Team name or ID the secret belongs to. Defaults to the organization's default team. Run 'baseten org team list' to see teams."`
 }
 
 type OrgSecretDeleteFlags struct {
 	CommandFlags
 
 	Name string `flag:"name" desc:"Name of the secret to delete." required:"true"`
-	Team string `flag:"team" desc:"Team name or ID the secret belongs to. Defaults to the organization's default team."`
+	Team string `flag:"team" desc:"Team name or ID the secret belongs to. Defaults to the organization's default team. Run 'baseten org team list' to see teams."`
 }
 
 // AuditLogFlags is the shared query flag set for `baseten org audit-logs` and

--- a/cmd/command.train.go
+++ b/cmd/command.train.go
@@ -594,7 +594,7 @@ type TrainCapacityDescribeFlags struct {
 type TrainCapacityUpdateFlags struct {
 	CommandFlags
 
-	Team    string `flag:"team" desc:"Team name or ID whose limit changes." required:"true"`
+	Team    string `flag:"team" desc:"Team name or ID whose limit changes. Run 'baseten org team list' to see teams." required:"true"`
 	GPUType string `flag:"gpu-type" desc:"GPU type the limit applies to (for example H100)." required:"true"`
 	MaxGPUs int    `flag:"max-gpus" desc:"Maximum concurrent GPUs of this type the team may use." required:"true"`
 }
@@ -621,7 +621,7 @@ type TrainCheckpointDeployFlags struct {
 	TrussAuthFlags
 
 	JobID        string `flag:"job-id" desc:"Training job whose checkpoints are deployed. Required unless --config names them."`
-	Config       string `flag:"config" desc:"Python file defining a DeployCheckpointsConfig: which checkpoints deploy and the model that serves them."`
+	Config       string `flag:"config" desc:"Python file defining a DeployCheckpointsConfig: which checkpoints deploy and the model that serves them. The type is documented at https://docs.baseten.co/reference/sdk/training#deploycheckpointsconfig."`
 	ConfigOutDir string `flag:"config-out-dir" desc:"Directory the generated model config is written to. Defaults to a directory under ./truss_configs."`
 	DryRun       bool   `flag:"dry-run" desc:"Write the generated model config without deploying anything."`
 }
@@ -646,9 +646,9 @@ type TrainPushFlags struct {
 	Config string `flag:"config" desc:"Python file defining the training project and its job." required:"true"`
 
 	JobName string `flag:"job-name" desc:"Name for the training job. Defaults to a generated name."`
-	Team    string `flag:"team" desc:"Team name or ID that owns the training project."`
+	Team    string `flag:"team" desc:"Team name or ID that owns the training project. Run 'baseten org team list' to see teams."`
 
-	Accelerator string `flag:"accelerator" desc:"Accelerator type and count, for example 'H200:8'. Overrides the config."`
+	Accelerator string `flag:"accelerator" desc:"Accelerator type and count, for example 'H200:8'. Overrides the config. Supported hardware is documented at https://docs.baseten.co/training/concepts/basics."`
 	NodeCount   int    `flag:"node-count" desc:"Number of compute nodes. Overrides the config."`
 	Entrypoint  string `flag:"entrypoint" desc:"Command the job runs. Overrides the config."`
 	Priority    int    `flag:"priority" desc:"Queue priority. Higher values are dequeued first."`
@@ -669,7 +669,7 @@ type TrainWorkstationCreateFlags struct {
 	Image       string `flag:"image" desc:"Docker base image the workstation runs."`
 
 	Project string `flag:"project" desc:"Training project that owns the workstation. Defaults to 'workstation-<accelerator>'."`
-	Team    string `flag:"team" desc:"Team name or ID that owns the training project."`
+	Team    string `flag:"team" desc:"Team name or ID that owns the training project. Run 'baseten org team list' to see teams."`
 
 	Orchestrator string `flag:"orchestrator" desc:"Multi-node orchestrator set up across the nodes." enum:"slurm" default:"slurm"`
 

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "reflect"
+import (
+	"reflect"
+	"strings"
+)
 
 // CommandOutputSpec is the type-erased view of a leaf command's [CommandOutput].
 // Every leaf [Command] must declare an Output value implementing this interface
@@ -68,12 +71,28 @@ type JSONAny = map[string]any
 // --help-output renders it as "output shape is undefined".
 type JSONUndefined struct{}
 
-// CommandExample documents one usage of a command.
+// CommandExample documents one usage of a command. Exactly one of Command or
+// CommandLines carries the invocation.
 type CommandExample struct {
 	// Description is a one-line "what this does" preceding the command.
 	Description string
 	// Command is a literal shell line beginning with "baseten ...".
 	Command string
+	// CommandLines is Command split over multiple lines for an invocation too
+	// long to render on one. Help joins them with a trailing backslash and
+	// indents the continuations, so write each line without either. Break at
+	// argument boundaries the reader would choose, never inside a quoted
+	// argument.
+	CommandLines []string
+}
+
+// CommandString returns the example as a single shell line, whichever field
+// it was declared in. Empty when the example is unset.
+func (e CommandExample) CommandString() string {
+	if len(e.CommandLines) > 0 {
+		return strings.Join(e.CommandLines, " ")
+	}
+	return e.Command
 }
 
 func (*CommandOutput[JSONT]) JSONOutputType() reflect.Type    { return reflect.TypeFor[JSONT]() }

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -312,22 +312,33 @@ func buildCommand(def cmd.Command, parentPath string, options *ExecuteOptions) *
 }
 
 // validateOutput panics if a leaf command's Output is malformed: missing
-// examples, or a JQExample whose Command doesn't actually invoke --jq.
-// Leaves with DisableFlagParsing, or whose JSON output is marked unimportant,
-// are exempt from the JQExample requirement since --jq is not honored (or not
-// useful) for them.
+// examples, an example declaring both Command and CommandLines, or a
+// JQExample that doesn't actually invoke --jq. Leaves with
+// DisableFlagParsing, or whose JSON output is marked unimportant, are exempt
+// from the JQExample requirement since --jq is not honored (or not useful)
+// for them.
 func validateOutput(path string, def cmd.Command) {
 	if len(def.Output.ExampleList()) == 0 {
 		panic(fmt.Sprintf("command %q Output requires at least one example", path))
 	}
+	for _, ex := range append(def.Output.ExampleList(), def.Output.JQ()) {
+		if ex.Command != "" && len(ex.CommandLines) > 0 {
+			panic(fmt.Sprintf("command %q example %q declares both Command and CommandLines", path, ex.Description))
+		}
+	}
+	for _, line := range help.OverlongExampleLines(def.Output) {
+		panic(fmt.Sprintf("command %q example line would render truncated in help; shorten it, or "+
+			"for a command split it with CommandLines: %q", path, line))
+	}
 	if def.DisableFlagParsing || def.Output.JSONOutputUnimportantBool() {
 		return
 	}
-	if def.Output.JQ().Command == "" {
+	jq := def.Output.JQ().CommandString()
+	if jq == "" {
 		panic(fmt.Sprintf("command %q Output requires a JQExample", path))
 	}
-	if !strings.Contains(def.Output.JQ().Command, "--jq") {
-		panic(fmt.Sprintf("command %q JQExample.Command must invoke --jq, got %q", path, def.Output.JQ().Command))
+	if !strings.Contains(jq, "--jq") {
+		panic(fmt.Sprintf("command %q JQExample must invoke --jq, got %q", path, jq))
 	}
 }
 
@@ -437,26 +448,40 @@ func bindFlags(flags *pflag.FlagSet, val reflect.Value, metas []cmd.CommandFlag)
 }
 
 // outputFormatFromArgs returns the --output value read straight out of argv,
-// for the failures cobra rejects before it finishes parsing flags. Returns ""
-// when the invocation names no format, a typo'd value included, since there
-// is no telling what the caller meant by it. --jq counts as json only if no
-// --output follows. Shorthands combined into one arg (-vojson) are not
-// recognized.
+// for the failures cobra rejects before it finishes parsing flags. Repeats
+// follow pflag: the last value wins, and nothing after a bare -- is a flag.
+// Returns "" when the invocation names no format. A typo'd value comes back
+// as written, and so matches neither json nor jsonl: the failure gets no
+// envelope, since there is no telling what the caller meant by it. --jq counts
+// as json only when no --output appears at all. Shorthands combined into one
+// arg (-vojson) are not recognized.
 func outputFormatFromArgs(args []string) string {
-	format := ""
-	for i, arg := range args {
+	format, sawOutput, sawJQ := "", false, false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
 		switch {
 		case arg == "--output" || arg == "-o":
+			sawOutput = true
+			// A trailing --output with no value is the parse error cobra is
+			// already reporting; it names no format.
+			format = ""
 			if i+1 < len(args) {
-				return args[i+1]
+				format = args[i+1]
+				i++
 			}
 		case strings.HasPrefix(arg, "--output="):
-			return strings.TrimPrefix(arg, "--output=")
+			sawOutput, format = true, strings.TrimPrefix(arg, "--output=")
 		case strings.HasPrefix(arg, "-o"):
-			return strings.TrimPrefix(strings.TrimPrefix(arg, "-o"), "=")
+			sawOutput, format = true, strings.TrimPrefix(strings.TrimPrefix(arg, "-o"), "=")
 		case arg == "--jq" || strings.HasPrefix(arg, "--jq=") || strings.HasPrefix(arg, "-q"):
-			format = "json"
+			sawJQ = true
 		}
+	}
+	if !sawOutput && sawJQ {
+		return "json"
 	}
 	return format
 }

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -158,6 +158,34 @@ func TestJSONErrorBadOutputValueWritesStderrOnly(t *testing.T) {
 	h.Require.Contains(h.Stderr.String(), "must be one of")
 }
 
+// A parse error is rejected before flags are bound, so the format is read
+// from argv. It has to agree with pflag on repeats and on --.
+func TestJSONErrorParseErrorFormatFollowsLastOutputFlag(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		wantJSON bool
+	}{
+		{"last wins, json then none", []string{"--output", "json", "--output", "none"}, false},
+		{"last wins, none then json", []string{"--output", "none", "--output", "json"}, true},
+		{"last wins with equals form", []string{"--output=json", "-o", "text"}, false},
+		{"output after -- is not a flag", []string{"--output", "json", "--", "--output", "none"}, true},
+		{"jq implies json", []string{"--jq", ".dedicated_usage"}, true},
+		{"jq does not override an output flag", []string{"--output", "none", "--jq", ".dedicated_usage"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewCommandHarness(t)
+			h.Require.Error(h.Execute(append([]string{"org", "billing", "usage", "--bogus"}, tc.args...)...))
+			h.Require.Equal(int(cmd.ExitUsage), h.ExitCode)
+			if tc.wantJSON {
+				h.Require.Contains(decodeJSONErrorEnvelope(h).Message, "unknown flag: --bogus")
+			} else {
+				h.Require.Empty(h.Stdout.String())
+			}
+		})
+	}
+}
+
 func TestJSONErrorRootHelpDocumentsEnvelope(t *testing.T) {
 	h := NewCommandHarness(t)
 	h.Require.NoError(h.Execute("--help-output"))

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -31,7 +31,19 @@ const (
 	minSpace = 10
 	shortPad = 2
 	longPad  = 4
+	// maxTermWidth is the width help renders at when stdout is not a terminal,
+	// and the cap on a terminal's own width.
+	maxTermWidth = 120
+	// exampleIndent is the width styleExample prefixes to a continuation line
+	// (one following a line ending in a backslash or pipe).
+	exampleIndent = 2
 )
+
+// exampleCodeblockPadding is the horizontal padding render applies to the
+// examples codeblock, read from the styles rather than assumed.
+var exampleCodeblockPadding = sync.OnceValue(func() int {
+	return makeStyles(mustColorscheme(fang.AnsiColorScheme)).Codeblock.Base.GetHorizontalPadding()
+})
 
 var termWidth = sync.OnceValue(func() int {
 	if s := os.Getenv("__FANG_TEST_WIDTH"); s != "" {
@@ -40,9 +52,9 @@ var termWidth = sync.OnceValue(func() int {
 	}
 	w, _, err := term.GetSize(os.Stdout.Fd())
 	if err != nil {
-		return 120
+		return maxTermWidth
 	}
-	return min(w, 120)
+	return min(w, maxTermWidth)
 })
 
 // render writes the help text for a cobra command. exampleText is the raw

--- a/internal/help/output.go
+++ b/internal/help/output.go
@@ -16,27 +16,60 @@ import (
 
 // composeExamples produces the newline-joined example block for a leaf's
 // help. Examples come first (each prefixed with a `# Description` line),
-// followed by JQExample. Returns "" for non-leaves or for leaves with no
-// declared examples (e.g. DisableFlagParsing commands).
+// followed by JQExample. An example declaring CommandLines is emitted over
+// those lines, joined by a trailing backslash so it stays pasteable.
+// Returns "" for non-leaves or for leaves with no declared examples (e.g.
+// DisableFlagParsing commands).
 func composeExamples(spec cmd.CommandOutputSpec) string {
 	if spec == nil {
 		return ""
 	}
 	var lines []string
 	add := func(ex cmd.CommandExample) {
-		if ex.Command == "" {
+		if ex.CommandString() == "" {
 			return
 		}
 		if ex.Description != "" {
 			lines = append(lines, "# "+ex.Description)
 		}
-		lines = append(lines, ex.Command)
+		if len(ex.CommandLines) == 0 {
+			lines = append(lines, ex.Command)
+			return
+		}
+		for i, line := range ex.CommandLines {
+			if i < len(ex.CommandLines)-1 {
+				line += " \\"
+			}
+			lines = append(lines, line)
+		}
 	}
 	for _, ex := range spec.ExampleList() {
 		add(ex)
 	}
 	add(spec.JQ())
 	return strings.Join(lines, "\n")
+}
+
+// OverlongExampleLines returns the composed example lines of spec that render
+// truncated, descriptions included. The budget is the non-terminal width; a
+// narrower terminal truncates sooner and no author can target every width.
+func OverlongExampleLines(spec cmd.CommandOutputSpec) []string {
+	// Mirrors render: the codeblock is capped at the terminal width less one
+	// padding, and its content at the block width less another.
+	limit := maxTermWidth - 2*exampleCodeblockPadding()
+	var overlong []string
+	var indented bool
+	for _, line := range strings.Split(composeExamples(spec), "\n") {
+		width := len(line)
+		if indented {
+			width += exampleIndent
+		}
+		if line != "" && width > limit {
+			overlong = append(overlong, line)
+		}
+		indented = strings.HasSuffix(line, "\\") || strings.HasSuffix(line, "|")
+	}
+	return overlong
 }
 
 // renderOutputSection produces the Output section appended to --help when


### PR DESCRIPTION
## :rocket: What

- Help no longer truncates long examples (they lost the arguments a reader needs to run them).
- `--output` on a pre-parse failure (unknown flag, unknown subcommand) now follows pflag: last value wins, `--` ends flags. Previously the first value won, so `--output json --output none` emitted JSON and the reverse emitted nothing.
- Constrained flags now name a discovery command or link the authoritative docs page.

## :computer: How

- New `CommandExample.CommandLines`, mutually exclusive with `Command`: the author picks the break points, help adds the trailing `\` and continuation indent so the example stays pasteable.
- `validateOutput` rejects an example (or description) line that would render truncated, and an example declaring both fields. It runs over the whole tree on every `Execute`, so any test that runs a command enforces it.
- Converted the 38 overlong lines across `model deployment`, `model environment`, `autoscaling-schedule`, `loops`, `model-api predict`, `replica terminate`.
- `outputFormatFromArgs` assigns instead of returning early, skips the consumed value, stops at `--`, and lets `--jq` imply json only when no `--output` appears.
- Help hints: supported-models for `loops --base-model`, training hardware for `train push --accelerator`, `DeployCheckpointsConfig` for both checkpoint-deploy `--config`s, autoscaling overview/schedules for the update commands, request-body docs for both `predict --data`s, and `environment list` / `checkpoint list` / `org team list` on the flags that select those resources.

## :microscope: Testing

- New table-driven test covers `--output` repeats in both orders, the `=` form, `--`, and `--jq` with and without `--output`.
- Verified rendered help for the longest examples (`autoscaling-schedule create`, `model-api predict`, `replica terminate`) fits with nothing truncated.