### PR TITLE
Add org regions command

### DIFF
--- a/cmd/command.model.go
+++ b/cmd/command.model.go
@@ -314,7 +314,7 @@ type ModelPushFlags struct {
 
 	Environment    string `flag:"environment" desc:"Stable environment to push to."`
 	DeploymentName string `flag:"deployment-name" desc:"Human-readable name for the new deployment."`
-	Region         string `flag:"region" desc:"Slug of the region to deploy the model in. Defaults to a region Baseten selects."`
+	Region         string `flag:"region" desc:"Slug of the region to deploy the model in. Defaults to a region Baseten selects. Run 'baseten org regions' to see the slugs available."`
 
 	NoBuildCache bool   `flag:"no-build-cache" desc:"Force a full rebuild without using cached layers."`
 	Labels       string `flag:"labels" desc:"User-provided labels for the deployment as a JSON object, e.g. '{\"team\":\"ml\",\"priority\":1}'."`

--- a/cmd/command.org.go
+++ b/cmd/command.org.go
@@ -155,6 +155,33 @@ var commandOrg = Command{
 			},
 		},
 		{
+			Name:    "regions",
+			Summary: "List available deployment regions",
+			Description: "List the regions the organization can deploy models in, with the slug " +
+				"each one is selected by.\n\n" +
+				"Pass --team to list the regions available to one team instead, which may be a " +
+				"subset of the organization's.",
+			Flags: OrgRegionsFlags{},
+			Output: &CommandOutput[managementapi.Regions]{
+				TextDescription: "Table with columns: SLUG, NAME. When the organization has no " +
+					"regions, prints \"No regions found.\" to stderr.",
+				Examples: []CommandExample{
+					{
+						Description: "List the organization's regions.",
+						Command:     "baseten org regions",
+					},
+					{
+						Description: "List one team's regions.",
+						Command:     "baseten org regions --team <team>",
+					},
+				},
+				JQExample: CommandExample{
+					Description: "Print just the region slugs.",
+					Command:     "baseten org regions --jq '.regions[].slug'",
+				},
+			},
+		},
+		{
 			Name:    "secret",
 			Summary: "Manage secrets",
 			Children: []Command{
@@ -418,6 +445,12 @@ type OrgBillingUsageFlags struct {
 	Since time.Duration `flag:"since" desc:"Relative window ending now (e.g. 24h, 7d). Used when neither --start nor --end is given. Maximum 31d. Mutually exclusive with --start/--end."`
 	Start time.Time     `flag:"start" desc:"Start of the window. Accepts ISO 8601 (e.g. '2026-05-01', '2026-05-01T12:00:00Z'); values without a timezone are interpreted in the local timezone. Requires --end. Mutually exclusive with --since."`
 	End   time.Time     `flag:"end" desc:"End of the window. Accepts ISO 8601; values without a timezone are interpreted in the local timezone. Requires --start. Mutually exclusive with --since."`
+}
+
+type OrgRegionsFlags struct {
+	CommandFlags
+
+	Team string `flag:"team" desc:"List the regions available to this team by name or ID, instead of the organization's. Run 'baseten org team list' to see teams."`
 }
 
 type OrgSecretListFlags struct {

--- a/cmd/command.org.go
+++ b/cmd/command.org.go
@@ -157,8 +157,8 @@ var commandOrg = Command{
 		{
 			Name:    "regions",
 			Summary: "List available deployment regions",
-			Description: "List the regions the organization can deploy models in, with the slug " +
-				"each one is selected by.\n\n" +
+			Description: "List the regions the organization can deploy models in.\n\n" +
+				"Pass a region's slug to 'baseten model push --region'.\n\n" +
 				"Pass --team to list the regions available to one team instead, which may be a " +
 				"subset of the organization's.",
 			Flags: OrgRegionsFlags{},

--- a/internal/cmd/command.org.go
+++ b/internal/cmd/command.org.go
@@ -23,6 +23,7 @@ func init() {
 	Register("org billing usage", commandOrgBillingUsage)
 	Register("org audit-logs", commandOrgAuditLogs)
 	Register("org describe", commandOrgDescribe)
+	Register("org regions", commandOrgRegions)
 }
 
 func commandOrgBillingUsage(ctx *CommandContext, flags *cmd.OrgBillingUsageFlags) error {
@@ -497,6 +498,52 @@ func auditEnumValues[T ~string](flagName string, values, allowed []string) ([]T,
 		out = append(out, T(strings.ToUpper(strings.ReplaceAll(v, "-", "_"))))
 	}
 	return out, nil
+}
+
+func commandOrgRegions(ctx *CommandContext, flags *cmd.OrgRegionsFlags) error {
+	cl, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	var regions *managementapi.Regions
+	if flags.Team != "" {
+		teamID, err := ResolveTeam(ctx, cl.API(), flags.Team)
+		if err != nil {
+			return err
+		}
+		regions, err = cl.API().GetTeamsRegions(ctx, teamID)
+		if err != nil {
+			return fmt.Errorf("listing regions for team %q: %w", flags.Team, err)
+		}
+	} else {
+		regions, err = cl.API().GetRegions(ctx)
+		if err != nil {
+			return fmt.Errorf("listing regions: %w", err)
+		}
+	}
+	// The endpoints do not promise an order, so sort by the field callers key
+	// off of rather than letting the table shuffle between runs.
+	slices.SortFunc(regions.Regions, func(a, b managementapi.Region) int {
+		return strings.Compare(a.Slug, b.Slug)
+	})
+
+	if ctx.JSON {
+		ctx.OutputJSON(regions)
+		return nil
+	}
+	if len(regions.Regions) == 0 {
+		ctx.LogLine("No regions found.")
+		return nil
+	}
+	rows := make([][]string, 0, len(regions.Regions))
+	for _, r := range regions.Regions {
+		rows = append(rows, []string{r.Slug, r.DisplayName})
+	}
+	ctx.OutputTable(TableOutput{
+		Headers: []string{"SLUG", "NAME"},
+		Rows:    rows,
+	})
+	return nil
 }
 
 func commandOrgDescribe(ctx *CommandContext, flags *cmd.OrgDescribeFlags) error {

--- a/internal/cmd/command.org_regions_test.go
+++ b/internal/cmd/command.org_regions_test.go
@@ -29,6 +29,8 @@ func Test_Org_Regions_SortedBySlug(t *testing.T) {
 	h.Require.Contains(out, "SLUG")
 	h.Require.Contains(out, "NAME")
 	h.Require.Contains(out, "US West (Oregon)")
+	h.Require.Contains(out, "eu-central-1")
+	h.Require.Contains(out, "us-west-2")
 	h.Require.Less(strings.Index(out, "eu-central-1"), strings.Index(out, "us-west-2"))
 }
 

--- a/internal/cmd/command.org_regions_test.go
+++ b/internal/cmd/command.org_regions_test.go
@@ -1,0 +1,71 @@
+package cmd_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func Test_Org_Regions_Empty(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/regions", 200, map[string]any{"regions": []any{}})
+
+	h.Require.NoError(h.Execute("org", "regions"))
+	h.Require.Equal("", h.Stdout.String())
+	h.Require.Contains(h.Stderr.String(), "No regions found.")
+}
+
+func Test_Org_Regions_SortedBySlug(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/regions", 200, map[string]any{
+		"regions": []any{
+			map[string]any{"slug": "us-west-2", "display_name": "US West (Oregon)"},
+			map[string]any{"slug": "eu-central-1", "display_name": "Europe (Frankfurt)"},
+		},
+	})
+
+	h.Require.NoError(h.Execute("org", "regions"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "SLUG")
+	h.Require.Contains(out, "NAME")
+	h.Require.Contains(out, "US West (Oregon)")
+	h.Require.Less(strings.Index(out, "eu-central-1"), strings.Index(out, "us-west-2"))
+}
+
+func Test_Org_Regions_JSON(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", "/v1/regions", 200, map[string]any{
+		"regions": []any{map[string]any{"slug": "us-west-2", "display_name": "US West (Oregon)"}},
+	})
+
+	h.Require.NoError(h.Execute("org", "regions", "--output", "json"))
+	h.Require.Contains(h.Stdout.String(), `"slug": "us-west-2"`)
+}
+
+func Test_Org_Regions_Team(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/teams", 200, map[string]any{
+		"teams": []any{teamFixture("t1", "Engineering", true)},
+	})
+	m.SetRoute("GET", "/v1/teams/t1/regions", 200, map[string]any{
+		"regions": []any{map[string]any{"slug": "eu-central-1", "display_name": "Europe (Frankfurt)"}},
+	})
+
+	// The team name is resolved to its ID before the regions call.
+	h.Require.NoError(h.Execute("org", "regions", "--team", "Engineering"))
+	h.Require.Contains(h.Stdout.String(), "eu-central-1")
+	h.Require.NotNil(m.FindCall("GET", "/v1/teams/t1/regions"))
+}
+
+func Test_Org_Regions_Team_NotFound(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	m.SetRoute("GET", "/v1/teams", 200, map[string]any{"teams": []any{}})
+	m.SetHandlerFallback(func(_ http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected call to %s", r.URL.Path)
+	})
+
+	err := h.Execute("org", "regions", "--team", "ghost")
+	h.Require.ErrorContains(err, `no team matched "ghost"`)
+}


### PR DESCRIPTION
## :rocket: What

- Adds `baseten org regions`, listing the deployment regions available to the organization with the slug `model push --region` takes.
- `--team <name|id>` lists one team's regions instead, which can be a subset.

## :computer: How

- Leaf under `org`, named as a plural noun like `org audit-logs`, since regions have one operation and don't warrant their own group.
- No `--team`: `GetRegions`. With `--team`: existing `ResolveTeam` maps name-or-ID to a team ID, then `GetTeamsRegions`.
- Text output is a `SLUG`, `NAME` table sorted by slug, since neither endpoint promises an order; JSON is the `Regions` response verbatim. Empty prints `No regions found.` to stderr.

## :microscope: Testing

- New `Test_Org_Regions_*`: empty, slug sort order, JSON, `--team` by name resolving to `/v1/teams/t1/regions`, and an unknown team failing before any regions call.