### PR TITLE
💥Make environment creation and instance type preservation opt-in on push and promote

### DIFF
--- a/cmd/command.model.go
+++ b/cmd/command.model.go
@@ -312,9 +312,10 @@ type ModelPushFlags struct {
 
 	DryRun bool `flag:"dry-run" desc:"Validate the push and request upload credentials without uploading or creating anything."`
 
-	Environment    string `flag:"environment" desc:"Stable environment to push to. Run 'baseten model environment list' to see a model's environments."`
-	DeploymentName string `flag:"deployment-name" desc:"Human-readable name for the new deployment."`
-	Region         string `flag:"region" desc:"Slug of the region to deploy the model in. Defaults to a region Baseten selects. Run 'baseten org regions' to see the slugs available."`
+	Environment                string `flag:"environment" desc:"Stable environment to push to. Run 'baseten model environment list' to see a model's environments."`
+	CreateEnvironmentIfMissing bool   `flag:"create-environment-if-missing" desc:"Create the environment named by --environment when the model does not have it yet. Without this, pushing to an environment that does not exist fails. Only meaningful for an environment other than production, which every model has."`
+	DeploymentName             string `flag:"deployment-name" desc:"Human-readable name for the new deployment."`
+	Region                     string `flag:"region" desc:"Slug of the region to deploy the model in. Defaults to a region Baseten selects. Run 'baseten org regions' to see the slugs available."`
 
 	NoBuildCache bool   `flag:"no-build-cache" desc:"Force a full rebuild without using cached layers."`
 	Labels       string `flag:"labels" desc:"User-provided labels for the deployment as a JSON object, e.g. '{\"team\":\"ml\",\"priority\":1}'."`
@@ -331,7 +332,7 @@ type ModelPushFlags struct {
 	DeployTimeout string `flag:"deploy-timeout" desc:"Deployment timeout as a duration (e.g. 30m, 1h); allowed range 10m to 24h."`
 
 	OverrideName            string `flag:"override-name" desc:"Override the model_name from config.yaml for this push only. The on-disk config.yaml is not modified."`
-	OverrideEnvInstanceType bool   `flag:"override-env-instance-type" desc:"Use this deployment's instance type instead of preserving the target environment's. Only meaningful when an environment is targeted."`
+	PreserveEnvInstanceType bool   `flag:"preserve-env-instance-type" desc:"Keep the target environment's current instance type instead of applying the one from config.yaml. Only meaningful when an environment is targeted."`
 
 	DisableArchiveDownload bool `flag:"disable-archive-download" desc:"Disable archive download for the new model. Only valid for new models."`
 }

--- a/cmd/command.model_deployment.go
+++ b/cmd/command.model_deployment.go
@@ -132,10 +132,10 @@ var commandModelDeployment = Command{
 						Command:     "baseten model deployment promote --model-id <model-id> --deployment-id <deployment-id> --yes",
 					},
 					{
-						Description: "Promote to a non-production environment using the deployment's own instance type.",
+						Description: "Promote to a non-production environment, keeping that environment's current instance type.",
 						CommandLines: []string{
 							"baseten model deployment promote --model-id <model-id> --deployment-id <deployment-id>",
-							"--environment staging --override-env-instance-type --yes",
+							"--environment staging --preserve-env-instance-type --yes",
 						},
 					},
 				},
@@ -488,7 +488,7 @@ type ModelDeploymentPromoteFlags struct {
 	ModelDeploymentIDFlags
 
 	Environment             string `flag:"environment" desc:"Target environment name. Defaults to production." default:"production"`
-	OverrideEnvInstanceType bool   `flag:"override-env-instance-type" desc:"Use this deployment's instance type instead of preserving the target environment's."`
+	PreserveEnvInstanceType bool   `flag:"preserve-env-instance-type" desc:"Keep the target environment's current instance type instead of applying the promoted deployment's."`
 
 	Yes bool `flag:"yes" desc:"Skip the interactive confirmation prompt. Required when stdin is not a terminal."`
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.2.1-0.20260909213418-4d896c098433
+	github.com/basetenlabs/baseten-go v0.2.1-0.20260911155034-9e5d4b83893c
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.21
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
-	github.com/basetenlabs/baseten-go v0.2.1-0.20260911155034-9e5d4b83893c
+	github.com/basetenlabs/baseten-go v0.2.1-0.20260911174128-7c00cba027b9
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.2.1-0.20260909213418-4d896c098433 h1:NH3f2sJTn+mSd2jnJEMhKAyXjs7q7+dqII83Nua9X10=
-github.com/basetenlabs/baseten-go v0.2.1-0.20260909213418-4d896c098433/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260911155034-9e5d4b83893c h1:5ggxdDKbHoVIz/+U44Tgu3Y1arwjZNSukejCevJ5bX4=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260911155034-9e5d4b83893c/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/basetenlabs/baseten-go v0.2.1-0.20260911155034-9e5d4b83893c h1:5ggxdDKbHoVIz/+U44Tgu3Y1arwjZNSukejCevJ5bX4=
-github.com/basetenlabs/baseten-go v0.2.1-0.20260911155034-9e5d4b83893c/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260911174128-7c00cba027b9 h1:yCUQa5MhcpRfT8oriftp9QBomS1AjZIbfDZHJzZvLNk=
+github.com/basetenlabs/baseten-go v0.2.1-0.20260911174128-7c00cba027b9/go.mod h1:V1hYwZ/70xV0s2sZ6ZXzB/QgAXGcCf9KRX3sWEvZH/I=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=

--- a/internal/cmd/command.model_deployment.go
+++ b/internal/cmd/command.model_deployment.go
@@ -519,11 +519,12 @@ func commandModelDeploymentPromote(ctx *CommandContext, flags *cmd.ModelDeployme
 		}
 	}
 
-	preserve := !flags.OverrideEnvInstanceType
+	// Sent explicitly so the behavior is the caller's choice rather than the
+	// server default, which is the opposite of this flag's.
 	dep, err := cl.API().PostModelsEnvironmentsPromote(ctx, ref.ModelID, flags.Environment,
 		managementapi.PromoteToEnvironmentRequest{
 			DeploymentId:            ref.DeploymentID,
-			PreserveEnvInstanceType: &preserve,
+			PreserveEnvInstanceType: &flags.PreserveEnvInstanceType,
 		})
 	if err != nil {
 		return fmt.Errorf("promote deployment %s to environment %s: %w", ref.DeploymentID, flags.Environment, err)

--- a/internal/cmd/command.model_deployment_test.go
+++ b/internal/cmd/command.model_deployment_test.go
@@ -318,11 +318,11 @@ func Test_Model_Deployment_Promote_Default(t *testing.T) {
 	call := m.FindCall("POST", "/v1/models/m-1/environments/production/promote")
 	h.Require.NotNil(call)
 	h.Require.Contains(call.Body, `"deployment_id":"d-1"`)
-	h.Require.Contains(call.Body, `"preserve_env_instance_type":true`)
+	h.Require.Contains(call.Body, `"preserve_env_instance_type":false`)
 	h.Require.Contains(h.Stderr.String(), "Promoted deployment d-1 to environment production")
 }
 
-func Test_Model_Deployment_Promote_OverrideInstanceType(t *testing.T) {
+func Test_Model_Deployment_Promote_PreserveInstanceType(t *testing.T) {
 	h := NewCommandHarness(t)
 	m := h.MockManagementAPI()
 	m.SetRoute("POST", "/v1/models/m-1/environments/staging/promote", 200,
@@ -330,10 +330,10 @@ func Test_Model_Deployment_Promote_OverrideInstanceType(t *testing.T) {
 
 	h.Require.NoError(h.Execute("model", "deployment", "promote",
 		"--model-id", "m-1", "--deployment-id", "d-1",
-		"--environment", "staging", "--override-env-instance-type", "--yes"))
+		"--environment", "staging", "--preserve-env-instance-type", "--yes"))
 	call := m.FindCall("POST", "/v1/models/m-1/environments/staging/promote")
 	h.Require.NotNil(call)
-	h.Require.Contains(call.Body, `"preserve_env_instance_type":false`)
+	h.Require.Contains(call.Body, `"preserve_env_instance_type":true`)
 }
 
 func Test_Model_Deployment_Promote_NoTTY_RequiresYes(t *testing.T) {

--- a/internal/cmd/command.model_push.go
+++ b/internal/cmd/command.model_push.go
@@ -188,8 +188,9 @@ func buildModelPushOptions(ctx *CommandContext, flags *cmd.ModelPushFlags) (clie
 		EnvironmentName: flags.Environment,
 		Region:          flags.Region,
 		// --watch implies --develop: both push a development deployment.
-		IsDevelopment:           flags.Develop || flags.Watch,
-		OverrideEnvInstanceType: flags.OverrideEnvInstanceType,
+		IsDevelopment:              flags.Develop || flags.Watch,
+		PreserveEnvInstanceType:    flags.PreserveEnvInstanceType,
+		CreateEnvironmentIfMissing: flags.CreateEnvironmentIfMissing,
 		Archive: modelarchive.BuildModelArchiveOptions{
 			Dir: flags.Dir,
 			IgnoreFileProcessor: func(_ context.Context, opts modelarchive.IgnoreFileProcessorOptions) (modelarchive.IgnoreFileFunc, error) {

--- a/internal/cmd/command.model_push_test.go
+++ b/internal/cmd/command.model_push_test.go
@@ -663,6 +663,33 @@ func Test_Model_Push_Develop_SetsIsDevelopment(t *testing.T) {
 	h.Require.Equal(true, dep["is_development"])
 }
 
+// Both environment behaviors are opt-in, so a plain environment push sends them
+// off rather than leaving the server to apply its own defaults.
+func Test_Model_Push_EnvironmentFlagsDefaultOff(t *testing.T) {
+	h := newModelPushHarness(t)
+	dir := h.WriteModelDir(modelPushMinimalConfig)
+	h.Require.NoError(h.Execute("model", "push", "--dir", dir, "--environment", "staging"))
+
+	prep := h.API.FindCall("POST", "/v1/prepare_model_upload")
+	h.Require.NotNil(prep)
+	dep := prep.BodyJSON(h.T)["deployment"].(map[string]any)
+	h.Require.Equal(false, dep["preserve_env_instance_type"])
+	h.Require.Equal(false, dep["create_environment_if_missing"])
+}
+
+func Test_Model_Push_EnvironmentFlagsOptIn(t *testing.T) {
+	h := newModelPushHarness(t)
+	dir := h.WriteModelDir(modelPushMinimalConfig)
+	h.Require.NoError(h.Execute("model", "push", "--dir", dir, "--environment", "staging",
+		"--preserve-env-instance-type", "--create-environment-if-missing"))
+
+	prep := h.API.FindCall("POST", "/v1/prepare_model_upload")
+	h.Require.NotNil(prep)
+	dep := prep.BodyJSON(h.T)["deployment"].(map[string]any)
+	h.Require.Equal(true, dep["preserve_env_instance_type"])
+	h.Require.Equal(true, dep["create_environment_if_missing"])
+}
+
 // A push into a region reports the per-region invoke URL, since the plain host
 // resolves to the model's default workload plane rather than the pinned one.
 func Test_Model_Push_Region(t *testing.T) {

--- a/internal/e2e-tests/model_test.go
+++ b/internal/e2e-tests/model_test.go
@@ -781,6 +781,13 @@ func (l *lifecycle) SSH(t *testing.T) {
 }
 
 func (l *lifecycle) Redeploy(t *testing.T) {
+	// Creating the environment is opt-in, so a push naming one the model does
+	// not have is rejected. This fails at prepare, before the archive uploads.
+	missingEnv := "nope-" + randomSuffix(t)
+	_, errOut, err := cli(t, "model", "push", "--dir", l.modelDir, "--environment", missingEnv)
+	require.Error(t, err, "push to a nonexistent environment should fail; stdout was %s", errOut)
+	require.Contains(t, errOut, missingEnv)
+
 	out := mustCLI(t, "model", "push", "--dir", l.modelDir, "--environment", "production", "--wait", "--output", "json")
 	var redeploy pushedDeployment
 	require.NoError(t, json.Unmarshal([]byte(out), &redeploy))


### PR DESCRIPTION
## :rocket: What

- 💥 BREAKING BEHAVIOR CHANGE - Pushing to a non-"production" environment the model lacks now fails. A new `--create-environment-if-missing` flag on `model push` will lazily create.
- 💥 BREAKING BEHAVIOR/FLAG CHANGE - `--override-env-instance-type` becomes `--preserve-env-instance-type` on `model push` and `model deployment promote`. The environment's instance type is no longer kept by default.

This depends on on https://github.com/basetenlabs/baseten-go/pull/41 and needs to update commit hash after that is merged.

## :computer: How

- Both flags pass straight through and are always sent explicitly, so behavior does not depend on server defaults.

## :microscope: Testing

- Unit tests for both flags off and on, on push and promote.
- E2E: `Redeploy` now asserts a push to a random environment name fails.