### PR TITLE
feat(misc): add model-api costs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ The directory defaults to the current working directory and is configurable via 
 
 Omit `--tail` and pass `--since 1h` (or `--start`/`--end`) to fetch a historical window.
 
+### Viewing Model API Costs
+
+```bash
+baseten model-api costs --since 7d --group-by model
+baseten model-api costs --start 2026-09-01 --end 2026-09-08 --output json
+```
+
+Costs are daily USD subtotals and may differ from finalized invoices. Date ranges use UTC,
+with an inclusive start and exclusive end. `--since 7d` includes today and the preceding
+six UTC dates. Group or filter by model, user, API-key prefix, or service tier; use
+`baseten model-api costs --help` for all options. JSON output preserves exact decimal
+strings, and `--output jsonl` streams one bucket per day.
+
 Run `baseten --help` for more, and see [docs.baseten.co](https://docs.baseten.co) for general Baseten platform documentation.
 
 ## Building

--- a/cmd/command.model_api.go
+++ b/cmd/command.model_api.go
@@ -13,6 +13,38 @@ var commandModelAPI = Command{
 		"Authentication is via 'baseten auth login' or the BASETEN_API_KEY environment variable.",
 	Children: []Command{
 		{
+			Name:    "costs",
+			Summary: "Show daily Model APIs costs",
+			Description: "Show the workspace's Model APIs costs in USD as daily UTC buckets, " +
+				"oldest first, grouped by model unless --group-by is set.\n\n" +
+				"Defaults to the last 7 UTC calendar days, including today. --start is inclusive " +
+				"and --end is exclusive; both accept YYYY-MM-DD dates in UTC. Use --since alone " +
+				"to select whole days (e.g. 7d), including today. " +
+				"The range cannot exceed 90 days. History starts on 2026-08-05 at 20:45 UTC, " +
+				"so that first day is partial.\n\n" +
+				"Costs preserve fractional cents and may differ from finalized invoice amounts. " +
+				"Empty days are included. Every bucket is fetched, paging as needed, until " +
+				"--limit buckets are collected. For streaming, use --output jsonl.",
+			Flags: ModelAPICostsFlags{},
+			Output: &CommandOutput[ModelAPICostBucket]{
+				JSONArrayStreamed: true,
+				TextDescription: "Table with DATE, the requested grouping dimensions, and SUBTOTAL (USD), " +
+					"followed by an ALL totals row when there are multiple results. Empty days show " +
+					"(no usage). If every day is empty, prints a message to stderr instead of a table.",
+				JSONDescription: "One record per UTC day: date and results. Each subtotal is an exact " +
+					"decimal string in USD; unavailable attribution remains null.",
+				Examples: []CommandExample{
+					{Description: "Show daily costs per model for the last 7 UTC days.", Command: "baseten model-api costs"},
+					{Description: "Break costs down by user and model.", Command: "baseten model-api costs --since 7d --group-by user --group-by model"},
+					{Description: "Show costs for an explicit UTC date range.", Command: "baseten model-api costs --start 2026-09-01 --end 2026-09-08"},
+				},
+				JQExample: CommandExample{
+					Description: "Stream each day's per-model dollar costs.",
+					Command:     "baseten model-api costs --output jsonl --jq '.results[] | {model, subtotal}'",
+				},
+			},
+		},
+		{
 			Name:        "describe",
 			Summary:     "Describe a Model API",
 			Description: "Describe a single Model API by name.",
@@ -182,6 +214,37 @@ type ModelAPIUsageFlags struct {
 	// tests can force multiple pages without a full page of buckets. Zero uses
 	// the backend's maximum for the bucket width.
 	PageSize int `flag:"page-size" hidden:"true" desc:"Time buckets fetched per backend request while paging."`
+}
+
+// ModelAPICostsFlags configures `baseten model-api costs`.
+type ModelAPICostsFlags struct {
+	CommandFlags
+
+	Start string        `flag:"start" desc:"Inclusive UTC date, YYYY-MM-DD. Defaults to 7 days before --end."`
+	End   string        `flag:"end" desc:"Exclusive UTC date, YYYY-MM-DD. Defaults to tomorrow UTC to include today."`
+	Since time.Duration `flag:"since" desc:"Number of whole UTC days, including today (e.g. 7d). Mutually exclusive with --start and --end."`
+
+	GroupBy        []string `flag:"group-by" desc:"Dimension to break costs down by: api-key, user, model, service-tier. May be repeated. Defaults to model."`
+	APIKeyPrefixes []string `flag:"api-key-prefix" desc:"Only return costs for these API key prefixes. May be repeated."`
+	UserIDs        []string `flag:"user-id" desc:"Only return costs attributed to these user IDs. May be repeated."`
+	Models         []string `flag:"model" desc:"Only return costs for these models. May be repeated."`
+	ServiceTiers   []string `flag:"service-tier" desc:"Only return costs for these service tiers. May be repeated."`
+	Limit          int      `flag:"limit" desc:"Maximum number of daily buckets, paging as needed. 0 for no limit."`
+}
+
+// ModelAPICostBucket is one UTC day's Model API costs.
+type ModelAPICostBucket struct {
+	Date    string               `json:"date" jsonschema:"format=date"`
+	Results []ModelAPICostResult `json:"results"`
+}
+
+// ModelAPICostResult is a cost subtotal for one combination of dimensions.
+type ModelAPICostResult struct {
+	APIKeyPrefixes []string `json:"api_key_prefixes" jsonschema:"nullable"`
+	UserID         *string  `json:"user_id" jsonschema:"nullable"`
+	Model          *string  `json:"model" jsonschema:"nullable"`
+	ServiceTier    *string  `json:"service_tier" jsonschema:"nullable"`
+	Subtotal       string   `json:"subtotal"`
 }
 
 // ModelAPIPredictFlags configures `baseten model-api predict`.

--- a/internal/cmd/command.model_api_costs.go
+++ b/internal/cmd/command.model_api_costs.go
@@ -1,0 +1,288 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-go/client/managementapi"
+)
+
+func init() {
+	Register("model-api costs", commandModelAPICosts)
+}
+
+func commandModelAPICosts(ctx *CommandContext, flags *cmd.ModelAPICostsFlags) error {
+	query, dims, err := modelAPICostsQuery(ctx, flags)
+	if err != nil {
+		return err
+	}
+	client, err := ctx.NewManagementClient()
+	if err != nil {
+		return err
+	}
+	var writer *JSONArrayWriter
+	if ctx.JSON {
+		writer = ctx.NewJSONArrayWriter()
+		defer writer.Close()
+	}
+	table := modelAPICostsTable{dims: dims, scale: 2}
+	count := 0
+	hitLimit := false
+	seenCursors := map[string]bool{}
+pages:
+	for {
+		page, err := getModelAPICosts(ctx, client.API(), query)
+		if err != nil {
+			return fmt.Errorf("getting Model APIs costs: %w", err)
+		}
+		for i, bucket := range page.Items {
+			if ctx.JSON {
+				writer.Write(bucket)
+			} else if err := table.addBucket(bucket); err != nil {
+				return err
+			}
+			count++
+			if flags.Limit > 0 && count == flags.Limit {
+				hitLimit = page.Pagination.HasMore || i < len(page.Items)-1
+				break pages
+			}
+		}
+		if !page.Pagination.HasMore {
+			break
+		}
+		cursor := page.Pagination.Cursor
+		if cursor == nil || *cursor == "" || seenCursors[*cursor] {
+			return fmt.Errorf("getting Model APIs costs: invalid pagination cursor in response")
+		}
+		seenCursors[*cursor] = true
+		query = url.Values{"cursor": {*cursor}}
+	}
+	if !ctx.JSON {
+		if table.dataRows == 0 {
+			ctx.LogLine("No usage in the selected window.")
+		} else {
+			ctx.Logf("Window: %s through %s UTC · %d daily buckets · grouped by %s\n",
+				table.firstDate, table.lastDate, count, strings.Join(dims, ", "))
+			ctx.LogLine("Costs are in USD and may differ from finalized invoice amounts.")
+			if table.sawNull {
+				ctx.LogLine("A '-' dimension means attribution is unavailable.")
+			}
+			ctx.OutputTable(table.render())
+		}
+	}
+	if hitLimit {
+		ctx.Logf("Reached the --limit of %d buckets; more exist. Increase --limit or use --limit 0 for no limit.\n", flags.Limit)
+	}
+	return nil
+}
+
+func modelAPICostsQuery(ctx *CommandContext, flags *cmd.ModelAPICostsFlags) (url.Values, []string, error) {
+	if flags.Limit < 0 {
+		return nil, nil, cmd.NewErrUsagef("--limit must be zero (no limit) or a positive number")
+	}
+	hasSince := ctx.Command.Flags().Changed("since")
+	if hasSince && (flags.Start != "" || flags.End != "") {
+		return nil, nil, cmd.NewErrUsagef("--since cannot be combined with --start or --end")
+	}
+	const day = 24 * time.Hour
+	window := 7 * day
+	if hasSince {
+		if flags.Since <= 0 || flags.Since%day != 0 {
+			return nil, nil, cmd.NewErrUsagef("--since must be a positive whole number of days (e.g. 7d)")
+		}
+		window = flags.Since
+	}
+	end := ctx.Now().UTC().Truncate(day).Add(day)
+	if flags.End != "" {
+		var err error
+		end, err = time.Parse(time.DateOnly, flags.End)
+		if err != nil {
+			return nil, nil, cmd.NewErrUsagef("--end must be a UTC date in YYYY-MM-DD format")
+		}
+	}
+	start := end.Add(-window)
+	if flags.Start != "" {
+		var err error
+		start, err = time.Parse(time.DateOnly, flags.Start)
+		if err != nil {
+			return nil, nil, cmd.NewErrUsagef("--start must be a UTC date in YYYY-MM-DD format")
+		}
+	}
+	if !start.Before(end) {
+		return nil, nil, cmd.NewErrUsagef("--start must be earlier than --end")
+	}
+	if end.Sub(start) > 90*day {
+		return nil, nil, cmd.NewErrUsagef("cost window must be at most 90 days")
+	}
+	if start.Format(time.DateOnly) < "2026-08-05" {
+		return nil, nil, cmd.NewErrUsagef("costs are not available before 2026-08-05 UTC")
+	}
+	dims := slices.Clone(flags.GroupBy)
+	if len(dims) == 0 {
+		dims = []string{"model"}
+	}
+	query := url.Values{
+		"start_date":       {start.Format(time.DateOnly)},
+		"end_date":         {end.Format(time.DateOnly)},
+		"api_key_prefixes": flags.APIKeyPrefixes,
+		"user_ids":         flags.UserIDs,
+		"models":           flags.Models,
+		"service_tiers":    flags.ServiceTiers,
+	}
+	uniqueDims := make([]string, 0, len(dims))
+	for _, dim := range dims {
+		var wire string
+		switch dim {
+		case "api-key":
+			wire = "api_key_prefix"
+		case "user", "model", "service-tier":
+			wire = strings.ReplaceAll(dim, "-", "_")
+		default:
+			return nil, nil, cmd.NewErrUsagef("invalid --group-by %q; must be one of: api-key, user, model, service-tier", dim)
+		}
+		if !slices.Contains(uniqueDims, dim) {
+			uniqueDims = append(uniqueDims, dim)
+			query.Add("group_by", wire)
+		}
+	}
+	pageSize := 31
+	if flags.Limit > 0 {
+		pageSize = min(pageSize, flags.Limit)
+	}
+	query.Set("limit", strconv.Itoa(pageSize))
+	return query, uniqueDims, nil
+}
+
+type modelAPICostsPage struct {
+	Items      []cmd.ModelAPICostBucket          `json:"items"`
+	Pagination *managementapi.PaginationResponse `json:"pagination"`
+}
+
+func getModelAPICosts(ctx *CommandContext, client *managementapi.Client, query url.Values) (*modelAPICostsPage, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		strings.TrimRight(client.BaseURL, "/")+"/v1/billing/model_apis?"+query.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = client.Headers.Clone()
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if err != nil {
+			return nil, fmt.Errorf("reading cost error response: %w", err)
+		}
+		return nil, &managementapi.ResponseError{StatusCode: resp.StatusCode, Body: string(body)}
+	}
+	var page modelAPICostsPage
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		return nil, fmt.Errorf("decoding daily costs: %w", err)
+	}
+	if page.Items == nil || page.Pagination == nil {
+		return nil, fmt.Errorf("cost response is missing items or pagination")
+	}
+	return &page, nil
+}
+
+type modelAPICostsTable struct {
+	dims                []string
+	rows                [][]string
+	firstDate, lastDate string
+	dataRows            int
+	sawNull             bool
+	total               big.Rat
+	scale               int
+}
+
+var modelAPICostDecimal = regexp.MustCompile(`^-?[0-9]+(?:\.[0-9]+)?$`)
+
+func (t *modelAPICostsTable) addBucket(bucket cmd.ModelAPICostBucket) error {
+	if t.firstDate == "" {
+		t.firstDate = bucket.Date
+	}
+	t.lastDate = bucket.Date
+	stamp := bucket.Date
+	if len(bucket.Results) == 0 {
+		row := make([]string, len(t.dims)+2)
+		row[0], row[1] = stamp, "(no usage)"
+		t.rows = append(t.rows, row)
+	}
+	for _, result := range bucket.Results {
+		if !modelAPICostDecimal.MatchString(result.Subtotal) {
+			return fmt.Errorf("invalid cost subtotal %q for %s", result.Subtotal, bucket.Date)
+		}
+		value, ok := new(big.Rat).SetString(result.Subtotal)
+		if !ok {
+			return fmt.Errorf("invalid cost subtotal %q for %s", result.Subtotal, bucket.Date)
+		}
+		_, fractional, _ := strings.Cut(result.Subtotal, ".")
+		t.scale = max(t.scale, len(fractional))
+		t.total.Add(&t.total, value)
+		row := []string{stamp}
+		for _, dim := range t.dims {
+			var cell string
+			switch dim {
+			case "api-key":
+				cell = strings.Join(result.APIKeyPrefixes, ", ")
+			case "user":
+				cell = modelAPIUsageCell(result.UserID)
+			case "model":
+				cell = modelAPIUsageCell(result.Model)
+			case "service-tier":
+				cell = modelAPIUsageCell(result.ServiceTier)
+			default:
+				return fmt.Errorf("unhandled cost dimension %q", dim)
+			}
+			if cell == "" || cell == "-" {
+				cell = "-"
+				t.sawNull = true
+			}
+			row = append(row, cell)
+		}
+		t.rows = append(t.rows, append(row, modelAPICostMoney(value, len(fractional))))
+		t.dataRows++
+		stamp = ""
+	}
+	return nil
+}
+
+func modelAPICostMoney(value *big.Rat, scale int) string {
+	amount := value.FloatString(max(2, scale))
+	whole, fraction, _ := strings.Cut(amount, ".")
+	fraction = strings.TrimRight(fraction, "0")
+	for len(fraction) < 2 {
+		fraction += "0"
+	}
+	sign := ""
+	if strings.HasPrefix(whole, "-") {
+		sign, whole = "-", strings.TrimPrefix(whole, "-")
+	}
+	return sign + "$" + billingGroupDigits(whole) + "." + fraction
+}
+
+func (t *modelAPICostsTable) render() TableOutput {
+	headers := []string{"DATE"}
+	for _, dim := range t.dims {
+		headers = append(headers, strings.ToUpper(strings.ReplaceAll(dim, "-", " ")))
+	}
+	headers = append(headers, "SUBTOTAL (USD)")
+	if t.dataRows > 1 {
+		row := make([]string, len(headers))
+		row[0], row[len(row)-1] = "ALL", modelAPICostMoney(&t.total, t.scale)
+		t.rows = append(t.rows, row)
+	}
+	return TableOutput{Headers: headers, Rows: t.rows, RightAlignedColumns: []int{len(headers) - 1}}
+}

--- a/internal/cmd/command.model_api_costs_test.go
+++ b/internal/cmd/command.model_api_costs_test.go
@@ -1,0 +1,279 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/internal/cmd"
+)
+
+const modelAPICostsPath = "/v1/billing/model_apis"
+
+// Matches ModelApisCostsResponseV1: UTC dates, decimal-string subtotals, and
+// nullable dimensions, including a list-valued api_key_prefixes field.
+func modelAPICostBucket(date string, results ...map[string]any) map[string]any {
+	if results == nil {
+		results = []map[string]any{}
+	}
+	return map[string]any{"date": date, "results": results}
+}
+
+func modelAPICostResult(model any, subtotal string) map[string]any {
+	return map[string]any{
+		"api_key_prefixes": nil, "user_id": nil, "model": model,
+		"service_tier": nil, "subtotal": subtotal,
+	}
+}
+
+func Test_ModelApi_Costs_TableAndExactTotals(t *testing.T) {
+	h := NewCommandHarness(t)
+	// Deliberately extreme values exercise precision beyond float64's mantissa.
+	h.MockManagementAPI().SetRoute("GET", modelAPICostsPath, 200, modelAPIUsageBody(
+		modelAPICostBucket("2026-09-01", modelAPICostResult("model-a", "9007199254740992.00000123"), modelAPICostResult("model-b", "0.00000001")),
+		modelAPICostBucket("2026-09-02"),
+		modelAPICostBucket("2026-09-03", modelAPICostResult("model-a", "-0.00000002")),
+	))
+	h.Require.NoError(h.Execute("model-api", "costs"))
+	out := h.Stdout.String()
+	h.Require.Contains(out, "SUBTOTAL (USD)")
+	h.Require.Contains(out, "$9,007,199,254,740,992.00000123")
+	h.Require.Contains(out, "$0.00000001")
+	h.Require.Contains(out, "-$0.00000002")
+	h.Require.Contains(out, "(no usage)")
+	h.Require.Contains(out, "ALL")
+	h.Require.Contains(out, "$9,007,199,254,740,992.00000122")
+	h.Require.Contains(h.Stderr.String(), "2026-09-01 through 2026-09-03 UTC")
+	h.Require.Contains(h.Stderr.String(), "may differ from finalized invoice")
+}
+
+func Test_ModelApi_Costs_DimensionsAndFilters(t *testing.T) {
+	h := NewCommandHarness(t)
+	m := h.MockManagementAPI()
+	result := modelAPICostResult("model-a", "1.23")
+	result["api_key_prefixes"] = []string{"key-a"}
+	result["service_tier"] = "priority"
+	m.SetRoute("GET", modelAPICostsPath, 200, modelAPIUsageBody(modelAPICostBucket("2026-09-01", result)))
+	h.Require.NoError(h.Execute("model-api", "costs",
+		"--group-by", "api-key", "--group-by", "user", "--group-by", "model", "--group-by", "service-tier", "--group-by", "user",
+		"--api-key-prefix", "key-a", "--api-key-prefix", "key-b", "--user-id", "user-a", "--user-id", "user-b",
+		"--model", "model-a", "--model", "model-b", "--service-tier", "priority", "--service-tier", "standard"))
+	query := m.FindCall("GET", modelAPICostsPath).Query()
+	h.Require.Equal([]string{"api_key_prefix", "user", "model", "service_tier"}, query["group_by"])
+	h.Require.Equal([]string{"key-a", "key-b"}, query["api_key_prefixes"])
+	h.Require.Equal([]string{"user-a", "user-b"}, query["user_ids"])
+	h.Require.Equal([]string{"model-a", "model-b"}, query["models"])
+	h.Require.Equal([]string{"priority", "standard"}, query["service_tiers"])
+	h.Require.Contains(h.Stdout.String(), "key-a")
+	h.Require.Contains(h.Stdout.String(), "priority")
+	h.Require.Contains(h.Stderr.String(), "attribution is unavailable")
+	h.Require.NotContains(h.Stdout.String(), "ALL")
+}
+
+func Test_ModelApi_Costs_UTCWindows(t *testing.T) {
+	// The local date is September 10, while UTC is already September 11.
+	now := time.Date(2026, 9, 10, 18, 30, 0, 0, time.FixedZone("local", -7*60*60))
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		start, end string
+	}{
+		{"default", nil, "2026-09-05", "2026-09-12"},
+		{"since", []string{"--since", "3d"}, "2026-09-09", "2026-09-12"},
+		{"dates", []string{"--start", "2026-08-05", "--end", "2026-08-06"}, "2026-08-05", "2026-08-06"},
+		{"start", []string{"--start", "2026-09-01"}, "2026-09-01", "2026-09-12"},
+		{"end", []string{"--end", "2026-09-01"}, "2026-08-25", "2026-09-01"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewCommandHarness(t)
+			h.Context = cmd.WithNow(h.Context, func() time.Time { return now })
+			m := h.MockManagementAPI()
+			m.SetRoute("GET", modelAPICostsPath, 200, modelAPIUsageBody())
+			h.Require.NoError(h.Execute(append([]string{"model-api", "costs"}, tc.args...)...))
+			q := m.FindCall("GET", modelAPICostsPath).Query()
+			h.Require.Equal(tc.start, q.Get("start_date"))
+			h.Require.Equal(tc.end, q.Get("end_date"))
+			h.Require.Equal([]string{"model"}, q["group_by"])
+			h.Require.Equal("31", q.Get("limit"))
+		})
+	}
+}
+
+func Test_ModelApi_Costs_InvalidFlags(t *testing.T) {
+	for _, tc := range []struct {
+		args    []string
+		message string
+	}{
+		{[]string{"--since", "0"}, "positive whole number of days"},
+		{[]string{"--since", "12h"}, "positive whole number of days"},
+		{[]string{"--since", "-1d"}, "positive whole number of days"},
+		{[]string{"--since", "91d"}, "at most 90 days"},
+		{[]string{"--since", "7d", "--start", "2026-09-01"}, "cannot be combined"},
+		{[]string{"--since", "7d", "--end", "2026-09-01"}, "cannot be combined"},
+		{[]string{"--start", "2026-09-02", "--end", "2026-09-01"}, "earlier than"},
+		{[]string{"--start", "2026-09-01", "--end", "2026-09-01"}, "earlier than"},
+		{[]string{"--start", "2026-08-04", "--end", "2026-08-06"}, "not available before"},
+		{[]string{"--start", "2026-09-01T12:00:00Z"}, "YYYY-MM-DD"},
+		{[]string{"--end", "invalid"}, "YYYY-MM-DD"},
+		{[]string{"--group-by", "invalid"}, "invalid --group-by"},
+		{[]string{"--limit", "-1"}, "--limit must"},
+	} {
+		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
+			h := NewCommandHarness(t)
+			h.MockManagementAPI().SetHandlerFallback(func(http.ResponseWriter, *http.Request) { t.Error("unexpected HTTP request") })
+			err := h.Execute(append([]string{"model-api", "costs"}, tc.args...)...)
+			h.Require.ErrorContains(err, tc.message)
+			h.Require.Equal(2, h.ExitCode)
+		})
+	}
+}
+
+func Test_ModelApi_Costs_PagingAndOutputs(t *testing.T) {
+	for _, output := range []string{"text", "json", "jsonl", "none"} {
+		for _, limit := range []int{0, 1, 32} {
+			t.Run(fmt.Sprintf("%s/limit-%d", output, limit), func(t *testing.T) {
+				h := NewCommandHarness(t)
+				m := h.MockManagementAPI()
+				calls := 0
+				m.SetRouteFunc("GET", modelAPICostsPath, func(w http.ResponseWriter, r *http.Request) {
+					calls++
+					first := r.URL.Query().Get("cursor") == ""
+					if first {
+						pageSize := 31
+						if limit > 0 {
+							pageSize = min(pageSize, limit)
+						}
+						h.Require.Equal(fmt.Sprint(pageSize), r.URL.Query().Get("limit"))
+						buckets := make([]map[string]any, pageSize)
+						for i := range buckets {
+							date := time.Date(2026, 8, 6+i, 0, 0, 0, 0, time.UTC).Format(time.DateOnly)
+							buckets[i] = modelAPICostBucket(date, modelAPICostResult(nil, "0.0000012300"))
+						}
+						body := modelAPIUsageBody(buckets...)
+						body["pagination"] = map[string]any{"has_more": true, "cursor": "page-2"}
+						_ = json.NewEncoder(w).Encode(body)
+					} else {
+						h.Require.Equal("cursor=page-2", r.URL.RawQuery)
+						_ = json.NewEncoder(w).Encode(modelAPIUsageBody(
+							modelAPICostBucket("2026-09-06"),
+							modelAPICostBucket("2026-09-07", modelAPICostResult("model-a", "0.1")),
+						))
+					}
+				})
+				h.Require.NoError(h.Execute("model-api", "costs", "--start", "2026-08-06", "--end", "2026-09-08", "--output", output, "--limit", fmt.Sprint(limit)))
+				wantCount := 33
+				if limit > 0 {
+					wantCount = limit
+				}
+				if limit == 1 {
+					h.Require.Equal(1, calls)
+				} else {
+					h.Require.Equal(2, calls)
+				}
+				if limit > 0 {
+					h.Require.Contains(h.Stderr.String(), "Reached the --limit")
+				}
+				switch output {
+				case "json", "jsonl":
+					var buckets []map[string]any
+					if output == "json" {
+						h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &buckets))
+					} else {
+						for _, line := range strings.Split(strings.TrimSpace(h.Stdout.String()), "\n") {
+							var bucket map[string]any
+							h.Require.NoError(json.Unmarshal([]byte(line), &bucket))
+							buckets = append(buckets, bucket)
+						}
+					}
+					h.Require.Len(buckets, wantCount)
+					result := buckets[0]["results"].([]any)[0].(map[string]any)
+					h.Require.Equal("0.0000012300", result["subtotal"])
+					h.Require.Nil(result["api_key_prefixes"])
+					h.Require.Nil(result["model"])
+				case "none":
+					h.Require.Empty(h.Stdout.String())
+				case "text":
+					h.Require.Contains(h.Stdout.String(), "$0.00000123")
+				}
+			})
+		}
+	}
+}
+
+func Test_ModelApi_Costs_JQ(t *testing.T) {
+	h := NewCommandHarness(t)
+	h.MockManagementAPI().SetRoute("GET", modelAPICostsPath, 200, modelAPIUsageBody(modelAPICostBucket("2026-09-01", modelAPICostResult("model-a", "0.00000123"))))
+	h.Require.NoError(h.Execute("model-api", "costs", "--jq", ".results[].subtotal"))
+	h.Require.Contains(h.Stdout.String(), "0.00000123")
+}
+
+func Test_ModelApi_Costs_Empty(t *testing.T) {
+	for _, buckets := range [][]map[string]any{nil, {modelAPICostBucket("2026-09-01")}} {
+		t.Run(fmt.Sprint(len(buckets)), func(t *testing.T) {
+			h := NewCommandHarness(t)
+			h.MockManagementAPI().SetRoute("GET", modelAPICostsPath, 200, modelAPIUsageBody(buckets...))
+			h.Require.NoError(h.Execute("model-api", "costs"))
+			h.Require.Empty(h.Stdout.String())
+			h.Require.Contains(h.Stderr.String(), "No usage in the selected window.")
+		})
+	}
+}
+
+func Test_ModelApi_Costs_Errors(t *testing.T) {
+	t.Run("missing page fields", func(t *testing.T) {
+		h := NewCommandHarness(t)
+		h.MockManagementAPI().SetRoute("GET", modelAPICostsPath, 200, map[string]any{})
+		h.Require.ErrorContains(h.Execute("model-api", "costs"), "missing items or pagination")
+		h.Require.NotContains(h.Stderr.String(), "No usage")
+	})
+	t.Run("malformed JSON", func(t *testing.T) {
+		h := NewCommandHarness(t)
+		h.MockManagementAPI().SetRouteFunc("GET", modelAPICostsPath, func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+				t.Errorf("Authorization = %q, want Bearer test-key", got)
+			}
+			_, _ = w.Write([]byte(`{"items":`))
+		})
+		h.Require.ErrorContains(h.Execute("model-api", "costs"), "decoding daily costs")
+	})
+	t.Run("failure on later page", func(t *testing.T) {
+		h := NewCommandHarness(t)
+		h.MockManagementAPI().SetRouteFunc("GET", modelAPICostsPath, func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("cursor") != "" {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"cost query failed"}`))
+				return
+			}
+			body := modelAPIUsageBody(modelAPICostBucket("2026-09-01", modelAPICostResult("model-a", "0.123")))
+			body["pagination"] = map[string]any{"has_more": true, "cursor": "next"}
+			_ = json.NewEncoder(w).Encode(body)
+		})
+		h.Require.Error(h.Execute("model-api", "costs"))
+		h.Require.Contains(h.Stderr.String(), "cost query failed")
+		h.Require.Empty(h.Stdout.String())
+	})
+	t.Run("permission denied", func(t *testing.T) {
+		h := NewCommandHarness(t)
+		h.MockManagementAPI().SetRoute("GET", modelAPICostsPath, 403, map[string]any{"code": "PERMISSION_DENIED", "message": "Costs are not available for this organization."})
+		h.Require.Error(h.Execute("model-api", "costs", "--output", "json"))
+		h.Require.Contains(h.Stdout.String(), "PERMISSION_DENIED")
+		h.Require.Contains(h.Stderr.String(), "Costs are not available")
+	})
+	t.Run("malformed decimal", func(t *testing.T) {
+		h := NewCommandHarness(t)
+		h.MockManagementAPI().SetRoute("GET", modelAPICostsPath, 200, modelAPIUsageBody(modelAPICostBucket("2026-09-01", modelAPICostResult("model-a", "1/2"))))
+		h.Require.ErrorContains(h.Execute("model-api", "costs"), "invalid cost subtotal")
+	})
+	for _, cursor := range []any{nil, "", "repeated-cursor"} {
+		t.Run(fmt.Sprint(cursor), func(t *testing.T) {
+			h := NewCommandHarness(t)
+			body := modelAPIUsageBody(modelAPICostBucket("2026-09-01"))
+			body["pagination"] = map[string]any{"has_more": true, "cursor": cursor}
+			h.MockManagementAPI().SetRoute("GET", modelAPICostsPath, 200, body)
+			h.Require.ErrorContains(h.Execute("model-api", "costs"), "invalid pagination cursor")
+		})
+	}
+}


### PR DESCRIPTION
## :rocket: What

Add `baseten model-api costs` alongside `model-api usage` to report daily Model API costs in USD, with grouping and filtering by model, user, API-key prefix, and service tier.

```sh
baseten model-api costs --since 7d --group-by model
baseten model-api costs --start 2026-09-01 --end 2026-09-08 --output json
```

Defaults to seven UTC calendar days including today, grouped by model. Dates use an inclusive start and exclusive end; `--since` accepts whole days. Supports automatic pagination, `--limit`, JSON/JSONL, and `--jq`. Text output includes exact decimal totals and empty-day markers; costs may differ from finalized invoices.

## :computer: How

- Call `GET /v1/billing/model_apis` through the existing authenticated management client's HTTP transport. The pinned Go SDK does not expose this endpoint yet, so this change defines the cost response types locally without adding dependencies.
- Match the backend's `date`/`results` buckets, decimal-string `subtotal`, nullable attribution, and repeated filters. Map CLI `--group-by api-key` to wire `api_key_prefix` and `service-tier` to `service_tier`.
- Preserve decimal strings in JSON and use exact arithmetic for table totals. Reject invalid date ranges, malformed page envelopes, and missing or repeated pagination cursors.
- Add command help, output schema, README examples, and mock API tests. The contract is grounded in `baseten/backend/rest_api/model_apis/types.py`, `ModelApisCostsView`, and the route in `backend/rest_api/urls.py`.

## :microscope: Testing

Passed with Go 1.26.1:

- `go test ./...`
- `go mod tidy -diff` (no changes)
- `go build ./cmd/baseten`
- `git diff --check`
- Inspected `model-api costs --help` and `--help-output` from the built binary.

Tests cover UTC date boundaries, filter/group mappings, pagination and limits across output modes, null attribution, exact fractional-cent totals, negative adjustments, empty results, invalid flags, malformed responses, permission errors, and failures on subsequent pages.

All API tests use local mock servers and dummy credentials. No login or live billing request was performed; deployment availability of the endpoint remains unverified.
