### PR TITLE
feat(misc): add hidden Baseten Code command foundation

### DIFF
--- a/cmd/command.code.go
+++ b/cmd/command.code.go
@@ -72,11 +72,10 @@ type CodeHarnessFlags struct {
 
 type CodeInitFlags struct {
 	CodeOutputFlags
-	Harness   []string `flag:"harness" desc:"Harness to configure (repeatable)" enum:"codex,codex-desktop,claude-code,claude-desktop,opencode"`
-	Model     string   `flag:"model" desc:"Initial Route slug from the authenticated catalog"`
-	Label     string   `flag:"label" desc:"Installation label for a new Code credential"`
-	NoBrowser bool     `flag:"no-browser" desc:"Display device authorization URL without opening a browser"`
-	DryRun    bool     `flag:"dry-run" desc:"Preview without writing configuration or issuing credentials"`
+	Harness []string `flag:"harness" desc:"Harness to configure (repeatable)" enum:"codex,codex-desktop,claude-code,claude-desktop,opencode"`
+	Model   string   `flag:"model" desc:"Initial Route slug from the authenticated catalog"`
+	Label   string   `flag:"label" desc:"Installation label for a new Code credential"`
+	DryRun  bool     `flag:"dry-run" desc:"Preview without writing configuration or issuing credentials"`
 }
 
 type CodeSpendFlags struct {

--- a/cmd/command.code.go
+++ b/cmd/command.code.go
@@ -1,0 +1,119 @@
+package cmd
+
+// Keep every node hidden independently. Hiding a parent alone does not hide
+// children when a user explicitly completes or asks for help beneath it.
+var commandCode = Command{
+	Name: "code", Summary: "Configure Baseten Code", Hidden: true,
+	Children: []Command{
+		codeLeaf("init", "Preview or configure installed coding harnesses", CodeInitFlags{}, "", 0),
+		codeLeaf("status", "Show local Code installation status", CodeHarnessFlags{}, "", 0),
+		codeLeaf("models", "Fetch the current authenticated Route catalog", CodeHarnessFlags{}, "", 0),
+		codeLeaf("spend", "Show the current user's Code spend", CodeSpendFlags{}, "", 0),
+		codeLeaf("doctor", "Check setup; --test sends billable inference requests", CodeDoctorFlags{}, "[harness]", 1),
+		codeLeaf("sync", "Manually refresh configured harnesses from the catalog", CodeSyncFlags{}, "[harness]", 1),
+		codeLeaf("teardown", "Restore settings still owned by this installation", CodeTeardownFlags{}, "[harness]", 1),
+		codeLeaf("logout", "Revoke this installation's Code key before clearing it", CodeConfirmFlags{}, "", 0),
+		{Name: "keys", Summary: "Manage your Code keys", Hidden: true, Children: []Command{
+			codeLeaf("list", "List Code key metadata", CodeKeysListFlags{}, "", 0),
+			codeLeaf("revoke", "Revoke one Code key, or explicitly select --all", CodeKeysRevokeFlags{}, "[id]", 1),
+		}},
+		{Name: "auth", Summary: "Internal Code authentication", Hidden: true, Children: []Command{
+			{Name: "token", RawOutput: true, Summary: "Print only this installation's Code credential", Hidden: true,
+				Flags: CodeTokenFlags{}, Output: &CommandOutput[JSONUndefined]{
+					TextDescription:       "Writes only the Code credential and a newline. Errors go to stderr. Output formatting is not supported.",
+					JSONOutputUnimportant: true,
+					Examples:              []CommandExample{{Description: "Fetch the credential for a harness.", Command: "baseten code auth token"}},
+				}},
+		}},
+	},
+}
+
+func codeLeaf(name, summary string, flags any, args string, maxArgs int) Command {
+	example := "baseten code " + name
+	if name == "list" || name == "revoke" {
+		example = "baseten code keys " + name
+	}
+	if name == "init" {
+		example += " --dry-run --harness codex"
+	}
+	if name == "teardown" {
+		example += " codex --dry-run"
+	}
+	if name == "revoke" {
+		example += " <id> --yes"
+	}
+	return Command{Name: name, Summary: summary, Description: summary + ".\n\nExperimental. Dedicated Code credential endpoints and active-session catalog refresh are not yet integrated. Unsupported operations fail explicitly.", Hidden: true, Flags: flags, ArgsUsage: args, MaxArgs: maxArgs,
+		Output: &CommandOutput[JSONAny]{TextDescription: summary + ". No credential values are included.", Examples: []CommandExample{{Description: summary + ".", Command: example}}, JQExample: CommandExample{Description: "Read structured output.", Command: example + " --jq '.'"}},
+	}
+}
+
+type CodeFlags struct {
+	CommandFlags
+	Org           string `flag:"org" desc:"Organization ID or slug (defaults to saved installation)"`
+	NoInteractive bool   `flag:"no-interactive" desc:"Disable prompts; never bypasses authentication"`
+}
+
+// The absolute state directory lets GUI launches use the same credential even
+// when BASETEN_CONFIG_DIR is absent from their environment.
+type CodeTokenFlags struct {
+	CodeFlags
+	ConfigDir string `flag:"config-dir" hidden:"true" desc:"Internal absolute Code state directory"`
+}
+
+type CodeOutputFlags struct {
+	CodeFlags
+	JSON bool `flag:"json" desc:"Alias for --output json"`
+}
+
+type CodeHarnessFlags struct {
+	CodeOutputFlags
+	Harness string `flag:"harness" desc:"Harness to inspect" enum:"codex,codex-desktop,claude-code,claude-desktop,opencode"`
+}
+
+type CodeInitFlags struct {
+	CodeOutputFlags
+	Harness   []string `flag:"harness" desc:"Harness to configure (repeatable)" enum:"codex,codex-desktop,claude-code,claude-desktop,opencode"`
+	Model     string   `flag:"model" desc:"Initial Route slug from the authenticated catalog"`
+	Label     string   `flag:"label" desc:"Installation label for a new Code credential"`
+	NoBrowser bool     `flag:"no-browser" desc:"Display device authorization URL without opening a browser"`
+	DryRun    bool     `flag:"dry-run" desc:"Preview without writing configuration or issuing credentials"`
+}
+
+type CodeSpendFlags struct {
+	CodeOutputFlags
+	From    string   `flag:"from" desc:"Inclusive start date in UTC (YYYY-MM-DD)"`
+	To      string   `flag:"to" desc:"Exclusive end date in UTC (YYYY-MM-DD)"`
+	GroupBy []string `flag:"group-by" desc:"Cost dimension (repeatable)" enum:"day,route,model,api-key-prefix"`
+}
+
+type CodeDoctorFlags struct {
+	CodeOutputFlags
+	Test  bool   `flag:"test" desc:"Send streaming and tool round-trip probes (incurs usage)"`
+	Model string `flag:"model" desc:"Route slug for --test"`
+}
+
+type CodeSyncFlags struct {
+	CodeOutputFlags
+	DryRun bool `flag:"dry-run" desc:"Preview without changing configuration"`
+}
+
+type CodeConfirmFlags struct {
+	CodeOutputFlags
+	Yes bool `flag:"yes" desc:"Confirm the explicitly selected scope"`
+}
+
+type CodeTeardownFlags struct {
+	CodeConfirmFlags
+	All    bool `flag:"all" desc:"Remove all configured harness integrations"`
+	DryRun bool `flag:"dry-run" desc:"Preview without changing configuration"`
+}
+
+type CodeKeysListFlags struct {
+	CodeOutputFlags
+	IncludeRevoked bool `flag:"include-revoked" desc:"Include revoked Code key metadata"`
+}
+
+type CodeKeysRevokeFlags struct {
+	CodeConfirmFlags
+	All bool `flag:"all" desc:"Revoke all of your Code keys"`
+}

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -33,6 +33,7 @@ var Root = Command{
 	Children: []Command{
 		commandAPI,
 		commandAuth,
+		commandCode,
 		commandLoops,
 		commandModel,
 		commandModelAPI,
@@ -85,6 +86,9 @@ type Command struct {
 	// Hidden keeps the command out of help listings and completion. The command
 	// is still fully runnable.
 	Hidden bool
+	// RawOutput disables output formatting and keeps every failure off stdout.
+	// Reserved for credential helpers and other strict machine protocols.
+	RawOutput bool
 }
 
 // LoadFlags parses the Flags struct tags and returns the flag metadata. Returns

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -82,7 +83,9 @@ require (
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,7 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -156,6 +157,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
@@ -179,6 +181,7 @@ github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
 github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
 github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
 github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
 go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=

--- a/internal/cmd/command.code.go
+++ b/internal/cmd/command.code.go
@@ -1,0 +1,672 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-cli/internal/auth"
+	"github.com/basetenlabs/baseten-cli/internal/code"
+	"github.com/charmbracelet/huh"
+)
+
+func init() {
+	Register("code init", commandCodeInit)
+	Register("code status", commandCodeStatus)
+	Register("code models", commandCodeModels)
+	Register("code spend", commandCodeSpend)
+	Register("code doctor", commandCodeDoctor)
+	Register("code sync", commandCodeSync)
+	Register("code teardown", commandCodeTeardown)
+	Register("code logout", commandCodeLogout)
+	Register("code keys list", commandCodeKeysList)
+	Register("code keys revoke", commandCodeKeysRevoke)
+	Register("code auth token", commandCodeToken)
+}
+
+func codeState(flags cmd.CodeFlags) (*code.Store, *code.Installation, error) {
+	s, err := code.NewStore()
+	if err != nil {
+		return nil, nil, err
+	}
+	i, err := s.Load()
+	if err != nil {
+		return nil, nil, err
+	}
+	if i != nil {
+		if flags.Org != "" && flags.Org != i.Org {
+			return nil, nil, cmd.NewErrUsagef("--org does not match this installation; organization switching and slug resolution require the Code backend")
+		}
+		if flags.Profile != "" && flags.Profile != i.Profile {
+			return nil, nil, cmd.NewErrUsagef("--profile does not match the Code installation's human profile")
+		}
+	}
+	return s, i, nil
+}
+func codeClient(ctx *CommandContext, s *code.Store, i *code.Installation) (*code.Client, error) {
+	token, err := s.Token(i)
+	if err != nil {
+		return nil, cmd.NewErrAuth(err)
+	}
+	return &code.Client{Token: token, Transport: ctx.httpClient().Transport}, nil
+}
+func codeOutput(ctx *CommandContext, r codeReport) {
+	if ctx.JSON {
+		ctx.OutputJSON(r)
+		return
+	}
+	ctx.Outputf("%s\n", r.Status)
+	if r.Org != "" {
+		ctx.Outputf("Organization: %s\n", r.Org)
+	}
+	if r.Profile != "" {
+		ctx.Outputf("Human profile: %s\n", r.Profile)
+	}
+	if r.UserID != "" {
+		ctx.Outputf("User: %s\n", r.UserID)
+	}
+	if r.Model != "" {
+		ctx.Outputf("Route: %s\n", r.Model)
+	}
+	if r.CredentialStatus != "" {
+		ctx.Outputf("Credential: %s\n", r.CredentialStatus)
+	}
+	for _, h := range r.Harnesses {
+		ctx.Outputf("%s: installed=%t, version=%s, config=%s\n", h.Name, h.Installed, h.Version, h.Path)
+	}
+	for _, change := range r.Changes {
+		ctx.Outputf("%s: %s (%s)\n", change.Harness, change.Path, strings.Join(change.Keys, ", "))
+	}
+	for _, check := range r.Checks {
+		ctx.Outputf("%s: %s\n", check.Name, check.Status)
+	}
+	for _, note := range r.Notes {
+		ctx.OutputLine(note)
+	}
+}
+
+type codeCheck struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+type codeReport struct {
+	Status           string         `json:"status"`
+	Org              string         `json:"org,omitempty"`
+	Profile          string         `json:"profile,omitempty"`
+	UserID           string         `json:"user_id,omitempty"`
+	Model            string         `json:"model,omitempty"`
+	CredentialStatus string         `json:"credential_status,omitempty"`
+	Harnesses        []code.Harness `json:"harnesses,omitempty"`
+	Changes          []*code.Change `json:"changes,omitempty"`
+	Checks           []codeCheck    `json:"checks,omitempty"`
+	Notes            []string       `json:"notes,omitempty"`
+}
+
+func reportFor(i *code.Installation, status string) codeReport {
+	r := codeReport{Status: status, Notes: []string{code.CatalogRefreshGap}}
+	if i != nil {
+		r.Org = i.Org
+		r.Profile = i.Profile
+		r.UserID = i.UserID
+		r.Model = i.Model
+	}
+	return r
+}
+func configured(i *code.Installation) []string {
+	names := []string{}
+	if i != nil {
+		for h := range i.Configs {
+			names = append(names, h)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+func codeTargets(ctx *CommandContext, i *code.Installation) ([]string, error) {
+	if len(ctx.Args) > 0 {
+		names, err := code.Normalize(ctx.Args)
+		if err != nil {
+			return nil, cmd.NewErrUsage(err)
+		}
+		return names, nil
+	}
+	names := configured(i)
+	if len(names) == 0 {
+		return nil, cmd.NewErrUsagef("no harnesses are configured; run baseten code init --dry-run --harness <name> to inspect setup requirements")
+	}
+	return names, nil
+}
+func commandCodeStatus(ctx *CommandContext, flags *cmd.CodeHarnessFlags) error {
+	s, i, err := codeState(flags.CodeFlags)
+	if err != nil {
+		return err
+	}
+	r := reportFor(i, "not_initialized")
+	r.CredentialStatus = "not_installed"
+	names := configured(i)
+	if flags.Harness != "" {
+		names, err = code.Normalize([]string{flags.Harness})
+		if err != nil {
+			return cmd.NewErrUsage(err)
+		}
+	}
+	if i != nil {
+		r.Status = "installed"
+		r.CredentialStatus = "stored_unverified"
+		if _, err := s.Token(i); err != nil {
+			r.CredentialStatus = "unavailable"
+		}
+	} else {
+		// Read only profile metadata. Do not refresh OAuth or expose its token.
+		session, err := auth.ResolveSession(flags.Profile, "")
+		if err != nil {
+			return err
+		}
+		r.Profile = session.ProfileName()
+		r.Notes = append(r.Notes, code.CredentialDependency)
+	}
+	for _, name := range names {
+		h, err := code.Describe(ctx, name)
+		if err != nil {
+			return err
+		}
+		r.Harnesses = append(r.Harnesses, h)
+	}
+	r.Notes = append(r.Notes, "Status is local only; it does not establish credential validity or current organization permissions.")
+	codeOutput(ctx, r)
+	return nil
+}
+func commandCodeModels(ctx *CommandContext, flags *cmd.CodeHarnessFlags) error {
+	s, i, err := codeState(flags.CodeFlags)
+	if err != nil {
+		return err
+	}
+	cl, err := codeClient(ctx, s, i)
+	if err != nil {
+		return err
+	}
+	catalog, err := cl.Models(ctx)
+	if err != nil {
+		return err
+	}
+	if flags.Harness != "" {
+		catalog.Compatibility = flags.Harness + ": protocol and capability compatibility is unverified; all server-returned IDs are shown"
+	}
+	if ctx.JSON {
+		ctx.OutputJSON(catalog)
+		return nil
+	}
+	rows := [][]string{}
+	for _, m := range catalog.Data {
+		rows = append(rows, []string{m.ID, m.Name})
+	}
+	ctx.OutputTable(TableOutput{Headers: []string{"ROUTE ID", "NAME"}, Rows: rows})
+	ctx.Outputf("Fetched at %s\n", catalog.FetchedAt.Format(time.RFC3339))
+	if catalog.Compatibility != "" {
+		ctx.OutputLine(catalog.Compatibility)
+	}
+	return nil
+}
+func commandCodeInit(ctx *CommandContext, flags *cmd.CodeInitFlags) error {
+	s, i, err := codeState(flags.CodeFlags)
+	if err != nil {
+		return err
+	}
+	names, err := code.Normalize(flags.Harness)
+	if err != nil {
+		return cmd.NewErrUsage(err)
+	}
+	if len(names) == 0 {
+		for _, name := range []string{"codex", "claude-code", "opencode"} {
+			h, e := code.Describe(ctx, name)
+			if e != nil {
+				return e
+			}
+			if h.Installed {
+				names = append(names, name)
+			}
+		}
+		if !flags.DryRun && (!ctx.IsInteractive() || flags.NoInteractive) {
+			return cmd.NewErrUsagef("--harness is required with --no-interactive or when stdin is not a terminal")
+		}
+		if !flags.DryRun && len(names) > 0 {
+			var selected []string
+			options := []huh.Option[string]{}
+			for _, name := range names {
+				options = append(options, huh.NewOption(name, name))
+			}
+			if err := huh.NewMultiSelect[string]().Title("Configure which installed harnesses?").Options(options...).Value(&selected).Run(); err != nil {
+				return err
+			}
+			names = selected
+		}
+	}
+	if len(names) == 0 {
+		return cmd.NewErrUsagef("no harness selected or detected; install a harness and pass --harness <name>")
+	}
+	r := reportFor(i, "preview")
+	r.Org = flags.Org
+	if i != nil {
+		r.Org = i.Org
+	}
+	model := flags.Model
+	if model == "" && i != nil {
+		model = i.Model
+	}
+	r.Model = model
+	for _, name := range names {
+		h, e := code.Describe(ctx, name)
+		if e != nil {
+			return e
+		}
+		r.Harnesses = append(r.Harnesses, h)
+		if h.Limitation != "" {
+			r.Notes = append(r.Notes, h.Limitation)
+		}
+	}
+	if i == nil {
+		r.Notes = append(r.Notes, "Sign-in, Code credential creation, authenticated catalog retrieval and Route selection are required before configuration can be installed.", code.CredentialDependency)
+		if flags.DryRun {
+			helper, e := os.Executable()
+			if e != nil {
+				return e
+			}
+			previewModel := model
+			if previewModel == "" {
+				previewModel = "<select-route-after-sign-in>"
+			}
+			for _, h := range r.Harnesses {
+				change, e := code.Prepare(h, previewModel, helper, s.Dir, flags.Org, nil)
+				if e != nil {
+					r.Checks = append(r.Checks, codeCheck{h.Name + " setup", e.Error()})
+				} else {
+					r.Changes = append(r.Changes, change)
+				}
+			}
+			r.Notes = append(r.Notes, "Preview contains paths and setting names only. Changed TOML files are normalized; the private rollback journal retains the original bytes.")
+			codeOutput(ctx, r)
+			return nil
+		}
+		return cmd.NewErrAuth(errors.New(code.CredentialDependency + "; use init --dry-run to inspect setup, or baseten auth login --web to establish the human profile separately"))
+	}
+	if flags.Label != "" && flags.Label != i.Label {
+		return cmd.NewErrUsagef("changing an installation label requires the dedicated Code credential backend")
+	}
+	// Serialize mutations and reload after locking, before preparing any edits.
+	if !flags.DryRun {
+		unlock, e := s.Lock()
+		if e != nil {
+			return e
+		}
+		defer unlock()
+		s, i, err = codeState(flags.CodeFlags)
+		if err != nil {
+			return err
+		}
+		if i == nil {
+			return errors.New("installation changed; retry init")
+		}
+		if flags.Model == "" {
+			model = i.Model
+		}
+	}
+	cl, err := codeClient(ctx, s, i)
+	if err != nil {
+		return err
+	}
+	catalog, err := cl.Models(ctx)
+	if err != nil {
+		return err
+	}
+	if model == "" {
+		if !ctx.IsInteractive() || flags.NoInteractive || flags.DryRun {
+			return cmd.NewErrUsagef("--model must select a Route from baseten code models")
+		}
+		options := []huh.Option[string]{}
+		for _, m := range catalog.Data {
+			options = append(options, huh.NewOption(m.ID, m.ID))
+		}
+		if len(options) == 0 {
+			return cmd.NewErrUsagef("no Routes are available")
+		}
+		if err := huh.NewSelect[string]().Title("Initial Route").Options(options...).Value(&model).Run(); err != nil {
+			return err
+		}
+	}
+	if !catalog.Has(model) {
+		return cmd.NewErrUsagef("selected Route is absent from the authenticated catalog; choose --model from baseten code models")
+	}
+	helper, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	for _, h := range r.Harnesses {
+		change, e := code.Prepare(h, model, helper, s.Dir, i.Org, i.Configs[h.Name])
+		if e != nil {
+			return e
+		}
+		r.Changes = append(r.Changes, change)
+	}
+	r.Model = model
+	if flags.DryRun {
+		codeOutput(ctx, r)
+		return nil
+	}
+	ctx.LogLine("Validating streaming and tool replay before configuration; these inference requests incur usage.")
+	for _, h := range r.Harnesses {
+		if err := cl.Probe(ctx, h.Name, model); err != nil {
+			return fmt.Errorf("%s validation: %w", h.Name, err)
+		}
+	}
+	i.Model = model
+	if err := s.Apply(i, r.Changes); err != nil {
+		return err
+	}
+	r.Status = "configured"
+	codeOutput(ctx, r)
+	return nil
+}
+func commandCodeSync(ctx *CommandContext, flags *cmd.CodeSyncFlags) error {
+	s, i, err := codeState(flags.CodeFlags)
+	if err != nil {
+		return err
+	}
+	names, err := codeTargets(ctx, i)
+	if err != nil {
+		return err
+	}
+	cl, err := codeClient(ctx, s, i)
+	if err != nil {
+		return err
+	}
+	catalog, err := cl.Models(ctx)
+	if err != nil {
+		return err
+	}
+	if !catalog.Has(i.Model) {
+		return cmd.NewErrUsagef("configured Route is no longer in the catalog; run code init with --model to select an available Route")
+	}
+	r := reportFor(i, "preview")
+	helper, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		if i.Configs[name] == nil {
+			return cmd.NewErrUsagef("%s is not configured", name)
+		}
+		h, e := code.Describe(ctx, name)
+		if e != nil {
+			return e
+		}
+		change, e := code.Prepare(h, i.Model, helper, s.Dir, i.Org, i.Configs[name])
+		if e != nil {
+			return e
+		}
+		r.Changes = append(r.Changes, change)
+	}
+	r.Notes = append(r.Notes, "Catalog retrieved and selected Route validated; generated picker catalogs are not implemented.")
+	if !flags.DryRun {
+		return errors.New("catalog retrieved, but picker catalog synchronization is not implemented for the configured harnesses; no configuration changed")
+	}
+	codeOutput(ctx, r)
+	return nil
+}
+func commandCodeDoctor(ctx *CommandContext, flags *cmd.CodeDoctorFlags) error {
+	if flags.Model != "" && !flags.Test {
+		return cmd.NewErrUsagef("--model requires --test")
+	}
+	s, i, err := codeState(flags.CodeFlags)
+	if err != nil {
+		return err
+	}
+	names, err := codeTargets(ctx, i)
+	if err != nil {
+		return err
+	}
+	r := reportFor(i, "diagnostics")
+	failed := false
+	if i == nil {
+		r.Checks = append(r.Checks, codeCheck{"credential", "not installed"})
+		failed = true
+	} else {
+		r.Checks = append(r.Checks, codeCheck{"credential", "stored; checking catalog authorization"})
+	}
+	for _, name := range names {
+		h, e := code.Describe(ctx, name)
+		if e != nil {
+			return e
+		}
+		r.Harnesses = append(r.Harnesses, h)
+		if !h.Installed {
+			r.Checks = append(r.Checks, codeCheck{name, "not installed or not on PATH"})
+			failed = true
+		}
+		if i == nil || i.Configs[name] == nil {
+			r.Checks = append(r.Checks, codeCheck{name + " configuration", "not configured"})
+			failed = true
+			continue
+		}
+		helper, e := os.Executable()
+		if e != nil {
+			return e
+		}
+		_, e = code.Prepare(h, i.Model, helper, s.Dir, i.Org, i.Configs[name])
+		if e != nil {
+			r.Checks = append(r.Checks, codeCheck{name + " configuration", e.Error()})
+			failed = true
+		} else {
+			r.Checks = append(r.Checks, codeCheck{name + " configuration", "managed settings match"})
+		}
+	}
+	cl, e := codeClient(ctx, s, i)
+	if e != nil {
+		r.Checks = append(r.Checks, codeCheck{"catalog", e.Error()})
+		failed = true
+	} else {
+		catalog, e := cl.Models(ctx)
+		if e != nil {
+			r.Checks = append(r.Checks, codeCheck{"catalog", e.Error()})
+			failed = true
+		} else {
+			r.Checks = append(r.Checks, codeCheck{"catalog", "retrieved at " + catalog.FetchedAt.Format(time.RFC3339)})
+			model := flags.Model
+			if model == "" && i != nil {
+				model = i.Model
+			}
+			if !catalog.Has(model) {
+				r.Checks = append(r.Checks, codeCheck{"Route", "not in current catalog"})
+				failed = true
+			} else if flags.Test {
+				ctx.LogLine("Running streaming and tool replay probes; these inference requests incur usage.")
+				for _, name := range names {
+					if e := cl.Probe(ctx, name, model); e != nil {
+						r.Checks = append(r.Checks, codeCheck{name + " protocol", e.Error()})
+						failed = true
+					} else {
+						r.Checks = append(r.Checks, codeCheck{name + " protocol", "streaming and tool-result replay passed"})
+					}
+				}
+			}
+		}
+	}
+	r.Notes = append(r.Notes, "Managed policies and project/launch overrides can change effective harness behavior. Protocol probes do not certify the complete harness.")
+	if failed {
+		r.Status = "failed"
+	} else {
+		r.Status = "passed"
+	}
+	codeOutput(ctx, r)
+	if failed {
+		ctx.SuppressJSONError()
+		return errors.New("Code diagnostics failed; review the reported checks")
+	}
+	return nil
+}
+func codeConfirm(ctx *CommandContext, flags cmd.CodeConfirmFlags, title string) error {
+	if flags.Yes {
+		return nil
+	}
+	if flags.NoInteractive || !ctx.IsInteractive() {
+		return cmd.NewErrUsagef("pass --yes to confirm the explicitly selected scope")
+	}
+	var yes bool
+	if err := huh.NewConfirm().Title(title).Value(&yes).Run(); err != nil {
+		return err
+	}
+	if !yes {
+		return errors.New("cancelled")
+	}
+	return nil
+}
+func commandCodeTeardown(ctx *CommandContext, flags *cmd.CodeTeardownFlags) error {
+	if flags.All && len(ctx.Args) > 0 {
+		return cmd.NewErrUsagef("a harness and --all are mutually exclusive")
+	}
+	s, i, err := codeState(flags.CodeFlags)
+	if err != nil {
+		return err
+	}
+	if !flags.All && len(ctx.Args) == 0 {
+		if flags.NoInteractive || !ctx.IsInteractive() {
+			return cmd.NewErrUsagef("select a harness or --all; --yes does not imply --all")
+		}
+		names := configured(i)
+		if len(names) == 0 {
+			return cmd.NewErrUsagef("no harnesses are configured")
+		}
+		options := []huh.Option[string]{}
+		for _, name := range names {
+			options = append(options, huh.NewOption(name, name))
+		}
+		var name string
+		if err := huh.NewSelect[string]().Title("Remove which harness setup?").Options(options...).Value(&name).Run(); err != nil {
+			return err
+		}
+		ctx.Args = []string{name}
+	}
+	if !flags.DryRun {
+		unlock, e := s.Lock()
+		if e != nil {
+			return e
+		}
+		defer unlock()
+		s, i, err = codeState(flags.CodeFlags)
+		if err != nil {
+			return err
+		}
+	}
+	names, err := codeTargets(ctx, i)
+	if err != nil {
+		return err
+	}
+	r := reportFor(i, "preview")
+	conflicts := false
+	for _, name := range names {
+		if i == nil || i.Configs[name] == nil {
+			return cmd.NewErrUsagef("%s is not configured", name)
+		}
+		change, kept, e := code.Restore(i.Configs[name])
+		if e != nil {
+			return e
+		}
+		r.Changes = append(r.Changes, change)
+		if len(kept) > 0 {
+			conflicts = true
+			r.Notes = append(r.Notes, name+": preserving edited settings: "+strings.Join(kept, ", "))
+		}
+	}
+	if !flags.DryRun {
+		if err := codeConfirm(ctx, flags.CodeConfirmFlags, "Remove Baseten setup for "+strings.Join(names, ", ")+"?"); err != nil {
+			return err
+		}
+		if err := s.Teardown(i, r.Changes); err != nil {
+			return err
+		}
+		r.Status = "restored"
+	}
+	r.Notes = append(r.Notes, "Code credential retained; logout is a separate server revocation operation.")
+	codeOutput(ctx, r)
+	if conflicts && !flags.DryRun {
+		ctx.SuppressJSONError()
+		return errors.New("user-edited settings were preserved; their backup records remain for review")
+	}
+	return nil
+}
+func commandCodeSpend(ctx *CommandContext, flags *cmd.CodeSpendFlags) error {
+	if (flags.From == "") != (flags.To == "") {
+		return cmd.NewErrUsagef("--from and --to must be supplied together")
+	}
+	if flags.From != "" {
+		from, e := time.Parse("2006-01-02", flags.From)
+		if e != nil {
+			return cmd.NewErrUsagef("--from must be YYYY-MM-DD")
+		}
+		to, e := time.Parse("2006-01-02", flags.To)
+		if e != nil {
+			return cmd.NewErrUsagef("--to must be YYYY-MM-DD")
+		}
+		if !from.Before(to) {
+			return cmd.NewErrUsagef("--from must precede exclusive --to")
+		}
+	}
+	if _, _, err := codeState(flags.CodeFlags); err != nil {
+		return err
+	}
+	return errors.New("Code spend is unavailable: the Cost API has daily user/model/API-key-prefix filters, but Code-key inventory and creator attribution are not integrated; cannot safely report current-user Code spend or Route grouping. Use baseten org billing for its documented organization billing scope")
+}
+func commandCodeLogout(ctx *CommandContext, flags *cmd.CodeConfirmFlags) error {
+	if _, _, err := codeState(flags.CodeFlags); err != nil {
+		return err
+	}
+	return errors.New(code.CredentialDependency + "; logout cannot revoke this installation, so local credentials and configuration were retained")
+}
+func commandCodeKeysList(ctx *CommandContext, flags *cmd.CodeKeysListFlags) error {
+	if _, _, err := codeState(flags.CodeFlags); err != nil {
+		return err
+	}
+	return errors.New(code.CredentialDependency)
+}
+func commandCodeKeysRevoke(ctx *CommandContext, flags *cmd.CodeKeysRevokeFlags) error {
+	if (len(ctx.Args) > 0) == flags.All {
+		return cmd.NewErrUsagef("select exactly one key ID or --all; --yes does not imply --all")
+	}
+	if _, _, err := codeState(flags.CodeFlags); err != nil {
+		return err
+	}
+	return errors.New(code.CredentialDependency + "; no key was revoked")
+}
+func commandCodeToken(ctx *CommandContext, flags *cmd.CodeTokenFlags) error {
+	ctx.SuppressJSONError()
+	if flags.Output != "text" || flags.JQ != "" {
+		return cmd.NewErrUsagef("auth token emits only the credential; output formatting is not supported")
+	}
+	s, err := code.NewStore()
+	if err != nil {
+		return err
+	}
+	if flags.ConfigDir != "" {
+		if !filepath.IsAbs(flags.ConfigDir) {
+			return cmd.NewErrUsagef("--config-dir must be absolute")
+		}
+		s = &code.Store{Dir: flags.ConfigDir}
+	}
+	i, err := s.Load()
+	if err != nil {
+		return err
+	}
+	if i != nil && ((flags.Org != "" && flags.Org != i.Org) || (flags.Profile != "" && flags.Profile != i.Profile)) {
+		return cmd.NewErrAuth(errors.New("credential helper context does not match the installed Code credential"))
+	}
+	token, err := s.Token(i)
+	if err != nil {
+		return cmd.NewErrAuth(err)
+	}
+	ctx.OutputLine(token)
+	return nil
+}

--- a/internal/cmd/command.code_test.go
+++ b/internal/cmd/command.code_test.go
@@ -95,7 +95,7 @@ func Test_Code_ExplicitCommandsRemainInvocable(t *testing.T) {
 }
 func Test_Code_Init_DryRunHasNoSideEffects(t *testing.T) {
 	h := newCodeHarness(t)
-	h.Require.NoError(h.Execute("code", "init", "--harness", "codex", "--harness", "codex-desktop", "--model", "engineering", "--no-browser", "--no-interactive", "--dry-run", "--json"))
+	h.Require.NoError(h.Execute("code", "init", "--harness", "codex", "--harness", "codex-desktop", "--model", "engineering", "--no-interactive", "--dry-run", "--json"))
 	var r struct {
 		Status    string
 		Harnesses []code.Harness

--- a/internal/cmd/command.code_test.go
+++ b/internal/cmd/command.code_test.go
@@ -1,0 +1,236 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	public "github.com/basetenlabs/baseten-cli/cmd"
+	"github.com/basetenlabs/baseten-cli/internal/auth"
+	"github.com/basetenlabs/baseten-cli/internal/cmd"
+	"github.com/basetenlabs/baseten-cli/internal/code"
+)
+
+func newCodeHarness(t *testing.T) *CommandHarness {
+	h := NewCommandHarness(t)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", os.Getenv("HOME"))
+	t.Setenv("CODEX_HOME", filepath.Join(t.TempDir(), "codex"))
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "claude"))
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("BASETEN_PROFILE", "")
+	// No harness executable is run by these CLI tests. Adapter tests construct
+	// their own Harness; protocol tests use an in-memory RoundTripper.
+	t.Setenv("PATH", t.TempDir())
+	return h
+}
+func seedCode(t *testing.T, h *CommandHarness) (*code.Store, *code.Installation) {
+	t.Helper()
+	s, err := code.NewStore()
+	h.Require.NoError(err)
+	i := &code.Installation{Version: 1, Org: "org-code", Profile: "human", UserID: "human-id", KeyID: "code-key-1", Model: "engineering", Configs: map[string]*code.ManagedConfig{}}
+	h.Require.NoError(s.Save(i))
+	h.Require.NoError(s.Credentials().SetAPIKeyProfile("baseten-code:"+i.KeyID, "https://app.baseten.co", "code-secret", false, nil))
+	return s, i
+}
+func Test_Code_AllNodesHidden(t *testing.T) {
+	var walk func(public.Command)
+	walk = func(c public.Command) {
+		if !c.Hidden {
+			t.Errorf("%s is not hidden", c.Name)
+		}
+		for _, child := range c.Children {
+			walk(child)
+		}
+	}
+	found := false
+	for _, c := range public.Root.Children {
+		if c.Name == "code" {
+			found = true
+			walk(c)
+		}
+	}
+	if !found {
+		t.Fatal("missing code group")
+	}
+}
+func Test_Code_HelpAndCompletionHideDescendants(t *testing.T) {
+	h := newCodeHarness(t)
+	for _, args := range [][]string{{"--help"}, {"help"}, {"__complete", ""}, {"__complete", "co"}, {"__complete", "code", ""}, {"__complete", "code", "keys", ""}, {"__complete", "code", "auth", ""}, {"__completeNoDesc", "code", ""}, {"code", "--help"}, {"code", "keys", "--help"}, {"code", "auth", "--help"}} {
+		h.Require.NoError(h.Execute(args...))
+		out := h.Stdout.String()
+		h.Require.NotContains(out, "Preview or configure")
+		h.Require.NotContains(out, "List Code key metadata")
+		if !(len(args) > 1 && args[1] == "auth") {
+			h.Require.NotContains(out, "Internal Code authentication")
+		}
+		if args[0] != "code" {
+			h.Require.NotContains(out, "Configure Baseten Code")
+		}
+		if strings.HasPrefix(args[0], "__complete") {
+			h.Require.NotContains(out, "\ninit")
+			h.Require.NotContains(out, "\ncode\t")
+			h.Require.NotContains(out, "\nrevoke")
+			h.Require.NotContains(out, "\ntoken")
+		}
+	}
+	for _, shell := range []string{"bash", "zsh", "fish", "powershell"} {
+		h.Require.NoError(h.Execute("completion", shell))
+		h.Require.NotContains(h.Stdout.String(), "Configure Baseten Code")
+		h.Require.NotContains(h.Stdout.String(), "List Code key metadata")
+	}
+}
+func Test_Code_ExplicitCommandsRemainInvocable(t *testing.T) {
+	h := newCodeHarness(t)
+	for _, leaf := range []string{"init", "status", "models", "spend", "doctor", "sync", "teardown", "logout", "keys list", "keys revoke", "auth token"} {
+		args := append([]string{"code"}, strings.Fields(leaf)...)
+		args = append(args, "--help")
+		h.Require.NoError(h.Execute(args...))
+		h.Require.Contains(h.Stdout.String(), "USAGE")
+	}
+}
+func Test_Code_Init_DryRunHasNoSideEffects(t *testing.T) {
+	h := newCodeHarness(t)
+	h.Require.NoError(h.Execute("code", "init", "--harness", "codex", "--harness", "codex-desktop", "--model", "engineering", "--no-browser", "--no-interactive", "--dry-run", "--json"))
+	var r struct {
+		Status    string
+		Harnesses []code.Harness
+		Notes     []string
+	}
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &r))
+	h.Require.Equal("preview", r.Status)
+	h.Require.Len(r.Harnesses, 1)
+	h.Require.Contains(h.Stdout.String(), "dedicated backend endpoints")
+	s, err := code.NewStore()
+	h.Require.NoError(err)
+	_, err = os.Stat(s.Dir)
+	h.Require.True(os.IsNotExist(err))
+	_, err = os.Stat(r.Harnesses[0].Path)
+	h.Require.True(os.IsNotExist(err))
+}
+func Test_Code_BackendDependenciesNeverFallBackToRegularKeys(t *testing.T) {
+	h := newCodeHarness(t)
+	for _, args := range [][]string{{"init", "--harness", "codex", "--no-interactive"}, {"models"}, {"keys", "list", "--include-revoked"}, {"keys", "revoke", "id", "--yes"}, {"keys", "revoke", "--all", "--yes"}, {"logout", "--yes"}, {"spend"}} {
+		h.Require.Error(h.Execute(append([]string{"code"}, args...)...))
+		h.Require.NotContains(h.Stdout.String(), "test-key")
+		h.Require.NotContains(h.Stderr.String(), "test-key")
+	}
+	s, err := code.NewStore()
+	h.Require.NoError(err)
+	_, err = os.Stat(s.Dir)
+	h.Require.True(os.IsNotExist(err))
+}
+func Test_Code_ScopeAndDateValidation(t *testing.T) {
+	h := newCodeHarness(t)
+	for _, args := range [][]string{{"teardown", "--yes"}, {"teardown", "codex", "--all", "--yes"}, {"keys", "revoke", "--yes"}, {"keys", "revoke", "id", "--all", "--yes"}, {"spend", "--from", "2026-09-01"}, {"spend", "--from", "bad", "--to", "2026-09-03"}, {"spend", "--from", "2026-09-03", "--to", "2026-09-01"}, {"doctor", "codex", "--model", "route"}, {"doctor", "unknown"}} {
+		h.Require.Error(h.Execute(append([]string{"code"}, args...)...))
+		h.Require.Equal(2, h.ExitCode)
+	}
+}
+func Test_Code_StatusAndTokenIsolation(t *testing.T) {
+	h := newCodeHarness(t)
+	s, i := seedCode(t, h)
+	regular := auth.NewStore(auth.StoreOptions{Dir: os.Getenv("BASETEN_CONFIG_DIR")})
+	h.Require.NoError(regular.SetAPIKeyProfile("other", "https://app.baseten.co", "regular-secret", true, nil))
+	h.Require.NoError(h.Execute("code", "status", "--json"))
+	h.Require.Contains(h.Stdout.String(), "stored_unverified")
+	h.Require.Contains(h.Stdout.String(), "human-id")
+	h.Require.NotContains(h.Stdout.String(), "code-secret")
+	h.Require.NotContains(h.Stdout.String(), "regular-secret")
+	h.Require.NoError(h.Execute("code", "auth", "token"))
+	h.Require.Equal("code-secret\n", h.Stdout.String())
+	h.Require.Empty(h.Stderr.String())
+	h.Require.Error(h.Execute("code", "auth", "token", "--org", "other"))
+	h.Require.Empty(h.Stdout.String())
+	h.Require.Error(h.Execute("code", "auth", "token", "--output", "json"))
+	h.Require.Empty(h.Stdout.String())
+	h.Require.Error(h.Execute("code", "logout", "--yes"))
+	h.Require.NotContains(h.Stderr.String(), "code-secret")
+	h.Require.NoError(h.Execute("code", "auth", "token"))
+	h.Require.Equal("code-secret\n", h.Stdout.String())
+	h.Require.Error(h.Execute("code", "status", "--org", "other"))
+	h.Require.Equal(2, h.ExitCode)
+	t.Setenv("BASETEN_CONFIG_DIR", t.TempDir())
+	h.Require.NoError(h.Execute("code", "auth", "token", "--config-dir", s.Dir, "--org", i.Org))
+	h.Require.Equal("code-secret\n", h.Stdout.String())
+}
+func Test_Code_JSONAliasAndJQ(t *testing.T) {
+	h := newCodeHarness(t)
+	h.Require.NoError(h.Execute("code", "status", "--json", "--jq", ".status"))
+	h.Require.JSONEq(`"not_initialized"`, h.Stdout.String())
+	h.Require.Error(h.Execute("code", "status", "--json", "--output", "text"))
+	h.Require.Equal(2, h.ExitCode)
+	h.Require.Error(h.Execute("code", "models", "--json"))
+	var envelope public.JSONErrorEnvelope
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &envelope))
+	h.Require.Equal(public.ExitAuth, envelope.Error.ExitCode)
+}
+
+type codeRoundTrip func(*http.Request) (*http.Response, error)
+
+func (f codeRoundTrip) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+func Test_Code_ModelsUsesOnlyCodeCredentialAndDoesNotFilter(t *testing.T) {
+	h := newCodeHarness(t)
+	seedCode(t, h)
+	calls := 0
+	h.Context = cmd.WithHTTPClient(h.Context, &http.Client{Transport: codeRoundTrip(func(r *http.Request) (*http.Response, error) {
+		calls++
+		h.Require.Equal("https://coding.baseten.co/v1/models", r.URL.String())
+		h.Require.Equal("Bearer code-secret", r.Header.Get("Authorization"))
+		h.Require.Empty(r.Header.Get("x-baseten-web-search-provider-priority"))
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"data":[{"id":"engineering","name":"Engineering"},{"id":"plain-route"}]}`))}, nil
+	})})
+	h.Require.NoError(h.Execute("code", "models", "--harness", "claude-code", "--json"))
+	h.Require.Equal(1, calls)
+	h.Require.Contains(h.Stdout.String(), "plain-route")
+	h.Require.Contains(h.Stdout.String(), "unverified")
+	h.Require.NotContains(h.Stdout.String(), "code-secret")
+}
+func Test_Code_DoctorWithoutTestNeverSendsInference(t *testing.T) {
+	h := newCodeHarness(t)
+	seedCode(t, h)
+	h.Context = cmd.WithHTTPClient(h.Context, &http.Client{Transport: codeRoundTrip(func(r *http.Request) (*http.Response, error) {
+		h.Require.Equal("GET", r.Method)
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"data":[{"id":"engineering"}]}`))}, nil
+	})})
+	h.Require.Error(h.Execute("code", "doctor", "codex", "--json"))
+	var report map[string]any
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &report))
+	h.Require.Equal("failed", report["status"])
+}
+func Test_Code_TeardownRequiresExplicitScopeAndRetainsCredential(t *testing.T) {
+	h := newCodeHarness(t)
+	s, i := seedCode(t, h)
+	path := filepath.Join(t.TempDir(), "settings.json")
+	h.Require.NoError(os.WriteFile(path, []byte(`{"model":"engineering","extra":"keep"}`), 0600))
+	i.Configs["claude-code"] = &code.ManagedConfig{Harness: "claude-code", Path: path, Format: "json", Original: []byte(`{"model":"old"}`), Existed: true, Settings: []code.Setting{{Path: []string{"model"}, Before: code.Value{Exists: true, Data: "old"}, Installed: code.Value{Exists: true, Data: "engineering"}}}}
+	h.Require.NoError(s.Save(i))
+	h.Require.NoError(h.Execute("code", "teardown", "claude-code", "--dry-run", "--json"))
+	raw, err := os.ReadFile(path)
+	h.Require.NoError(err)
+	h.Require.Contains(string(raw), "engineering")
+	h.Require.Error(h.Execute("code", "teardown", "claude-code", "--no-interactive"))
+	h.Require.Equal(2, h.ExitCode)
+	h.Require.NoError(h.Execute("code", "teardown", "claude-code", "--yes", "--json"))
+	raw, err = os.ReadFile(path)
+	h.Require.NoError(err)
+	h.Require.JSONEq(`{"model":"old","extra":"keep"}`, string(raw))
+	h.Require.NoError(h.Execute("code", "auth", "token"))
+	h.Require.Equal("code-secret\n", h.Stdout.String())
+}
+
+func Test_Code_TokenFailuresNeverWriteStdout(t *testing.T) {
+	h := newCodeHarness(t)
+	for _, args := range [][]string{{"--jq", "["}, {"--output", "json", "--unknown"}, {"--output", "jsonl", "extra"}, {"--json"}} {
+		h.Require.Error(h.Execute(append([]string{"code", "auth", "token"}, args...)...))
+		h.Require.Empty(h.Stdout.String())
+	}
+	h.Require.Error(h.Execute("code", "status", "--json", "--unknown"))
+	var e public.JSONErrorEnvelope
+	h.Require.NoError(json.Unmarshal(h.Stdout.Bytes(), &e))
+	h.Require.Equal(public.ExitUsage, e.Error.ExitCode)
+}

--- a/internal/cmd/command.code_visibility_test.go
+++ b/internal/cmd/command.code_visibility_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	public "github.com/basetenlabs/baseten-cli/cmd"
+	mango "github.com/muesli/mango-cobra"
+	"github.com/muesli/roff"
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Code_GeneratedDocumentationAndStaticCompletion(t *testing.T) {
+	root := &cobra.Command{Use: "baseten"}
+	for _, child := range public.Root.Children {
+		root.AddCommand(buildCommand(child, "", &ExecuteOptions{}))
+	}
+	dir := t.TempDir()
+	require.NoError(t, doc.GenMarkdownTree(root, dir))
+	files, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, file := range files {
+		require.NotContains(t, file.Name(), "baseten_code")
+		data, err := os.ReadFile(filepath.Join(dir, file.Name()))
+		require.NoError(t, err)
+		require.NotContains(t, string(data), "Configure Baseten Code")
+	}
+	page, err := mango.NewManPage(1, root)
+	require.NoError(t, err)
+	require.NotContains(t, page.Build(roff.NewDocument()), "Configure Baseten Code")
+	require.NotContains(t, page.Build(roff.NewDocument()), "Code key metadata")
+	var b bytes.Buffer
+	require.NoError(t, root.GenBashCompletion(&b))
+	require.NotContains(t, b.String(), "_baseten_code")
+}

--- a/internal/cmd/command.go
+++ b/internal/cmd/command.go
@@ -118,6 +118,9 @@ func Execute(ctx context.Context, options ExecuteOptions) error {
 	// give it the same exit code and envelope a leaf would produce.
 	ce := cmd.NewErrUsage(err)
 	format := outputFormatFromArgs(options.Args)
+	if failed, _, _ := root.Find(options.Args); failed != nil && failed.Annotations["baseten/raw-output"] == "true" {
+		format = "text"
+	}
 	(&CommandContext{
 		Stdout:      options.Stdout,
 		JSON:        format == "json" || format == "jsonl",
@@ -143,6 +146,9 @@ func buildCommand(def cmd.Command, parentPath string, options *ExecuteOptions) *
 		Short:  def.Summary,
 		Long:   def.Description,
 		Hidden: def.Hidden,
+	}
+	if def.RawOutput {
+		c.Annotations = map[string]string{"baseten/raw-output": "true"}
 	}
 	c.InitDefaultHelpFlag()
 	if f := c.Flags().Lookup("help"); f != nil {
@@ -219,20 +225,32 @@ func buildCommand(def cmd.Command, parentPath string, options *ExecuteOptions) *
 				cmdFlags = f.Interface().(cmd.CommandFlags)
 			}
 			ctx := &CommandContext{
-				Context:      c.Context(),
-				Command:      c,
-				Args:         args,
-				Stdin:        options.Stdin,
-				Stdout:       options.Stdout,
-				Stderr:       options.Stderr,
-				ExitWithCode: options.ExitWithCode,
-				strictOutput: options.StrictOutputChecks,
-				authInfo:     authInfo{profileFlag: cmdFlags.Profile},
+				Context:           c.Context(),
+				Command:           c,
+				Args:              args,
+				Stdin:             options.Stdin,
+				Stdout:            options.Stdout,
+				Stderr:            options.Stderr,
+				ExitWithCode:      options.ExitWithCode,
+				strictOutput:      options.StrictOutputChecks,
+				suppressJSONError: def.RawOutput,
+				authInfo:          authInfo{profileFlag: cmdFlags.Profile},
 			}
 
-			// Resolve --jq and --output, populating ctx.
+			// Code's spec uses --json; preserve the CLI's output and jq machinery.
 			var runErr error
-			if cmdFlags.JQ != "" {
+			if f := flagsVal.FieldByName("JSON"); f.IsValid() && f.Kind() == reflect.Bool && f.Bool() {
+				if c.Flags().Changed("output") && cmdFlags.Output != "json" {
+					runErr = cmd.NewErrUsagef("--json conflicts with --output %s", cmdFlags.Output)
+				} else {
+					cmdFlags.Output = "json"
+				}
+			}
+			// Resolve --jq and --output, populating ctx.
+			if def.RawOutput && (cmdFlags.Output != "text" || cmdFlags.JQ != "") {
+				runErr = cmd.NewErrUsagef("this command emits raw output and does not support --output or --jq")
+			}
+			if runErr == nil && cmdFlags.JQ != "" {
 				outputChanged := c.Flags().Changed("output")
 				if outputChanged && (cmdFlags.Output == "text" || cmdFlags.Output == "none") {
 					runErr = cmd.NewErrUsagef("--jq cannot be used with --output %s", cmdFlags.Output)
@@ -456,13 +474,17 @@ func bindFlags(flags *pflag.FlagSet, val reflect.Value, metas []cmd.CommandFlag)
 // as json only when no --output appears at all. Shorthands combined into one
 // arg (-vojson) are not recognized.
 func outputFormatFromArgs(args []string) string {
-	format, sawOutput, sawJQ := "", false, false
+	format, sawOutput, sawJQ, sawJSON := "", false, false, false
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if arg == "--" {
 			break
 		}
 		switch {
+		case arg == "--json" || arg == "--json=true":
+			sawJSON = true
+		case arg == "--json=false":
+			sawJSON = false
 		case arg == "--output" || arg == "-o":
 			sawOutput = true
 			// A trailing --output with no value is the parse error cobra is
@@ -480,7 +502,7 @@ func outputFormatFromArgs(args []string) string {
 			sawJQ = true
 		}
 	}
-	if !sawOutput && sawJQ {
+	if !sawOutput && (sawJQ || sawJSON) {
 		return "json"
 	}
 	return format

--- a/internal/code/README.md
+++ b/internal/code/README.md
@@ -1,0 +1,86 @@
+# Baseten Code implementation boundary
+
+This is internal developer documentation. All `code` commands, including every
+group and leaf, are hidden in the declarative command tree. Explicit invocation
+and explicit `--help` still work. Cobra 1.10.2 filters hidden commands from
+completion, suggestions, Markdown docs and man pages. The tests cover the CLI's
+help renderer, dynamic completion, generated scripts and both doc generators.
+This checkout has no `cmd/docs` JSON exporter; any future exporter must also
+filter `Command.Hidden` before descending.
+
+## Available behavior
+
+- `init --dry-run` detects harness executables/versions, consolidates Codex CLI
+  and desktop, inspects supported config files, and previews paths and setting
+  names. No sign-in, keyring write, config write, inference or restart occurs.
+- `status` reports local installation and human-profile metadata, explicitly
+  distinguishing a stored credential from verified authorization.
+- The isolated Code credential store uses the CLI's existing keyring/fallback
+  implementation. Ordinary profiles, OAuth tokens and `BASETEN_API_KEY` are
+  never treated as Code credentials. `auth token` writes only the installed
+  credential; all failures stay on stderr, including parser/formatting errors.
+- With a provisioned installation, `models` reads `coding.baseten.co/v1/models`
+  using its Code credential. It reports fetch time, accepts the existing `data`
+  envelope, and never filters IDs or guesses capabilities from model names.
+- Codex and Claude Code adapters configure the selected Route and the coding
+  endpoint. Codex uses Responses and command-backed authentication. Claude uses
+  Messages, `apiKeyHelper` and explicit secondary model roles. Helpers pin the
+  absolute binary and Code state-directory paths, including for GUI launches.
+  No web-search provider-priority header or permission/sandbox policy is written.
+- Reinitialization of an existing installation validates catalog membership,
+  streaming and a synthetic tool-result replay before writes. `doctor --test`
+  exposes the same two-turn probe; ordinary doctor sends catalog reads only.
+  Probes never execute model-generated commands. Only mocked protocols have
+  been tested here, not live harness compatibility.
+- A private journal saves original bytes and managed values before changes.
+  File writes preserve existing permissions and symlinks, check identity and
+  content for concurrent edits, and serialize CLI mutations with a lock.
+  `teardown` restores only matching managed values, preserves later user edits,
+  and retains conflicting backup entries with a nonzero exit. Newly created
+  files are removed only when empty after restoration. Unedited original files
+  are restored byte for byte. Modified TOML is normalized, which can remove
+  comments until rollback; unrelated setting values are preserved.
+- Interrupted multi-file setup can leave a partial installation. Its journal
+  permits conservative recovery with `teardown`; this is not a filesystem-wide
+  atomic transaction. Non-cooperating editors can race the final check/rename.
+
+## Required follow-up contracts
+
+1. **Code credentials:** the pinned `baseten-go` SDK at
+   `7c00cba027b9` has no dedicated Code issuance/list/revoke operations. Neither
+   the CLI spec nor auth spec publishes their paths or request/response schemas.
+   Initial `init`, `keys list`, `keys revoke` and `logout` fail explicitly and
+   make no guessed management requests. Logout retains credentials until
+   confirmed revocation. No ordinary API-key management endpoint is substituted.
+   Wire the existing OAuth device login/profile machinery to these contracts,
+   including no-browser flow, installation reuse, organization resolution and
+   creator identity. M1 does not introduce a separate eligibility/team gate.
+   There is intentionally no production command to seed local Code credentials.
+2. **Spend:** the SDK has daily Cost API user/model/API-key-prefix filters, but
+   Code-key inventory and creator attribution are not integrated. `spend`
+   validates date and grouping syntax and fails instead of returning org totals,
+   ordinary MAPI spend, or incomplete per-installation totals as user Code spend.
+   Route attribution, freshness and month-to-date semantics need backend wiring.
+3. **Catalog generation and live refresh:** final Route capability metadata and
+   versioned harness catalog adapters are unresolved. `sync --dry-run` validates
+   the selected Route and reports this gap; actual `sync` fails with no config
+   writes. No init-time fetch is claimed as active-session refresh.
+4. **OpenCode and Claude desktop:** recognized and diagnosed, but installation
+   and probes fail explicitly. OpenCode needs verified V1/V2 credential delivery,
+   model catalog generation and JSONC preservation. Claude desktop needs a
+   version-checked profile installer, credential delivery and arbitrary Route
+   discovery validation. No aliases disguising Routes as Claude are generated.
+5. **Harness coverage:** minimum versions, desktop picker/profile behavior,
+   effective project/launch overrides and managed MDM policy resolution remain
+   validation work. Known local managed-policy files cause setup to stop;
+   existing policy settings are never edited. Device login and real inference
+   were not exercised while implementing this change.
+
+Sources read on 2026-09-11:
+
+- [CLI spec](https://app.notion.com/p/3d191d24727380288156f15d569c95c6)
+- [Auth spec](https://app.notion.com/p/3d191d24727380838f94d2dece50341f)
+- [Codex configuration](https://learn.chatgpt.com/docs/config-file/config-advanced)
+- [Codex tool-bank guide](https://app.notion.com/p/3c191d24727381b381eaf08b984e994e)
+- [Claude tool-bank guide](https://app.notion.com/p/3c291d2472738107a9e8d30fa540a7d4)
+- [Protocol probes](https://app.notion.com/p/3cf91d2472738117987ed2d18342d4d5)

--- a/internal/code/README.md
+++ b/internal/code/README.md
@@ -53,7 +53,7 @@ filter `Command.Hidden` before descending.
    make no guessed management requests. Logout retains credentials until
    confirmed revocation. No ordinary API-key management endpoint is substituted.
    Wire the existing OAuth device login/profile machinery to these contracts,
-   including no-browser flow, installation reuse, organization resolution and
+   including installation reuse, organization resolution and
    creator identity. M1 does not introduce a separate eligibility/team gate.
    There is intentionally no production command to seed local Code credentials.
 2. **Spend:** the SDK has daily Cost API user/model/API-key-prefix filters, but

--- a/internal/code/client.go
+++ b/internal/code/client.go
@@ -1,0 +1,103 @@
+package code
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/basetenlabs/baseten-go/client"
+)
+
+// Catalog deliberately consumes only the established OpenAI-compatible list
+// envelope. Capabilities and Route-specific schemas are not yet a contract;
+// callers must not infer protocol support from a model's name.
+type Model struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+type Catalog struct {
+	Data          []Model   `json:"data"`
+	FetchedAt     time.Time `json:"fetched_at"`
+	Compatibility string    `json:"compatibility,omitempty"`
+}
+type Client struct {
+	Token     string
+	Transport http.RoundTripper
+}
+
+func (c *Client) request(ctx context.Context, method, path string, body any, stream bool) ([]byte, error) {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(data)
+	}
+	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, method, Endpoint+path, reader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	client.ApplyUserAgentHeader(req.Header)
+	// Never follow redirects with Code credentials, including same-origin
+	// redirects. The fixed gateway is the only credential destination.
+	hc := &http.Client{Transport: c.Transport, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, errors.New("Code gateway request failed; check connectivity and retry")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Code gateway returned HTTP %d; check Code credential access and Route availability", resp.StatusCode)
+	}
+	if stream && !strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
+		return nil, errors.New("gateway did not return an event stream")
+	}
+	const limit = 8 << 20
+	data, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, errors.New("reading Code gateway response failed")
+	}
+	if len(data) > limit {
+		return nil, errors.New("Code gateway response exceeded 8 MiB")
+	}
+	return data, nil
+}
+func (c *Client) Models(ctx context.Context) (*Catalog, error) {
+	raw, err := c.request(ctx, "GET", "/v1/models", nil, false)
+	if err != nil {
+		return nil, err
+	}
+	var result Catalog
+	if err := json.Unmarshal(raw, &result); err != nil || result.Data == nil {
+		return nil, errors.New("gateway catalog must contain a data array; check the Route catalog backend contract")
+	}
+	seen := map[string]bool{}
+	for _, m := range result.Data {
+		if m.ID == "" || seen[m.ID] {
+			return nil, errors.New("gateway catalog contains missing or duplicate model IDs")
+		}
+		seen[m.ID] = true
+	}
+	result.FetchedAt = time.Now().UTC()
+	return &result, nil
+}
+func (c *Catalog) Has(id string) bool {
+	for _, m := range c.Data {
+		if m.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/code/client_test.go
+++ b/internal/code/client_test.go
@@ -1,0 +1,140 @@
+package code
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type roundTrip func(*http.Request) (*http.Response, error)
+
+func (f roundTrip) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+func response(status int, body, kind string) *http.Response {
+	return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": []string{kind}}, Body: io.NopCloser(strings.NewReader(body))}
+}
+func event(v any) string { b, _ := json.Marshal(v); return "data: " + string(b) + "\n\n" }
+func responsesStream(output []any) string {
+	return event(map[string]any{"type": "response.completed", "response": map[string]any{"status": "completed", "output": output}})
+}
+func messagesStream(block map[string]any) string {
+	return event(map[string]any{"type": "content_block_start", "index": 0, "content_block": block}) + event(map[string]any{"type": "message_stop"})
+}
+func TestCatalogContractAndErrors(t *testing.T) {
+	for _, tc := range []struct {
+		body   string
+		status int
+		ok     bool
+	}{{`{"data":[]}`, 200, true}, {`{"data":[{"id":"plain-route"}]}`, 200, true}, {`{"models":[]}`, 200, false}, {`{"data":[{"id":"x"},{"id":"x"}]}`, 200, false}, {`{"data":[{}]}`, 200, false}, {`{"data":null}`, 200, false}, {`secret`, 401, false}, {`secret`, 403, false}, {`secret`, 500, false}} {
+		t.Run(fmt.Sprint(tc.status, tc.body), func(t *testing.T) {
+			cl := Client{Token: "secret", Transport: roundTrip(func(r *http.Request) (*http.Response, error) {
+				require.Equal(t, Endpoint+"/v1/models", r.URL.String())
+				require.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+				return response(tc.status, tc.body, "application/json"), nil
+			})}
+			catalog, err := cl.Models(t.Context())
+			if tc.ok {
+				require.NoError(t, err)
+				require.NotNil(t, catalog.Data)
+				require.False(t, catalog.FetchedAt.IsZero())
+			} else {
+				require.Error(t, err)
+				require.NotContains(t, err.Error(), "secret")
+			}
+		})
+	}
+}
+func TestCatalogNeverFollowsRedirect(t *testing.T) {
+	calls := 0
+	cl := Client{Token: "secret", Transport: roundTrip(func(r *http.Request) (*http.Response, error) {
+		calls++
+		resp := response(302, "", "application/json")
+		resp.Header.Set("Location", "https://other.example/models")
+		return resp, nil
+	})}
+	_, err := cl.Models(t.Context())
+	require.ErrorContains(t, err, "302")
+	require.Equal(t, 1, calls)
+}
+func TestProbeStreamingAndToolReplay(t *testing.T) {
+	for _, h := range []string{"codex", "claude-code"} {
+		t.Run(h, func(t *testing.T) {
+			count := 0
+			cl := Client{Token: "secret", Transport: roundTrip(func(r *http.Request) (*http.Response, error) {
+				count++
+				require.Equal(t, "POST", r.Method)
+				require.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+				require.Empty(t, r.Header.Get("x-baseten-web-search-provider-priority"))
+				var body map[string]any
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+				require.Equal(t, "engineering", body["model"])
+				require.Equal(t, true, body["stream"])
+				if h == "codex" {
+					require.Equal(t, "/v1/responses", r.URL.Path)
+				} else {
+					require.Equal(t, "/v1/messages", r.URL.Path)
+					require.Equal(t, "2023-06-01", r.Header.Get("anthropic-version"))
+				}
+				if count == 1 {
+					if h == "codex" {
+						return response(200, responsesStream([]any{map[string]any{"type": "function_call", "name": probeTool, "call_id": "call-1", "arguments": "{}"}}), "text/event-stream"), nil
+					}
+					return response(200, messagesStream(map[string]any{"type": "tool_use", "name": probeTool, "id": "call-1", "input": map[string]any{}}), "text/event-stream"), nil
+				}
+				var marker string
+				if h == "codex" {
+					input := body["input"].([]any)
+					result := input[len(input)-1].(map[string]any)
+					require.Equal(t, "call-1", result["call_id"])
+					marker = result["output"].(string)
+					return response(200, responsesStream([]any{map[string]any{"type": "message", "content": []any{map[string]any{"type": "output_text", "text": marker}}}}), "text/event-stream"), nil
+				}
+				messages := body["messages"].([]any)
+				result := messages[2].(map[string]any)["content"].([]any)[0].(map[string]any)
+				require.Equal(t, "call-1", result["tool_use_id"])
+				marker = result["content"].(string)
+				return response(200, event(map[string]any{"type": "content_block_start", "index": 0, "content_block": map[string]any{"type": "text", "text": ""}})+event(map[string]any{"type": "content_block_delta", "index": 0, "delta": map[string]any{"type": "text_delta", "text": marker}})+event(map[string]any{"type": "message_stop"}), "text/event-stream"), nil
+			})}
+			require.NoError(t, cl.Probe(t.Context(), h, "engineering"))
+			require.Equal(t, 2, count)
+		})
+	}
+}
+func TestProbeRejectsIncompleteAndFailedStreams(t *testing.T) {
+	for _, h := range []string{"codex", "claude-code"} {
+		for _, stream := range []string{"", `data: {}`, "data: {}\n\n", event(map[string]any{"type": "error", "error": "secret"}), event(map[string]any{"type": "response.incomplete"})} {
+			_, _, err := parseProbeStream(h, []byte(stream))
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), "secret")
+		}
+	}
+	cl := Client{Transport: roundTrip(func(*http.Request) (*http.Response, error) {
+		return response(200, `{"ok":true}`, "application/json"), nil
+	})}
+	require.ErrorContains(t, cl.Probe(t.Context(), "codex", "route"), "event stream")
+}
+func TestProbeRejectsMissingToolAndWrongReplay(t *testing.T) {
+	cl := Client{Transport: roundTrip(func(*http.Request) (*http.Response, error) {
+		return response(200, responsesStream([]any{}), "text/event-stream"), nil
+	})}
+	require.ErrorContains(t, cl.Probe(t.Context(), "codex", "route"), "tool call")
+	count := 0
+	cl.Transport = roundTrip(func(*http.Request) (*http.Response, error) {
+		count++
+		output := []any{map[string]any{"type": "function_call", "name": probeTool, "call_id": "id", "arguments": "{}"}}
+		if count > 1 {
+			output = []any{map[string]any{"type": "message", "content": []any{map[string]any{"type": "output_text", "text": "unrelated"}}}}
+		}
+		return response(200, responsesStream(output), "text/event-stream"), nil
+	})
+	require.ErrorContains(t, cl.Probe(t.Context(), "codex", "route"), "did not replay")
+}
+func TestSSEMultilineDataAndComments(t *testing.T) {
+	events, err := streamEvents([]byte(":keepalive\n\ndata: {\ndata: \"type\":\"message_stop\"}\n\n"))
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+}

--- a/internal/code/config.go
+++ b/internal/code/config.go
@@ -1,0 +1,429 @@
+package code
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+)
+
+var Harnesses = []string{"codex", "codex-desktop", "claude-code", "claude-desktop", "opencode"}
+
+func Canonical(h string) (string, error) {
+	for _, name := range Harnesses {
+		if h == name {
+			if h == "codex-desktop" {
+				return "codex", nil
+			}
+			return h, nil
+		}
+	}
+	return "", fmt.Errorf("unknown harness %q; use %s", h, strings.Join(Harnesses, ", "))
+}
+func Normalize(names []string) ([]string, error) {
+	out := []string{}
+	seen := map[string]bool{}
+	for _, h := range names {
+		h, err := Canonical(h)
+		if err != nil {
+			return nil, err
+		}
+		if !seen[h] {
+			out = append(out, h)
+			seen[h] = true
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+type Harness struct {
+	Name       string `json:"name"`
+	Path       string `json:"config_path"`
+	Installed  bool   `json:"installed"`
+	Version    string `json:"version"`
+	Limitation string `json:"limitation,omitempty"`
+}
+
+func Describe(ctx context.Context, h string) (Harness, error) {
+	h, err := Canonical(h)
+	if err != nil {
+		return Harness{}, err
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return Harness{}, err
+	}
+	info := Harness{Name: h, Version: "unknown"}
+	binary := h
+	switch h {
+	case "codex":
+		dir := os.Getenv("CODEX_HOME")
+		if dir == "" {
+			dir = filepath.Join(home, ".codex")
+		}
+		info.Path = filepath.Join(dir, "config.toml")
+		info.Limitation = "CLI and desktop share this file; desktop provider selection and minimum supported versions require validation."
+	case "claude-code":
+		binary = "claude"
+		dir := os.Getenv("CLAUDE_CONFIG_DIR")
+		if dir == "" {
+			dir = filepath.Join(home, ".claude")
+		}
+		info.Path = filepath.Join(dir, "settings.json")
+		info.Limitation = "Explicit Route selection is supported; gateway discovery filters Route IDs and does not provide active-session refresh."
+	case "claude-desktop":
+		info.Path = filepath.Join(home, "Library", "Application Support", "Claude-3p", "configLibrary")
+		info.Limitation = "Desktop installation is not implemented: third-party profile schema, credential storage and arbitrary Route discovery require version validation."
+		return info, nil
+	case "opencode":
+		dir := os.Getenv("XDG_CONFIG_HOME")
+		if dir == "" {
+			dir = filepath.Join(home, ".config")
+		}
+		info.Path = filepath.Join(dir, "opencode", "opencode.json")
+		info.Limitation = "OpenCode configuration and credential delivery are not implemented; V1/V2 schemas and JSONC need a verified adapter."
+	}
+	info.Path, err = filepath.Abs(info.Path)
+	if err != nil {
+		return info, err
+	}
+	path, err := exec.LookPath(binary)
+	if err != nil {
+		return info, nil
+	}
+	info.Installed = true
+	versionCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	// --version only, never start an interactive harness or a coding session.
+	data, err := exec.CommandContext(versionCtx, path, "--version").Output()
+	if err == nil {
+		version := strings.TrimSpace(string(data))
+		if len(version) < 120 && !strings.ContainsAny(version, "\r\n\x1b") {
+			info.Version = version
+		}
+	}
+	return info, nil
+}
+
+type Value struct {
+	Exists bool `json:"exists"`
+	Data   any  `json:"data,omitempty"`
+}
+type Setting struct {
+	Path      []string `json:"path"`
+	Before    Value    `json:"before"`
+	Installed Value    `json:"installed"`
+}
+type ManagedConfig struct {
+	Harness  string    `json:"harness"`
+	Path     string    `json:"path"`
+	Format   string    `json:"format"`
+	Original []byte    `json:"original"`
+	Existed  bool      `json:"existed"`
+	Settings []Setting `json:"settings"`
+}
+
+// Change never serializes file contents. Configs and backups can contain
+// existing secrets; previews report paths and setting names only.
+type Change struct {
+	Harness  string   `json:"harness"`
+	Path     string   `json:"path"`
+	Keys     []string `json:"settings"`
+	snapshot *Snapshot
+	data     []byte
+	managed  *ManagedConfig
+}
+
+func decode(format string, data []byte) (map[string]any, error) {
+	out := map[string]any{}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return out, nil
+	}
+	var err error
+	if format == "toml" {
+		_, err = toml.Decode(string(data), &out)
+	} else {
+		err = json.Unmarshal(data, &out)
+	}
+	if err != nil || out == nil {
+		return nil, errors.New("invalid configuration syntax; repair the file before continuing")
+	}
+	return out, nil
+}
+func encode(format string, data map[string]any) ([]byte, error) {
+	if format == "toml" {
+		var b bytes.Buffer
+		err := toml.NewEncoder(&b).Encode(data)
+		return b.Bytes(), err
+	}
+	b, err := json.MarshalIndent(data, "", "  ")
+	return append(b, '\n'), err
+}
+func get(data map[string]any, path []string) Value {
+	for _, p := range path[:len(path)-1] {
+		child, ok := data[p].(map[string]any)
+		if !ok {
+			return Value{}
+		}
+		data = child
+	}
+	v, ok := data[path[len(path)-1]]
+	return Value{Exists: ok, Data: v}
+}
+func set(data map[string]any, path []string, value Value) error {
+	if len(path) == 1 {
+		if value.Exists {
+			data[path[0]] = value.Data
+		} else {
+			delete(data, path[0])
+		}
+		return nil
+	}
+	child, ok := data[path[0]].(map[string]any)
+	if !ok {
+		if _, exists := data[path[0]]; exists {
+			return fmt.Errorf("setting %s conflicts with an existing scalar", path[0])
+		}
+		if !value.Exists {
+			return nil
+		}
+		child = map[string]any{}
+		data[path[0]] = child
+	}
+	if err := set(child, path[1:], value); err != nil {
+		return err
+	}
+	if len(child) == 0 {
+		delete(data, path[0])
+	}
+	return nil
+}
+func equal(a, b Value) bool {
+	// JSON normalizes numbers and nested arrays when a journal is reloaded.
+	aa, _ := json.Marshal(a)
+	bb, _ := json.Marshal(b)
+	return bytes.Equal(aa, bb)
+}
+func setting(path []string, v any) Setting {
+	return Setting{Path: path, Installed: Value{Exists: true, Data: v}}
+}
+
+func Prepare(h Harness, model, helper, stateDir, org string, prior *ManagedConfig) (*Change, error) {
+	if h.Name == "claude-desktop" {
+		return nil, errors.New(h.Limitation)
+	}
+	if !h.Installed {
+		return nil, fmt.Errorf("%s is not installed or not on PATH", h.Name)
+	}
+	snap, err := ReadSnapshot(h.Path)
+	if err != nil {
+		return nil, err
+	}
+	format := "json"
+	if h.Name == "codex" {
+		format = "toml"
+	}
+	data, err := decode(format, snap.Data)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", h.Path, err)
+	}
+	// Configuration managed by organizations is never changed. A known local
+	// managed-policy file makes setup conservative until policy resolution is
+	// integrated; no attempt is made to weaken or overwrite policy.
+	policyPaths := []string{}
+	switch h.Name {
+	case "codex":
+		policyPaths = []string{filepath.Join(filepath.Dir(h.Path), "managed_config.toml"), "/etc/codex/managed_config.toml", "/etc/codex/requirements.toml"}
+	case "claude-code":
+		policyPaths = []string{filepath.Join(filepath.Dir(h.Path), "managed-settings.json"), "/Library/Application Support/ClaudeCode/managed-settings.json", "/etc/claude-code/managed-settings.json"}
+	}
+	for _, path := range policyPaths {
+		if _, err := os.Stat(path); err == nil {
+			return nil, fmt.Errorf("managed policy detected at %s; ask your administrator to configure Baseten Code", path)
+		} else if !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	var settings []Setting
+	switch h.Name {
+	case "codex":
+		if value := get(data, []string{"profile"}); value.Exists {
+			return nil, errors.New("Codex has a selected profile override; resolve it before configuring the shared CLI/desktop provider")
+		}
+		if value := get(data, []string{"model_catalog_json"}); value.Exists {
+			return nil, errors.New("Codex has a model_catalog_json override; resolve it before selecting a Code Route")
+		}
+		settings = []Setting{
+			setting([]string{"model"}, model), setting([]string{"model_provider"}, "baseten-code"),
+			setting([]string{"model_providers", "baseten-code"}, map[string]any{
+				"name": "Baseten Code", "base_url": Endpoint + "/v1", "wire_api": "responses",
+				"auth": map[string]any{"command": helper, "args": []string{"code", "auth", "token", "--config-dir", stateDir, "--org", org}},
+			}),
+		}
+	case "claude-code":
+		for _, name := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_USE_BEDROCK", "CLAUDE_CODE_USE_VERTEX", "CLAUDE_CODE_USE_FOUNDRY"} {
+			if value := get(data, []string{"env", name}); value.Exists {
+				return nil, fmt.Errorf("Claude setting env.%s overrides gateway authentication; resolve it before setup", name)
+			}
+			if os.Getenv(name) != "" {
+				return nil, fmt.Errorf("environment variable %s overrides gateway authentication; unset it before setup", name)
+			}
+		}
+		settings = []Setting{setting([]string{"apiKeyHelper"}, shellQuote(helper)+" code auth token --config-dir "+shellQuote(stateDir)+" --org "+shellQuote(org)), setting([]string{"env", "ANTHROPIC_BASE_URL"}, Endpoint), setting([]string{"model"}, model)}
+		for _, role := range []string{"ANTHROPIC_MODEL", "ANTHROPIC_DEFAULT_OPUS_MODEL", "ANTHROPIC_DEFAULT_SONNET_MODEL", "ANTHROPIC_DEFAULT_HAIKU_MODEL", "CLAUDE_CODE_SUBAGENT_MODEL", "ANTHROPIC_SMALL_FAST_MODEL"} {
+			settings = append(settings, setting([]string{"env", role}, model))
+		}
+	case "opencode":
+		// OpenCode's published V1 config has no command-backed credential field.
+		// Do not write a key into config or pretend an environment reference works
+		// for desktop launches. Add credential delivery with the versioned adapter.
+		return nil, errors.New("OpenCode setup requires a verified V1/V2 credential-delivery and catalog adapter; no configuration was changed")
+	}
+	record := &ManagedConfig{Harness: h.Name, Path: h.Path, Format: format, Original: snap.Data, Existed: snap.Info != nil}
+	if prior != nil {
+		if prior.Path != h.Path || prior.Format != format {
+			return nil, errors.New("harness config location changed; teardown the previous location before reinitializing")
+		}
+		record.Original, record.Existed = prior.Original, prior.Existed
+	}
+	keys := []string{}
+	for _, s := range settings {
+		before := get(data, s.Path)
+		s.Before = before
+		owned := false
+		if prior != nil {
+			for _, p := range prior.Settings {
+				if reflect.DeepEqual(p.Path, s.Path) {
+					owned = true
+					if !equal(before, p.Installed) {
+						return nil, fmt.Errorf("user changed %s in %s; preserve or restore that setting before syncing", strings.Join(s.Path, "."), h.Path)
+					}
+					s.Before = p.Before
+				}
+			}
+		}
+		// Do not take over a pre-existing provider or helper with different values.
+		if !owned && before.Exists && (s.Path[0] == "model_providers" || s.Path[0] == "apiKeyHelper") && !equal(before, s.Installed) {
+			return nil, fmt.Errorf("existing %s conflicts with Baseten Code; resolve it before setup", strings.Join(s.Path, "."))
+		}
+		if err := set(data, s.Path, s.Installed); err != nil {
+			return nil, err
+		}
+		record.Settings = append(record.Settings, s)
+		keys = append(keys, strings.Join(s.Path, "."))
+	}
+	output, err := encode(format, data)
+	if err != nil {
+		return nil, err
+	}
+	// A repeat with identical values does not rewrite comments/formatting.
+	existing, _ := decode(format, snap.Data)
+	if reflect.DeepEqual(existing, data) {
+		output = snap.Data
+	}
+	return &Change{Harness: h.Name, Path: h.Path, Keys: keys, snapshot: snap, data: output, managed: record}, nil
+}
+func shellQuote(s string) string { return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'" }
+
+// Apply journals original values before any harness write. If interrupted,
+// teardown can conservatively restore only values that match the journal.
+// All changes are preflighted before the first write.
+func (s *Store) Apply(i *Installation, changes []*Change) error {
+	for _, change := range changes {
+		if err := change.snapshot.Check(); err != nil {
+			return err
+		}
+	}
+	for _, change := range changes {
+		i.Configs[change.Harness] = change.managed
+	}
+	if err := s.Save(i); err != nil {
+		return err
+	}
+	for _, change := range changes {
+		if err := change.snapshot.Write(change.data); err != nil {
+			return fmt.Errorf("setup interrupted: %w; backups were saved, use code teardown to recover", err)
+		}
+	}
+	return nil
+}
+
+func Restore(record *ManagedConfig) (*Change, []string, error) {
+	snap, err := ReadSnapshot(record.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+	data, err := decode(record.Format, snap.Data)
+	if err != nil {
+		return nil, nil, err
+	}
+	remaining := *record
+	remaining.Settings = nil
+	conflicts := []string{}
+	keys := []string{}
+	for _, s := range record.Settings {
+		current := get(data, s.Path)
+		if equal(current, s.Before) {
+			continue
+		} // Journal may precede a failed write.
+		if !equal(current, s.Installed) {
+			remaining.Settings = append(remaining.Settings, s)
+			conflicts = append(conflicts, strings.Join(s.Path, "."))
+			continue
+		}
+		if err := set(data, s.Path, s.Before); err != nil {
+			return nil, nil, err
+		}
+		keys = append(keys, strings.Join(s.Path, "."))
+	}
+	output, err := encode(record.Format, data)
+	if err != nil {
+		return nil, nil, err
+	}
+	original, err := decode(record.Format, record.Original)
+	if err == nil && reflect.DeepEqual(data, original) {
+		output = record.Original
+	}
+	if len(keys) == 0 {
+		output = snap.Data
+	}
+	return &Change{Harness: record.Harness, Path: record.Path, Keys: keys, snapshot: snap, data: output, managed: &remaining}, conflicts, nil
+}
+func (s *Store) Teardown(i *Installation, changes []*Change) error {
+	for _, change := range changes {
+		if err := change.snapshot.Check(); err != nil {
+			return err
+		}
+	}
+	for _, change := range changes {
+		// Remove a newly created empty file, but retain files with later user settings.
+		if !change.managed.Existed && len(change.data) == 0 && len(change.managed.Settings) == 0 {
+			if err := change.snapshot.Check(); err != nil {
+				return err
+			}
+			if err := os.Remove(change.snapshot.Target); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		} else if err := change.snapshot.Write(change.data); err != nil {
+			return err
+		}
+		if len(change.managed.Settings) == 0 {
+			delete(i.Configs, change.Harness)
+		} else {
+			i.Configs[change.Harness] = change.managed
+		}
+	}
+	// Keep the installation credential until server revocation succeeds.
+	return s.Save(i)
+}

--- a/internal/code/config_test.go
+++ b/internal/code/config_test.go
@@ -1,0 +1,219 @@
+package code
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testHarness(t *testing.T, name, original string) Harness {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if name == "codex" {
+		path = filepath.Join(filepath.Dir(path), "config.toml")
+	}
+	if original != "" {
+		require.NoError(t, os.WriteFile(path, []byte(original), 0640))
+	}
+	return Harness{Name: name, Path: path, Installed: true, Version: "test"}
+}
+func prepare(t *testing.T, h Harness, prior *ManagedConfig) *Change {
+	t.Helper()
+	change, err := Prepare(h, "engineering", "/opt/baseten cli", t.TempDir(), "org-1", prior)
+	require.NoError(t, err)
+	return change
+}
+func installation() *Installation {
+	return &Installation{Version: 1, Org: "org-1", KeyID: "key-1", Model: "engineering", Configs: map[string]*ManagedConfig{}}
+}
+
+func TestConfigPreservesAndRestores(t *testing.T) {
+	for _, name := range []string{"codex", "claude-code"} {
+		t.Run(name, func(t *testing.T) {
+			original := "{\n \"theme\":\"dark\",\"model\":\"previous\",\"env\":{\"EXAMPLE\":\"keep\"}\n}\n"
+			if name == "codex" {
+				original = "# my comment\nmodel = \"previous\"\napproval_policy = \"on-request\"\n[model_providers.other]\nname = \"keep\"\n"
+			}
+			h := testHarness(t, name, original)
+			s := &Store{Dir: t.TempDir()}
+			i := installation()
+			change := prepare(t, h, nil)
+			preview, err := json.Marshal(change)
+			require.NoError(t, err)
+			require.NotContains(t, string(preview), "Before")
+			require.NotContains(t, string(preview), "previous")
+			require.NoError(t, s.Apply(i, []*Change{change}))
+			written, err := os.ReadFile(h.Path)
+			require.NoError(t, err)
+			require.Contains(t, string(written), Endpoint)
+			require.NotContains(t, string(written), "web-search-provider-priority")
+			require.Contains(t, string(written), "--config-dir")
+			require.Contains(t, string(written), "--org")
+			data, err := decode(change.managed.Format, written)
+			require.NoError(t, err)
+			if name == "codex" {
+				require.Equal(t, "on-request", data["approval_policy"])
+				require.Contains(t, string(written), "responses")
+				require.NotContains(t, string(written), "requires_openai_auth")
+			} else {
+				require.Equal(t, "dark", data["theme"])
+				require.Equal(t, "keep", get(data, []string{"env", "EXAMPLE"}).Data)
+			}
+			// Re-read the serialized journal to exercise JSON/TOML type normalization.
+			loaded, err := s.Load()
+			require.NoError(t, err)
+
+			// Same state dir and executable must yield a no-op config write.
+			var helperDir string
+			if name == "codex" {
+				provider := get(data, []string{"model_providers", "baseten-code"}).Data.(map[string]any)
+				args := provider["auth"].(map[string]any)["args"].([]any)
+				helperDir = args[4].(string)
+			} else {
+				helperDir = "unused"
+			}
+			if name == "codex" {
+				again, err := Prepare(h, "engineering", "/opt/baseten cli", helperDir, "org-1", loaded.Configs[name])
+				require.NoError(t, err)
+				require.Equal(t, written, again.data)
+			}
+			restored, conflicts, err := Restore(loaded.Configs[name])
+			require.NoError(t, err)
+			require.Empty(t, conflicts)
+			require.NoError(t, s.Teardown(loaded, []*Change{restored}))
+			back, err := os.ReadFile(h.Path)
+			require.NoError(t, err)
+			require.Equal(t, original, string(back))
+			info, err := os.Stat(h.Path)
+			require.NoError(t, err)
+			if info.Mode().Perm() != 0666 {
+				require.Equal(t, os.FileMode(0640), info.Mode().Perm())
+			}
+		})
+	}
+}
+func TestConfigPreservesUserEditsOnTeardown(t *testing.T) {
+	h := testHarness(t, "claude-code", `{"model":"old","env":{"UNRELATED":"keep"}}`)
+	s := &Store{Dir: t.TempDir()}
+	i := installation()
+	change := prepare(t, h, nil)
+	require.NoError(t, s.Apply(i, []*Change{change}))
+	data, err := decode("json", change.data)
+	require.NoError(t, err)
+	data["model"] = "user-choice"
+	data["extra"] = "later"
+	edited, err := encode("json", data)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(h.Path, edited, 0600))
+	_, err = Prepare(h, "new", "/opt/baseten cli", "state", "org-1", i.Configs[h.Name])
+	require.ErrorContains(t, err, "user changed")
+	restore, conflicts, err := Restore(i.Configs[h.Name])
+	require.NoError(t, err)
+	require.Equal(t, []string{"model"}, conflicts)
+	require.NoError(t, s.Teardown(i, []*Change{restore}))
+	raw, err := os.ReadFile(h.Path)
+	require.NoError(t, err)
+	data, err = decode("json", raw)
+	require.NoError(t, err)
+	require.Equal(t, "user-choice", data["model"])
+	require.Equal(t, "later", data["extra"])
+	require.NotContains(t, data, "apiKeyHelper")
+	require.Len(t, i.Configs[h.Name].Settings, 1)
+}
+func TestConfigRejectsConflictsAndInvalidSyntax(t *testing.T) {
+	for _, original := range []string{`{"apiKeyHelper":"other"}`, `{"env":{"ANTHROPIC_AUTH_TOKEN":"secret"}}`, `{"env":null}`, `{broken`} {
+		h := testHarness(t, "claude-code", original)
+		_, err := Prepare(h, "route", "helper", "state", "org", nil)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "secret")
+		raw, err := os.ReadFile(h.Path)
+		require.NoError(t, err)
+		require.Equal(t, original, string(raw))
+	}
+	h := testHarness(t, "codex", "profile = \"work\"\n")
+	_, err := Prepare(h, "route", "helper", "state", "org", nil)
+	require.ErrorContains(t, err, "profile override")
+	h = testHarness(t, "claude-code", `{}`)
+	require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(h.Path), "managed-settings.json"), []byte(`{}`), 0600))
+	_, err = Prepare(h, "route", "helper", "state", "org", nil)
+	require.ErrorContains(t, err, "managed policy")
+}
+func TestSnapshotConcurrentEditsAndSymlinks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, os.WriteFile(path, []byte("before"), 0600))
+	snap, err := ReadSnapshot(path)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, []byte("concurrent"), 0600))
+	require.ErrorContains(t, snap.Write([]byte("ours")), "concurrently")
+	link := filepath.Join(filepath.Dir(path), "link")
+	if err := os.Symlink(path, link); err != nil {
+		t.Skip("symlinks unavailable")
+	}
+	snap, err = ReadSnapshot(link)
+	require.NoError(t, err)
+	require.NoError(t, snap.Write([]byte("through-link")))
+	info, err := os.Lstat(link)
+	require.NoError(t, err)
+	require.NotZero(t, info.Mode()&os.ModeSymlink)
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "through-link", string(raw))
+	dangling := filepath.Join(filepath.Dir(path), "dangling")
+	require.NoError(t, os.Symlink(path+"-missing", dangling))
+	_, err = ReadSnapshot(dangling)
+	require.ErrorContains(t, err, "dangling")
+}
+func TestApplyPreflightsAllFiles(t *testing.T) {
+	h1 := testHarness(t, "codex", "")
+	h2 := testHarness(t, "claude-code", `{}`)
+	a := prepare(t, h1, nil)
+	b := prepare(t, h2, nil)
+	require.NoError(t, os.WriteFile(h2.Path, []byte(`{"changed":true}`), 0600))
+	s := &Store{Dir: t.TempDir()}
+	require.ErrorContains(t, s.Apply(installation(), []*Change{a, b}), "concurrently")
+	_, err := os.Stat(h1.Path)
+	require.True(t, os.IsNotExist(err))
+	_, err = os.Stat(s.Path())
+	require.True(t, os.IsNotExist(err))
+}
+func TestInterruptedJournalCanRestoreUnwrittenSettings(t *testing.T) {
+	h := testHarness(t, "claude-code", `{"model":"old"}`)
+	c := prepare(t, h, nil)
+	restore, conflicts, err := Restore(c.managed)
+	require.NoError(t, err)
+	require.Empty(t, conflicts)
+	require.Empty(t, restore.managed.Settings)
+}
+func TestConsolidatesCodexSurfaces(t *testing.T) {
+	names, err := Normalize([]string{"codex-desktop", "codex", "claude-code"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"claude-code", "codex"}, names)
+}
+func TestStoreLock(t *testing.T) {
+	s := &Store{Dir: t.TempDir()}
+	unlock, err := s.Lock()
+	require.NoError(t, err)
+	_, err = s.Lock()
+	require.Error(t, err)
+	unlock()
+	unlock, err = s.Lock()
+	require.NoError(t, err)
+	unlock()
+}
+
+func TestTeardownRemovesOnlyNewEmptyFile(t *testing.T) {
+	h := testHarness(t, "codex", "")
+	s := &Store{Dir: t.TempDir()}
+	i := installation()
+	c := prepare(t, h, nil)
+	require.NoError(t, s.Apply(i, []*Change{c}))
+	restore, conflicts, err := Restore(i.Configs[h.Name])
+	require.NoError(t, err)
+	require.Empty(t, conflicts)
+	require.NoError(t, s.Teardown(i, []*Change{restore}))
+	_, err = os.Stat(h.Path)
+	require.True(t, os.IsNotExist(err))
+}

--- a/internal/code/probe.go
+++ b/internal/code/probe.go
@@ -1,0 +1,243 @@
+package code
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const probeTool = "baseten_code_probe"
+
+// Probe performs two streamed turns with a synthetic, side-effect-free tool.
+// No model-generated command is executed. The marker is generated after the
+// tool call, so merely repeating the initial prompt cannot pass replay.
+func (c *Client) Probe(ctx context.Context, harness, model string) error {
+	canonical, err := Canonical(harness)
+	if err != nil {
+		return err
+	}
+	if canonical != "codex" && canonical != "claude-code" {
+		return fmt.Errorf("protocol probes for %s are not implemented", harness)
+	}
+	schema := map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}
+	prompt := "Call baseten_code_probe with no arguments. Then reply with exactly the marker returned by that tool."
+	var path string
+	var first map[string]any
+	if canonical == "codex" {
+		path = "/v1/responses"
+		first = map[string]any{"model": model, "stream": true, "max_output_tokens": 512, "input": prompt,
+			"tools":       []any{map[string]any{"type": "function", "name": probeTool, "description": "Return a diagnostic marker", "parameters": schema}},
+			"tool_choice": map[string]any{"type": "function", "name": probeTool},
+		}
+	} else {
+		path = "/v1/messages"
+		first = map[string]any{"model": model, "stream": true, "max_tokens": 512, "messages": []any{map[string]any{"role": "user", "content": prompt}},
+			"tools":       []any{map[string]any{"name": probeTool, "description": "Return a diagnostic marker", "input_schema": schema}},
+			"tool_choice": map[string]any{"type": "tool", "name": probeTool},
+		}
+	}
+	raw, err := c.request(ctx, "POST", path, first, true)
+	if err != nil {
+		return err
+	}
+	blocks, _, err := parseProbeStream(canonical, raw)
+	if err != nil {
+		return err
+	}
+	var tool map[string]any
+	for _, block := range blocks {
+		kind, _ := block["type"].(string)
+		if kind == "function_call" || kind == "tool_use" {
+			if tool != nil {
+				return errors.New("probe returned more than one tool call")
+			}
+			tool = block
+		}
+	}
+	if tool == nil || tool["name"] != probeTool {
+		return errors.New("stream did not contain the requested diagnostic tool call")
+	}
+	entropy := make([]byte, 12)
+	if _, err := rand.Read(entropy); err != nil {
+		return err
+	}
+	marker := "BASETEN_CODE_" + hex.EncodeToString(entropy)
+	second := map[string]any{"model": model, "stream": true}
+	if canonical == "codex" {
+		id, _ := tool["call_id"].(string)
+		if id == "" {
+			return errors.New("Responses tool call is missing call_id")
+		}
+		second["max_output_tokens"] = 512
+		input := []any{map[string]any{"role": "user", "content": prompt}}
+		for _, block := range blocks {
+			input = append(input, block)
+		}
+		input = append(input, map[string]any{"type": "function_call_output", "call_id": id, "output": marker})
+		second["input"] = input
+	} else {
+		id, _ := tool["id"].(string)
+		if id == "" {
+			return errors.New("Messages tool call is missing id")
+		}
+		second["max_tokens"] = 512
+		second["messages"] = []any{map[string]any{"role": "user", "content": prompt}, map[string]any{"role": "assistant", "content": blocks}, map[string]any{"role": "user", "content": []any{map[string]any{"type": "tool_result", "tool_use_id": id, "content": marker}}}}
+	}
+	raw, err = c.request(ctx, "POST", path, second, true)
+	if err != nil {
+		return err
+	}
+	_, text, err := parseProbeStream(canonical, raw)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(text, marker) {
+		return errors.New("streamed response did not replay the diagnostic tool result")
+	}
+	return nil
+}
+
+// SSE permits multiple data lines per event and comments between events.
+func streamEvents(raw []byte) ([]map[string]any, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	scanner.Buffer(make([]byte, 4096), 8<<20)
+	events := []map[string]any{}
+	data := []string{}
+	flush := func() error {
+		if len(data) == 0 {
+			return nil
+		}
+		payload := strings.Join(data, "\n")
+		data = nil
+		if payload == "[DONE]" {
+			return nil
+		}
+		var event map[string]any
+		if err := json.Unmarshal([]byte(payload), &event); err != nil || event == nil {
+			return errors.New("invalid JSON in gateway event stream")
+		}
+		events = append(events, event)
+		return nil
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			data = append(data, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, errors.New("invalid gateway event stream")
+	}
+	if len(data) > 0 {
+		return nil, errors.New("truncated gateway event stream")
+	}
+	return events, nil
+}
+func parseProbeStream(harness string, raw []byte) ([]map[string]any, string, error) {
+	events, err := streamEvents(raw)
+	if err != nil {
+		return nil, "", err
+	}
+	blocks := []map[string]any{}
+	text := ""
+	completed := false
+	indices := map[int]map[string]any{}
+	partial := map[int]string{}
+	for _, event := range events {
+		kind, _ := event["type"].(string)
+		if kind == "error" || kind == "response.failed" || kind == "response.incomplete" {
+			return nil, "", errors.New("gateway stream reported a failed or incomplete response")
+		}
+		if harness == "codex" && kind == "response.completed" {
+			response, ok := event["response"].(map[string]any)
+			if !ok || response["status"] != "completed" {
+				return nil, "", errors.New("invalid Responses completion event")
+			}
+			output, ok := response["output"].([]any)
+			if !ok {
+				return nil, "", errors.New("Responses completion is missing output")
+			}
+			for _, item := range output {
+				block, ok := item.(map[string]any)
+				if !ok {
+					return nil, "", errors.New("invalid Responses output item")
+				}
+				blocks = append(blocks, block)
+				if content, ok := block["content"].([]any); ok {
+					for _, part := range content {
+						if p, ok := part.(map[string]any); ok && p["type"] == "output_text" {
+							if t, ok := p["text"].(string); ok {
+								text += t
+							}
+						}
+					}
+				}
+			}
+			completed = true
+		}
+		if harness == "claude-code" {
+			index, _ := event["index"].(float64)
+			n := int(index)
+			switch kind {
+			case "content_block_start":
+				block, ok := event["content_block"].(map[string]any)
+				if !ok {
+					return nil, "", errors.New("invalid Messages content block")
+				}
+				indices[n] = block
+				blocks = append(blocks, block)
+			case "content_block_delta":
+				delta, ok := event["delta"].(map[string]any)
+				if !ok {
+					return nil, "", errors.New("invalid Messages delta")
+				}
+				if delta["type"] == "text_delta" {
+					t, _ := delta["text"].(string)
+					text += t
+					if block := indices[n]; block != nil {
+						old, _ := block["text"].(string)
+						block["text"] = old + t
+					}
+				}
+				if delta["type"] == "input_json_delta" {
+					s, _ := delta["partial_json"].(string)
+					partial[n] += s
+				}
+			case "message_delta":
+				delta, _ := event["delta"].(map[string]any)
+				if delta["stop_reason"] == "max_tokens" {
+					return nil, "", errors.New("Messages stream exceeded probe token limit")
+				}
+			case "message_stop":
+				completed = true
+			}
+		}
+	}
+	for index, raw := range partial {
+		block := indices[index]
+		if block == nil {
+			return nil, "", errors.New("tool input has no content block")
+		}
+		var input any
+		if json.Unmarshal([]byte(raw), &input) != nil {
+			return nil, "", errors.New("invalid streamed tool input")
+		}
+		block["input"] = input
+	}
+	if !completed {
+		return nil, "", errors.New("gateway stream ended without a completion event")
+	}
+	return blocks, text, nil
+}

--- a/internal/code/store.go
+++ b/internal/code/store.go
@@ -1,0 +1,242 @@
+// Package code owns local Baseten Code installation state. It deliberately has
+// no credential-issuance API: the dedicated server contract is not published.
+package code
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/basetenlabs/baseten-cli/internal/auth"
+)
+
+const Endpoint = "https://coding.baseten.co"
+const CredentialDependency = "Code credential creation, listing, and revocation require dedicated backend endpoints that are not yet integrated; ordinary API keys and OAuth access tokens cannot substitute for a Code key"
+const CatalogRefreshGap = "Active-session catalog refresh is not implemented; sync is a manual recovery operation. Restart the harness after configuration changes."
+
+type Installation struct {
+	Version int                       `json:"version"`
+	Org     string                    `json:"org"`
+	Profile string                    `json:"profile"`
+	UserID  string                    `json:"user_id"`
+	KeyID   string                    `json:"key_id"`
+	Label   string                    `json:"label,omitempty"`
+	Model   string                    `json:"model"`
+	Configs map[string]*ManagedConfig `json:"configs"`
+}
+
+// Secrets use the CLI's existing keyring/fallback machinery in a separate
+// store and namespace. Neither ambient credentials nor a switched profile can
+// change the key emitted by the helper.
+type Store struct{ Dir string }
+
+func NewStore() (*Store, error) {
+	dir, err := auth.DefaultConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	dir, err = filepath.Abs(filepath.Join(dir, "code"))
+	if err != nil {
+		return nil, err
+	}
+	return &Store{Dir: dir}, nil
+}
+func (s *Store) Path() string { return filepath.Join(s.Dir, "installation.json") }
+func (s *Store) Credentials() *auth.Store {
+	return auth.NewStore(auth.StoreOptions{Dir: filepath.Join(s.Dir, "credentials")})
+}
+func credentialName(keyID string) string { return "baseten-code:" + keyID }
+func (s *Store) Token(i *Installation) (string, error) {
+	if i == nil || i.KeyID == "" {
+		return "", errors.New("no Code credential is installed; " + CredentialDependency)
+	}
+	token, err := s.Credentials().GetAPIKey(credentialName(i.KeyID))
+	if err != nil {
+		return "", errors.New("stored Code credential is unavailable; sign in again after Code issuance is available")
+	}
+	if strings.TrimSpace(token) != token || token == "" || strings.ContainsAny(token, "\r\n\t ") {
+		return "", errors.New("stored Code credential is invalid")
+	}
+	return token, nil
+}
+func (s *Store) Load() (*Installation, error) {
+	data, err := os.ReadFile(s.Path())
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var i Installation
+	if err = json.Unmarshal(data, &i); err != nil {
+		return nil, errors.New("invalid Code installation file; restore its backup before continuing")
+	}
+	if i.Version != 1 || i.KeyID == "" || i.Org == "" {
+		return nil, errors.New("unsupported or incomplete Code installation state")
+	}
+	if i.Configs == nil {
+		i.Configs = map[string]*ManagedConfig{}
+	}
+	for name, record := range i.Configs {
+		canonical, err := Canonical(name)
+		if err != nil || canonical != name || record == nil || record.Harness != name || !filepath.IsAbs(record.Path) || (record.Format != "toml" && record.Format != "json") {
+			return nil, errors.New("invalid Code configuration backup; restore the installation journal before continuing")
+		}
+		for _, setting := range record.Settings {
+			if len(setting.Path) == 0 {
+				return nil, errors.New("invalid Code setting backup")
+			}
+			for _, key := range setting.Path {
+				if key == "" {
+					return nil, errors.New("invalid Code setting backup")
+				}
+			}
+		}
+	}
+	return &i, nil
+}
+func (s *Store) Save(i *Installation) error {
+	data, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		return err
+	}
+	snap, err := ReadSnapshot(s.Path())
+	if err != nil {
+		return err
+	}
+	if snap.Info != nil && snap.Info.Mode().Perm()&0077 != 0 && os.PathSeparator != '\\' {
+		return errors.New("Code installation journal must be private; set its permissions to 0600 before continuing")
+	}
+	return snap.Write(append(data, '\n'))
+}
+
+// Lock serializes cooperating init/sync/teardown processes. Read-only commands
+// never create directories or lock files. An interrupted mutation leaves a
+// clear recovery instruction, rather than silently stealing another lock.
+func (s *Store) Lock() (func(), error) {
+	if err := os.MkdirAll(s.Dir, 0700); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(s.Dir, "config.lock")
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("cannot lock Code setup; check for another init/sync/teardown process before removing %s: %w", path, err)
+	}
+	_ = f.Close()
+	return func() { _ = os.Remove(path) }, nil
+}
+
+// Snapshot retains identity, bytes, permissions and the resolved symlink
+// target. Writes reject concurrent edits and leave an existing symlink intact.
+// As with normal editor saves, a non-cooperating writer can still race the
+// final check and rename. The installation lock covers other CLI processes.
+type Snapshot struct {
+	Path   string
+	Target string
+	Data   []byte
+	Info   os.FileInfo
+}
+
+func ReadSnapshot(path string) (*Snapshot, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	s := &Snapshot{Path: path, Target: path}
+	target, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		s.Target = target
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	} else {
+		if _, e := os.Lstat(path); e == nil {
+			return nil, fmt.Errorf("refusing dangling symlink %s", path)
+		}
+		// Resolve an existing parent symlink, including when the final file is new.
+		parent := filepath.Dir(path)
+		suffix := filepath.Base(path)
+		for {
+			resolved, e := filepath.EvalSymlinks(parent)
+			if e == nil {
+				s.Target = filepath.Join(resolved, suffix)
+				break
+			}
+			if !os.IsNotExist(e) {
+				return nil, e
+			}
+			next := filepath.Dir(parent)
+			if next == parent {
+				return nil, e
+			}
+			suffix = filepath.Join(filepath.Base(parent), suffix)
+			parent = next
+		}
+	}
+	s.Info, err = os.Stat(s.Target)
+	if os.IsNotExist(err) {
+		return s, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !s.Info.Mode().IsRegular() {
+		return nil, fmt.Errorf("refusing non-regular configuration file %s", path)
+	}
+	s.Data, err = os.ReadFile(s.Target)
+	return s, err
+}
+func (s *Snapshot) Check() error {
+	now, err := ReadSnapshot(s.Path)
+	if err != nil {
+		return err
+	}
+	same := s.Target == now.Target && bytes.Equal(s.Data, now.Data) && (s.Info == nil) == (now.Info == nil)
+	if same && s.Info != nil {
+		same = os.SameFile(s.Info, now.Info) && s.Info.ModTime() == now.Info.ModTime() && s.Info.Mode() == now.Info.Mode()
+	}
+	if !same {
+		return fmt.Errorf("configuration changed concurrently: %s; retry after reviewing it", s.Path)
+	}
+	return nil
+}
+func (s *Snapshot) Write(data []byte) error {
+	if err := s.Check(); err != nil {
+		return err
+	}
+	if s.Info != nil && bytes.Equal(s.Data, data) {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.Target), 0700); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(filepath.Dir(s.Target), ".baseten-code-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	mode := os.FileMode(0600)
+	if s.Info != nil {
+		mode = s.Info.Mode().Perm()
+	}
+	if err = f.Chmod(mode); err == nil {
+		_, err = f.Write(data)
+	}
+	if err == nil {
+		err = f.Sync()
+	}
+	closeErr := f.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if err = s.Check(); err != nil {
+		return err
+	}
+	return os.Rename(f.Name(), s.Target)
+}


### PR DESCRIPTION
## :rocket: What

Add an experimental `baseten code` command tree with `init`, `status`, `models`, `spend`, `doctor`, `sync`, `teardown`, `logout`, `keys list`, `keys revoke`, and internal `auth token`. Every group and leaf is hidden from normal help, command suggestions, shell completions, and generated documentation while remaining explicitly invocable.

This is a draft foundation, not working end-to-end onboarding. Initial Code-key issuance, key listing/revocation, logout, Code spend, catalog synchronization, and OpenCode/Claude desktop installation fail explicitly pending their missing backend or harness integrations. A fresh installation cannot complete `init` yet.

## :computer: How

- Reuse the CLI's command definitions, output handling, HTTP transport injection, and credential storage. Keep Code credentials separate from ordinary profiles and ambient API keys; the internal helper prints only the credential and keeps errors off stdout.
- Add read-only setup previews and local status. With a provisioned installation, support authenticated catalog reads, Codex/Claude Code configuration, and streaming plus synthetic tool-result replay diagnostics.
- Configure `coding.baseten.co`, Responses for Codex and Messages for Claude Code. Consolidate Codex CLI/desktop configuration and pin the helper's binary and credential-store paths. Do not generate a web-search provider-priority header.
- Journal original configuration and managed values, preserve symlinks and file permissions, reject concurrent edits, and restore only settings that still match the installed values. Teardown preserves user edits and retains credentials.
- Document the remaining contracts in `internal/code/README.md`. No active-session catalog refresh is claimed. Modified TOML is normalized; rollback retains the original bytes. Multi-file setup is journaled but not an atomic transaction.

## :microscope: Testing

- `GOTOOLCHAIN=go1.26.1 go test ./...`
- `git diff --check`
- Regression coverage for every hidden node, explicit invocation, nested help/completion, generated shell scripts, Markdown/man docs, JSON and raw-helper output, credential isolation, config preservation/rollback, symlinks, concurrent edits, catalog validation, streaming failures, and tool-result replay.
- Tests use temporary configuration, an in-memory keyring, and mocked HTTP responses. Protocol fixtures validate the client mechanics, not live harness or backend compatibility. No real credentials, production changes, or live inference were used.
